### PR TITLE
Allow app roles to skip personal group creation for new users

### DIFF
--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -449,8 +449,12 @@ will be dropped in a later release.
   `AppRoleID` via `UserRepository.appRoleSkipsDefaultGroup` → `RoleRepository.AppRoleSkipsDefaultGroup`
   (a single-column read, mirroring `GetGroupRolePaidByConfig`) and skips only the `"My Receipts"`
   `CreateGroup` call. Assigning the role later — or unchecking the box — never adds or removes a
-  group for an existing user. Resolution is **best-effort** like `resolveAppRoleId`: a nil or
-  unreadable role falls back to creating the group rather than failing user creation.
+  group for an existing user. Resolution is **best-effort** in the same way as `resolveAppRoleId`: a
+  nil or **missing** role (`gorm.ErrRecordNotFound`) falls back to creating the group rather than
+  failing user creation, while any *other* lookup error propagates and rolls the creation back — a
+  transient DB failure must not silently decide which groups an account is created with. (The
+  missing-role branch is defensive: `User.AppRoleID` is an `OnDelete:RESTRICT` FK, so a non-nil id
+  always references a live row.)
 - Because the flag lives on the role, it applies at **every** creation path — admin create (explicit
   `appRoleId`) and public self-signup (which uses the configured **default** app role, so flagging
   the default makes signups skip the personal group too). The bootstrap admin resolves to Legacy

--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -430,6 +430,42 @@ will be dropped in a later release.
   modern-role authoring flow — see "Modern role assignment in authoring flows" under "Enforcement
   status".
 
+### Skipping the personal group per app role
+
+- Every new user normally gets **two** groups in `UserRepository.CreateUser`: the personal
+  `"My Receipts"` group and the virtual `"All"` aggregate group (`IsAllGroup`, which backs the
+  dashboard's all-receipts view). For accounts that are only ever meant to live in a few specific
+  shared groups, the personal group is dead weight that accumulates as clutter in group management.
+- **`AppRole.SkipDefaultGroupCreation`** (`models/app_role.go`, `not null;default:false`) opts a
+  role's new users out of the personal group. The `"All"` group is **always** created, so the
+  account still has a working dashboard landing page and sees receipts from groups an admin adds it
+  to. AutoMigrate adds the column with default `false`, so existing roles/installs are unchanged —
+  **no data migration**.
+- **App-scope only**, mirroring the group-scope-only `seesAllMembers` in the opposite direction:
+  `UpsertRoleCommand.Validate` rejects it on GROUP scope (`skipDefaultGroupCreation` error key), and
+  `structs.RoleView` serializes `false` for every group role. Carried on `swagger.yml` for both
+  `Role` and `UpsertRoleCommand`.
+- **Creation-time only.** `CreateUser` resolves the flag from the user's just-assigned
+  `AppRoleID` via `UserRepository.appRoleSkipsDefaultGroup` → `RoleRepository.AppRoleSkipsDefaultGroup`
+  (a single-column read, mirroring `GetGroupRolePaidByConfig`) and skips only the `"My Receipts"`
+  `CreateGroup` call. Assigning the role later — or unchecking the box — never adds or removes a
+  group for an existing user. Resolution is **best-effort** like `resolveAppRoleId`: a nil or
+  unreadable role falls back to creating the group rather than failing user creation.
+- Because the flag lives on the role, it applies at **every** creation path — admin create (explicit
+  `appRoleId`) and public self-signup (which uses the configured **default** app role, so flagging
+  the default makes signups skip the personal group too). The bootstrap admin resolves to Legacy
+  Admin, a seeded system role whose column is the `false` zero value and which the UI opens
+  read-only, so it is never affected.
+- `UpdateAppRole` writes the column through the **map form** `Updates` — GORM's struct form skips
+  zero-value bools, which would leave a toggled-off flag stuck on (the same reason
+  `UpdateGroupRole` uses it).
+- Tests: `commands/upsert_role_command_test.go` (APP accepted / GROUP rejected),
+  `repositories/roles_test.go` (`TestAppRoleSkipDefaultGroupCreationRoundTrips` incl. the
+  toggle-off case, `TestGetAllRolesReturnsSkipDefaultGroupCreation`), `repositories/users_test.go`
+  (`TestCreateUserSkipsDefaultGroupForFlaggedAppRole` — only `"All"` remains — and
+  `TestCreateUserCreatesDefaultGroupForUnflaggedAppRole`), and `services/roles_test.go`
+  (service round-trip + group roles never carrying it).
+
 ### Legacy role assignment (one-time data migration)
 
 - A startup data migration back-fills the new role assignments from the legacy role values so

--- a/api/internal/commands/upsert_role_command.go
+++ b/api/internal/commands/upsert_role_command.go
@@ -35,6 +35,11 @@ type UpsertRoleCommand struct {
 	// visible to every member. Group-scoped only; ignored (rejected) on APP scope,
 	// mirroring the paid-by flags. Default false ⇒ no effect on existing roles.
 	SeesAllMembers bool `json:"seesAllMembers"`
+	// SkipDefaultGroupCreation suppresses the personal "My Receipts" group that is
+	// otherwise created for every new user assigned this role. App-scoped only;
+	// rejected on GROUP scope (a group role is assigned to a membership, long
+	// after the user was created). Default false ⇒ no effect on existing roles.
+	SkipDefaultGroupCreation bool `json:"skipDefaultGroupCreation"`
 	// ReportTemplateGrants restrict which report templates members of a group role
 	// may act on, per action. Group-scoped only and opt-in: an empty set means
 	// unrestricted (act on every template the role's group access reaches). Each
@@ -116,6 +121,13 @@ func (command *UpsertRoleCommand) Validate() structs.ValidatorError {
 			len(command.PaidByUserGrants) > 0 || command.IncludeOwnPaidReceipts ||
 			command.SeesAllMembers) {
 		errors["grants"] = "Category, tag, paid-by, and member-visibility settings are only valid on group roles"
+	}
+
+	// Skipping personal-group creation is an app-role concept: it acts when the
+	// user account is created, whereas a group role is assigned to an existing
+	// membership long after that.
+	if command.Scope == permissions.ScopeGroup && command.SkipDefaultGroupCreation {
+		errors["skipDefaultGroupCreation"] = "Skipping default group creation is only valid on application roles"
 	}
 
 	if hasDuplicateUint(command.CategoryGrants) {

--- a/api/internal/commands/upsert_role_command_test.go
+++ b/api/internal/commands/upsert_role_command_test.go
@@ -225,6 +225,34 @@ func TestUpsertRoleCommandSeesAllMembersRejectedOnAppScope(t *testing.T) {
 	}
 }
 
+func TestUpsertRoleCommandSkipDefaultGroupCreationValidOnAppScope(t *testing.T) {
+	command := UpsertRoleCommand{
+		Name:                     "Restricted App Role",
+		Scope:                    permissions.ScopeApp,
+		Permissions:              []string{permissions.AppUsersRead},
+		SkipDefaultGroupCreation: true,
+	}
+
+	vErr := command.Validate()
+	if len(vErr.Errors) > 0 {
+		t.Errorf("expected no errors, got %+v", vErr.Errors)
+	}
+}
+
+func TestUpsertRoleCommandSkipDefaultGroupCreationRejectedOnGroupScope(t *testing.T) {
+	command := UpsertRoleCommand{
+		Name:                     "Group Role With Skip",
+		Scope:                    permissions.ScopeGroup,
+		Permissions:              []string{permissions.GroupReceiptsRead},
+		SkipDefaultGroupCreation: true,
+	}
+
+	vErr := command.Validate()
+	if _, ok := vErr.Errors["skipDefaultGroupCreation"]; !ok {
+		t.Errorf("expected skipDefaultGroupCreation error, got %+v", vErr.Errors)
+	}
+}
+
 func TestUpsertRoleCommandDuplicatePaidByGrant(t *testing.T) {
 	command := UpsertRoleCommand{
 		Name:             "Dup Paid-By Grant",

--- a/api/internal/handlers/auth_test_helpers_test.go
+++ b/api/internal/handlers/auth_test_helpers_test.go
@@ -24,7 +24,7 @@ func grantAppPerms(t *testing.T, userId uint, perms ...string) {
 	db := repositories.GetDB()
 
 	roleRepository := repositories.NewRoleRepository(nil)
-	role, err := roleRepository.CreateAppRole(fmt.Sprintf("Test App Role %d", userId), "", perms)
+	role, err := roleRepository.CreateAppRole(fmt.Sprintf("Test App Role %d", userId), "", perms, false)
 	if err != nil {
 		t.Fatalf("create app role: %v", err)
 	}

--- a/api/internal/handlers/roles_test.go
+++ b/api/internal/handlers/roles_test.go
@@ -49,7 +49,7 @@ func ensureRoleAdmin(userId uint) {
 			permissions.AppRolesRead,
 			permissions.AppRolesUpdate,
 			permissions.AppRolesDelete,
-		})
+		}, false)
 		if cErr != nil {
 			panic(cErr)
 		}
@@ -349,7 +349,7 @@ func TestShouldNotUpdateRoleDueToRole(t *testing.T) {
 func TestShouldNotChangeRoleType(t *testing.T) {
 	defer repositories.TruncateTestDb()
 	roleRepository := repositories.NewRoleRepository(nil)
-	created, err := roleRepository.CreateAppRole("App Role", "desc", []string{permissions.AppUsersCreate})
+	created, err := roleRepository.CreateAppRole("App Role", "desc", []string{permissions.AppUsersCreate}, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
@@ -513,7 +513,7 @@ func TestShouldReturnNotFoundForMissingDeleteRole(t *testing.T) {
 func TestShouldNotDeleteRoleDueToScopeMismatch(t *testing.T) {
 	defer repositories.TruncateTestDb()
 	roleRepository := repositories.NewRoleRepository(nil)
-	created, err := roleRepository.CreateAppRole("App Role", "desc", []string{permissions.AppUsersCreate})
+	created, err := roleRepository.CreateAppRole("App Role", "desc", []string{permissions.AppUsersCreate}, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
@@ -564,7 +564,7 @@ func TestShouldNotDeleteSystemRole(t *testing.T) {
 func TestShouldNotDeleteAssignedAppRole(t *testing.T) {
 	defer repositories.TruncateTestDb()
 	roleRepository := repositories.NewRoleRepository(nil)
-	created, err := roleRepository.CreateAppRole("App Role", "desc", []string{permissions.AppUsersCreate})
+	created, err := roleRepository.CreateAppRole("App Role", "desc", []string{permissions.AppUsersCreate}, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return

--- a/api/internal/mcp/mcp_test.go
+++ b/api/internal/mcp/mcp_test.go
@@ -168,7 +168,7 @@ func addGroupMemberWithGrants(
 // resolve to it.
 func setAppRole(t *testing.T, userId uint, roleName string, perms []string) {
 	t.Helper()
-	role, err := repositories.NewRoleRepository(nil).CreateAppRole(roleName, "", perms)
+	role, err := repositories.NewRoleRepository(nil).CreateAppRole(roleName, "", perms, false)
 	if err != nil {
 		t.Fatalf("failed to create app role: %v", err)
 	}

--- a/api/internal/models/app_role.go
+++ b/api/internal/models/app_role.go
@@ -2,9 +2,15 @@ package models
 
 type AppRole struct {
 	BaseModel
-	Name        string              `gorm:"not null;size:64;uniqueIndex" json:"name"`
-	Description string              `json:"description"`
-	IsDefault   bool                `gorm:"not null;default:false" json:"isDefault"`
-	IsSystem    bool                `gorm:"not null;default:false" json:"isSystem"`
-	Permissions []AppRolePermission `gorm:"foreignKey:AppRoleID;constraint:OnDelete:CASCADE" json:"permissions"`
+	Name        string `gorm:"not null;size:64;uniqueIndex" json:"name"`
+	Description string `json:"description"`
+	IsDefault   bool   `gorm:"not null;default:false" json:"isDefault"`
+	IsSystem    bool   `gorm:"not null;default:false" json:"isSystem"`
+	// SkipDefaultGroupCreation suppresses the personal "My Receipts" group that is
+	// otherwise created for every new user. The virtual "All" group is always
+	// created, so the account still has a working dashboard. Creation-time only —
+	// flipping it never adds or removes a group for an existing user. Default
+	// false ⇒ existing roles keep creating the group (no data migration needed).
+	SkipDefaultGroupCreation bool                `gorm:"not null;default:false" json:"skipDefaultGroupCreation"`
+	Permissions              []AppRolePermission `gorm:"foreignKey:AppRoleID;constraint:OnDelete:CASCADE" json:"permissions"`
 }

--- a/api/internal/repositories/data_migrations_test.go
+++ b/api/internal/repositories/data_migrations_test.go
@@ -253,7 +253,7 @@ func TestRunDataMigrationsDoesNotClobberExistingAssignment(t *testing.T) {
 	db := GetDB()
 
 	roleRepository := NewRoleRepository(nil)
-	customAppRole, err := roleRepository.CreateAppRole("Custom Role", "", []string{permissions.AppUsersRead})
+	customAppRole, err := roleRepository.CreateAppRole("Custom Role", "", []string{permissions.AppUsersRead}, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return

--- a/api/internal/repositories/roles.go
+++ b/api/internal/repositories/roles.go
@@ -22,7 +22,7 @@ func NewRoleRepository(tx *gorm.DB) RoleRepository {
 	return repository
 }
 
-func (repository RoleRepository) CreateAppRole(name string, description string, perms []string) (models.AppRole, error) {
+func (repository RoleRepository) CreateAppRole(name string, description string, perms []string, skipDefaultGroupCreation bool) (models.AppRole, error) {
 	db := repository.GetDB()
 
 	rolePermissions := make([]models.AppRolePermission, 0, len(perms))
@@ -31,9 +31,10 @@ func (repository RoleRepository) CreateAppRole(name string, description string, 
 	}
 
 	role := models.AppRole{
-		Name:        name,
-		Description: description,
-		Permissions: rolePermissions,
+		Name:                     name,
+		Description:              description,
+		SkipDefaultGroupCreation: skipDefaultGroupCreation,
+		Permissions:              rolePermissions,
 	}
 
 	err := db.Create(&role).Error
@@ -103,7 +104,7 @@ func (repository RoleRepository) GetGroupRoleById(id uint) (models.GroupRoleDefi
 	return role, nil
 }
 
-func (repository RoleRepository) UpdateAppRole(id uint, name string, description string, perms []string) (models.AppRole, error) {
+func (repository RoleRepository) UpdateAppRole(id uint, name string, description string, perms []string, skipDefaultGroupCreation bool) (models.AppRole, error) {
 	db := repository.GetDB()
 
 	err := db.Where("app_role_id = ?", id).Delete(&models.AppRolePermission{}).Error
@@ -111,9 +112,12 @@ func (repository RoleRepository) UpdateAppRole(id uint, name string, description
 		return models.AppRole{}, err
 	}
 
+	// Use the map form so false bools persist (GORM's struct Updates skips
+	// zero-value bools, which would leave a toggled-off flag set).
 	err = db.Model(&models.AppRole{}).Where("id = ?", id).Updates(map[string]interface{}{
-		"name":        name,
-		"description": description,
+		"name":                        name,
+		"description":                 description,
+		"skip_default_group_creation": skipDefaultGroupCreation,
 	}).Error
 	if err != nil {
 		return models.AppRole{}, err
@@ -315,18 +319,19 @@ func (repository RoleRepository) GetAllRoles() ([]structs.RoleView, error) {
 		}
 
 		roles = append(roles, structs.RoleView{
-			Id:                   role.ID,
-			Name:                 role.Name,
-			Description:          role.Description,
-			Scope:                permissions.ScopeApp,
-			IsDefault:            role.IsDefault,
-			IsSystem:             role.IsSystem,
-			Permissions:          perms,
-			AssignedCount:        appRoleCounts[role.ID],
-			CategoryGrants:       []uint{},
-			TagGrants:            []uint{},
-			PaidByUserGrants:     []uint{},
-			ReportTemplateGrants: []structs.ReportTemplateGrantView{},
+			Id:                       role.ID,
+			Name:                     role.Name,
+			Description:              role.Description,
+			Scope:                    permissions.ScopeApp,
+			IsDefault:                role.IsDefault,
+			IsSystem:                 role.IsSystem,
+			Permissions:              perms,
+			AssignedCount:            appRoleCounts[role.ID],
+			SkipDefaultGroupCreation: role.SkipDefaultGroupCreation,
+			CategoryGrants:           []uint{},
+			TagGrants:                []uint{},
+			PaidByUserGrants:         []uint{},
+			ReportTemplateGrants:     []structs.ReportTemplateGrantView{},
 		})
 	}
 
@@ -681,6 +686,23 @@ func (repository RoleRepository) GetGroupRoleReportTemplateGrantsRestricted(grou
 
 // GetUserAppRoleId returns the app role id assigned to a user, or nil when the
 // user has no app role. Returns gorm.ErrRecordNotFound if the user is missing.
+// AppRoleSkipsDefaultGroup reports whether users created with this app role skip
+// the personal "My Receipts" group. Reads the single column so user creation does
+// not preload the role's whole permission set.
+func (repository RoleRepository) AppRoleSkipsDefaultGroup(id uint) (bool, error) {
+	db := repository.GetDB()
+
+	var role models.AppRole
+	err := db.Select("skip_default_group_creation").
+		Where("id = ?", id).
+		First(&role).Error
+	if err != nil {
+		return false, err
+	}
+
+	return role.SkipDefaultGroupCreation, nil
+}
+
 func (repository RoleRepository) GetUserAppRoleId(userId uint) (*uint, error) {
 	db := repository.GetDB()
 

--- a/api/internal/repositories/roles_test.go
+++ b/api/internal/repositories/roles_test.go
@@ -29,7 +29,7 @@ func TestCreateAppRolePersistsPermissions(t *testing.T) {
 	repository := NewRoleRepository(nil)
 
 	perms := []string{permissions.AppUsersCreate, permissions.AppUsersRead}
-	role, err := repository.CreateAppRole("App Role", "Description", perms)
+	role, err := repository.CreateAppRole("App Role", "Description", perms, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
@@ -68,13 +68,13 @@ func TestUpdateAppRolePersistsChanges(t *testing.T) {
 	defer TruncateTestDb()
 	repository := NewRoleRepository(nil)
 
-	created, err := repository.CreateAppRole("App Role", "Description", []string{permissions.AppUsersCreate})
+	created, err := repository.CreateAppRole("App Role", "Description", []string{permissions.AppUsersCreate}, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
 	}
 
-	updated, err := repository.UpdateAppRole(created.ID, "Renamed Role", "New description", []string{permissions.AppUsersRead})
+	updated, err := repository.UpdateAppRole(created.ID, "Renamed Role", "New description", []string{permissions.AppUsersRead}, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
@@ -86,6 +86,94 @@ func TestUpdateAppRolePersistsChanges(t *testing.T) {
 
 	if updated.Description != "New description" {
 		utils.PrintTestError(t, updated.Description, "New description")
+	}
+}
+
+func TestAppRoleSkipDefaultGroupCreationRoundTrips(t *testing.T) {
+	defer TruncateTestDb()
+	repository := NewRoleRepository(nil)
+
+	created, err := repository.CreateAppRole("Shared Groups Only", "", []string{permissions.AppUsersRead}, true)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	if !created.SkipDefaultGroupCreation {
+		utils.PrintTestError(t, created.SkipDefaultGroupCreation, true)
+	}
+
+	skips, err := repository.AppRoleSkipsDefaultGroup(created.ID)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if !skips {
+		utils.PrintTestError(t, skips, true)
+	}
+
+	// Toggling the flag back off must persist — the update uses the map form
+	// precisely because GORM's struct Updates skips zero-value bools.
+	updated, err := repository.UpdateAppRole(created.ID, "Shared Groups Only", "", []string{permissions.AppUsersRead}, false)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if updated.SkipDefaultGroupCreation {
+		utils.PrintTestError(t, updated.SkipDefaultGroupCreation, false)
+	}
+
+	skips, err = repository.AppRoleSkipsDefaultGroup(created.ID)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if skips {
+		utils.PrintTestError(t, skips, false)
+	}
+}
+
+func TestGetAllRolesReturnsSkipDefaultGroupCreation(t *testing.T) {
+	defer TruncateTestDb()
+	repository := NewRoleRepository(nil)
+
+	appRole, err := repository.CreateAppRole("Shared Groups Only", "", []string{permissions.AppUsersRead}, true)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	groupRole, err := repository.CreateGroupRole("Group Role", "", []string{permissions.GroupReceiptsRead}, nil, nil, nil, false, false)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	roles, err := repository.GetAllRoles()
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	var sawApp, sawGroup bool
+	for _, role := range roles {
+		if role.Scope == permissions.ScopeApp && role.Id == appRole.ID {
+			sawApp = true
+			if !role.SkipDefaultGroupCreation {
+				utils.PrintTestError(t, role.SkipDefaultGroupCreation, true)
+			}
+		}
+		// A group role never carries the app-only flag.
+		if role.Scope == permissions.ScopeGroup && role.Id == groupRole.ID {
+			sawGroup = true
+			if role.SkipDefaultGroupCreation {
+				utils.PrintTestError(t, role.SkipDefaultGroupCreation, false)
+			}
+		}
+	}
+
+	if !sawApp || !sawGroup {
+		utils.PrintTestError(t, []bool{sawApp, sawGroup}, []bool{true, true})
 	}
 }
 
@@ -118,13 +206,13 @@ func TestUpdateAppRoleReplacesPermissions(t *testing.T) {
 	defer TruncateTestDb()
 	repository := NewRoleRepository(nil)
 
-	created, err := repository.CreateAppRole("App Role", "Description", []string{permissions.AppUsersCreate, permissions.AppUsersRead})
+	created, err := repository.CreateAppRole("App Role", "Description", []string{permissions.AppUsersCreate, permissions.AppUsersRead}, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
 	}
 
-	updated, err := repository.UpdateAppRole(created.ID, "App Role", "Description", []string{permissions.AppUsersDelete})
+	updated, err := repository.UpdateAppRole(created.ID, "App Role", "Description", []string{permissions.AppUsersDelete}, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
@@ -189,7 +277,7 @@ func TestGetAppRolePermissions(t *testing.T) {
 	repository := NewRoleRepository(nil)
 
 	perms := []string{permissions.AppUsersCreate, permissions.AppUsersRead}
-	role, err := repository.CreateAppRole("App Role", "", perms)
+	role, err := repository.CreateAppRole("App Role", "", perms, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
@@ -208,7 +296,7 @@ func TestGetAppRolePermissions(t *testing.T) {
 	}
 
 	// A role with no permissions resolves to an empty (non-nil) slice.
-	empty, err := repository.CreateAppRole("Empty Role", "", []string{})
+	empty, err := repository.CreateAppRole("Empty Role", "", []string{}, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
@@ -249,7 +337,7 @@ func TestGetUserAppRoleId(t *testing.T) {
 	repository := NewRoleRepository(nil)
 	db := GetDB()
 
-	role, err := repository.CreateAppRole("App Role", "", []string{permissions.AppUsersRead})
+	role, err := repository.CreateAppRole("App Role", "", []string{permissions.AppUsersRead}, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
@@ -334,12 +422,12 @@ func TestSetDefaultAppRoleClearsOthers(t *testing.T) {
 	defer TruncateTestDb()
 	repository := NewRoleRepository(nil)
 
-	first, err := repository.CreateAppRole("First", "", []string{permissions.AppUsersRead})
+	first, err := repository.CreateAppRole("First", "", []string{permissions.AppUsersRead}, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
 	}
-	second, err := repository.CreateAppRole("Second", "", []string{permissions.AppUsersRead})
+	second, err := repository.CreateAppRole("Second", "", []string{permissions.AppUsersRead}, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
@@ -421,7 +509,7 @@ func TestGetDefaultAppRoleIdNilWhenUnset(t *testing.T) {
 	defer TruncateTestDb()
 	repository := NewRoleRepository(nil)
 
-	if _, err := repository.CreateAppRole("Role", "", []string{permissions.AppUsersRead}); err != nil {
+	if _, err := repository.CreateAppRole("Role", "", []string{permissions.AppUsersRead}, false); err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
 	}
@@ -440,7 +528,7 @@ func TestGetAppRoleIdByName(t *testing.T) {
 	defer TruncateTestDb()
 	repository := NewRoleRepository(nil)
 
-	created, err := repository.CreateAppRole("Named Role", "", []string{permissions.AppUsersRead})
+	created, err := repository.CreateAppRole("Named Role", "", []string{permissions.AppUsersRead}, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
@@ -470,7 +558,7 @@ func TestGetAllRolesReturnsIsDefault(t *testing.T) {
 	defer TruncateTestDb()
 	repository := NewRoleRepository(nil)
 
-	role, err := repository.CreateAppRole("Default App", "", []string{permissions.AppUsersRead})
+	role, err := repository.CreateAppRole("Default App", "", []string{permissions.AppUsersRead}, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return

--- a/api/internal/repositories/seed_roles_test.go
+++ b/api/internal/repositories/seed_roles_test.go
@@ -528,7 +528,7 @@ func TestEnsureDefaultRolesPreservesCustomDefault(t *testing.T) {
 
 	// An administrator picked a custom app role as the default before this runs.
 	repository := NewRoleRepository(nil)
-	custom, err := repository.CreateAppRole("Custom Default", "", []string{permissions.AppUsersRead})
+	custom, err := repository.CreateAppRole("Custom Default", "", []string{permissions.AppUsersRead}, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return

--- a/api/internal/repositories/users.go
+++ b/api/internal/repositories/users.go
@@ -136,9 +136,11 @@ func (repository UserRepository) CreateUser(userData commands.SignUpCommand) (mo
 }
 
 // appRoleSkipsDefaultGroup reports whether a newly-created user's app role opts
-// out of the personal "My Receipts" group. Best-effort, matching resolveAppRoleId:
-// an unassigned or unreadable role falls back to creating the group rather than
-// failing user creation.
+// out of the personal "My Receipts" group. Best-effort in the same way as
+// resolveAppRoleId: an unassigned (nil) or missing role falls back to creating
+// the group rather than failing user creation. Any *other* lookup error
+// propagates and rolls the creation back — a transient DB failure must not
+// silently decide which groups an account is created with.
 func (repository UserRepository) appRoleSkipsDefaultGroup(tx *gorm.DB, appRoleId *uint) (bool, error) {
 	if appRoleId == nil {
 		return false, nil

--- a/api/internal/repositories/users.go
+++ b/api/internal/repositories/users.go
@@ -89,15 +89,27 @@ func (repository UserRepository) CreateUser(userData commands.SignUpCommand) (mo
 			return err
 		}
 
-		groupCommand := commands.UpsertGroupCommand{
-			Name:           "My Receipts",
-			IsDefaultGroup: true,
-		}
-
-		_, err := groupRepository.CreateGroup(groupCommand, user.ID)
+		// An app role may opt its users out of the personal "My Receipts" group, for
+		// accounts that are only ever meant to live in specific shared groups. The
+		// virtual "All" group is always created, so the account still has a working
+		// dashboard.
+		skipDefaultGroup, err := repository.appRoleSkipsDefaultGroup(tx, user.AppRoleID)
 		if err != nil {
 			repository.ClearTransaction()
 			return err
+		}
+
+		if !skipDefaultGroup {
+			groupCommand := commands.UpsertGroupCommand{
+				Name:           "My Receipts",
+				IsDefaultGroup: true,
+			}
+
+			_, err := groupRepository.CreateGroup(groupCommand, user.ID)
+			if err != nil {
+				repository.ClearTransaction()
+				return err
+			}
 		}
 
 		_, err = groupRepository.CreateAllGroup(user.ID)
@@ -121,6 +133,26 @@ func (repository UserRepository) CreateUser(userData commands.SignUpCommand) (mo
 	}
 
 	return user, nil
+}
+
+// appRoleSkipsDefaultGroup reports whether a newly-created user's app role opts
+// out of the personal "My Receipts" group. Best-effort, matching resolveAppRoleId:
+// an unassigned or unreadable role falls back to creating the group rather than
+// failing user creation.
+func (repository UserRepository) appRoleSkipsDefaultGroup(tx *gorm.DB, appRoleId *uint) (bool, error) {
+	if appRoleId == nil {
+		return false, nil
+	}
+
+	skip, err := NewRoleRepository(tx).AppRoleSkipsDefaultGroup(*appRoleId)
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	return skip, nil
 }
 
 // resolveAppRoleId picks the modern app role for a newly-created user: the

--- a/api/internal/repositories/users_test.go
+++ b/api/internal/repositories/users_test.go
@@ -239,8 +239,9 @@ func TestCreateUserSkipsDefaultGroupForFlaggedAppRole(t *testing.T) {
 // Both must report "don't skip" rather than erroring, so user creation proceeds
 // with the personal group instead of failing. (A non-record-not-found lookup
 // error deliberately propagates instead — that path needs DB error injection,
-// which this package has no mechanism for, and is unreachable in practice since
-// User.AppRoleID is an OnDelete:RESTRICT FK.)
+// which this package has no mechanism for. The OnDelete:RESTRICT FK on
+// User.AppRoleID rules out dangling role ids, not connection, transaction, or
+// context errors.)
 func TestAppRoleSkipsDefaultGroupBestEffortBranches(t *testing.T) {
 	defer TruncateTestDb()
 	userRepository := NewUserRepository(nil)

--- a/api/internal/repositories/users_test.go
+++ b/api/internal/repositories/users_test.go
@@ -234,6 +234,35 @@ func TestCreateUserSkipsDefaultGroupForFlaggedAppRole(t *testing.T) {
 	}
 }
 
+// The two best-effort branches of the helper, which the CreateUser tests below
+// can't reach: a user with no app role at all, and an id with no matching row.
+// Both must report "don't skip" rather than erroring, so user creation proceeds
+// with the personal group instead of failing. (A non-record-not-found lookup
+// error deliberately propagates instead — that path needs DB error injection,
+// which this package has no mechanism for, and is unreachable in practice since
+// User.AppRoleID is an OnDelete:RESTRICT FK.)
+func TestAppRoleSkipsDefaultGroupBestEffortBranches(t *testing.T) {
+	defer TruncateTestDb()
+	userRepository := NewUserRepository(nil)
+
+	skip, err := userRepository.appRoleSkipsDefaultGroup(nil, nil)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	if skip {
+		utils.PrintTestError(t, skip, false)
+	}
+
+	missingId := uint(999999)
+	skip, err = userRepository.appRoleSkipsDefaultGroup(nil, &missingId)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	if skip {
+		utils.PrintTestError(t, skip, false)
+	}
+}
+
 func TestCreateUserCreatesDefaultGroupForUnflaggedAppRole(t *testing.T) {
 	defer TruncateTestDb()
 

--- a/api/internal/repositories/users_test.go
+++ b/api/internal/repositories/users_test.go
@@ -149,7 +149,7 @@ func TestCreateUserHonorsExplicitAppRole(t *testing.T) {
 	}
 
 	// A custom (non-system) app role is honored as-is on the modern FK.
-	custom, err := roleRepository.CreateAppRole("Auditor", "", []string{permissions.AppUsersRead})
+	custom, err := roleRepository.CreateAppRole("Auditor", "", []string{permissions.AppUsersRead}, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
@@ -164,6 +164,123 @@ func TestCreateUserHonorsExplicitAppRole(t *testing.T) {
 	}
 	if auditor.AppRoleID == nil || *auditor.AppRoleID != custom.ID {
 		utils.PrintTestError(t, auditor.AppRoleID, custom.ID)
+	}
+}
+
+// groupNamesForUser returns the names of every group the user is a member of.
+func groupNamesForUser(t *testing.T, userId uint) []string {
+	var groups []models.Group
+	err := GetDB().Model(&models.Group{}).
+		Joins("JOIN group_members ON group_members.group_id = groups.id").
+		Where("group_members.user_id = ?", userId).
+		Find(&groups).Error
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return nil
+	}
+
+	names := make([]string, 0, len(groups))
+	for _, group := range groups {
+		names = append(names, group.Name)
+	}
+
+	return names
+}
+
+func TestCreateUserSkipsDefaultGroupForFlaggedAppRole(t *testing.T) {
+	defer TruncateTestDb()
+
+	if err := SeedSystemRoles(); err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if err := EnsureDefaultRoles(); err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	userRepository := NewUserRepository(nil)
+	roleRepository := NewRoleRepository(nil)
+
+	// Occupy the first-user slot so the accounts below take their explicit role
+	// rather than the bootstrap Legacy Admin.
+	if _, err := userRepository.CreateUser(commands.SignUpCommand{
+		Username: "bootstrap", DisplayName: "b", Password: "a really secure password",
+	}); err != nil {
+		utils.PrintTestError(t, err, "no error")
+		return
+	}
+
+	skipRole, err := roleRepository.CreateAppRole("Shared Groups Only", "", []string{permissions.AppUsersRead}, true)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	restricted, err := userRepository.CreateUser(commands.SignUpCommand{
+		Username: "restricted", DisplayName: "r", Password: "a really secure password",
+		AppRoleID: &skipRole.ID,
+	})
+	if err != nil {
+		utils.PrintTestError(t, err, "no error")
+		return
+	}
+
+	// The personal group is skipped, but the virtual "All" group is always created
+	// so the account still has a working dashboard.
+	names := groupNamesForUser(t, restricted.ID)
+	if len(names) != 1 || names[0] != "All" {
+		utils.PrintTestError(t, names, []string{"All"})
+	}
+}
+
+func TestCreateUserCreatesDefaultGroupForUnflaggedAppRole(t *testing.T) {
+	defer TruncateTestDb()
+
+	if err := SeedSystemRoles(); err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if err := EnsureDefaultRoles(); err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	userRepository := NewUserRepository(nil)
+
+	if _, err := userRepository.CreateUser(commands.SignUpCommand{
+		Username: "bootstrap", DisplayName: "b", Password: "a really secure password",
+	}); err != nil {
+		utils.PrintTestError(t, err, "no error")
+		return
+	}
+
+	// The default app role is unflagged, so the personal group is still created.
+	normal, err := userRepository.CreateUser(commands.SignUpCommand{
+		Username: "normal", DisplayName: "n", Password: "a really secure password",
+	})
+	if err != nil {
+		utils.PrintTestError(t, err, "no error")
+		return
+	}
+
+	names := groupNamesForUser(t, normal.ID)
+	if len(names) != 2 {
+		utils.PrintTestError(t, names, []string{"My Receipts", "All"})
+		return
+	}
+
+	var hasPersonal, hasAll bool
+	for _, name := range names {
+		if name == "My Receipts" {
+			hasPersonal = true
+		}
+		if name == "All" {
+			hasAll = true
+		}
+	}
+	if !hasPersonal || !hasAll {
+		utils.PrintTestError(t, names, []string{"My Receipts", "All"})
 	}
 }
 

--- a/api/internal/services/auth_test.go
+++ b/api/internal/services/auth_test.go
@@ -182,7 +182,7 @@ func TestShouldLogInUserCorrectly(t *testing.T) {
 	// (the modern replacement for the removed UserRole == ADMIN check), so the
 	// user must hold an admin role for the firstAdminToLogin path to be exercised.
 	roleRepository := repositories.NewRoleRepository(nil)
-	adminRole, err := roleRepository.CreateAppRole("Login Admin Role", "", []string{permissions.AppUsersRead})
+	adminRole, err := roleRepository.CreateAppRole("Login Admin Role", "", []string{permissions.AppUsersRead}, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 	}
@@ -551,7 +551,7 @@ func TestGetAppData_PopulatesPermissions(t *testing.T) {
 	roleRepository := repositories.NewRoleRepository(nil)
 
 	appPerms := []string{permissions.AppUsersRead, permissions.AppUsersCreate}
-	appRole, err := roleRepository.CreateAppRole("AppData App Role", "", appPerms)
+	appRole, err := roleRepository.CreateAppRole("AppData App Role", "", appPerms, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 	}
@@ -609,7 +609,7 @@ func TestGetAppData_GroupCategoriesFilteredByGrants(t *testing.T) {
 	db.Create(&hiddenCategory)
 
 	// Legacy-User-like app role: create but not read.
-	appRole, err := roleRepository.CreateAppRole("AppData User Role", "", []string{permissions.AppCategoriesCreate})
+	appRole, err := roleRepository.CreateAppRole("AppData User Role", "", []string{permissions.AppCategoriesCreate}, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 	}
@@ -659,7 +659,7 @@ func TestGetAppData_AdminGetsFlatCategoriesUnrestrictedGroup(t *testing.T) {
 	db.Create(&models.Category{Name: "Groceries"})
 	db.Create(&models.Category{Name: "Salary"})
 
-	appRole, err := roleRepository.CreateAppRole("AppData Admin Role", "", []string{permissions.AppCategoriesRead, permissions.AppTagsRead})
+	appRole, err := roleRepository.CreateAppRole("AppData Admin Role", "", []string{permissions.AppCategoriesRead, permissions.AppTagsRead}, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 	}

--- a/api/internal/services/grant_filter_test.go
+++ b/api/internal/services/grant_filter_test.go
@@ -30,7 +30,7 @@ func categoryIdSet(categories []models.Category) map[uint]struct{} {
 // user bypasses grant filtering for those resources.
 func grantUserAppPermissions(t *testing.T, userId uint, perms []string) {
 	t.Helper()
-	role, err := repositories.NewRoleRepository(nil).CreateAppRole("Bypass Role", "", perms)
+	role, err := repositories.NewRoleRepository(nil).CreateAppRole("Bypass Role", "", perms, false)
 	if err != nil {
 		t.Fatalf("create app role: %v", err)
 	}

--- a/api/internal/services/permission_test.go
+++ b/api/internal/services/permission_test.go
@@ -17,7 +17,7 @@ func seedUserWithAppRole(t *testing.T, username string, perms []string) (uint, u
 	db := repositories.GetDB()
 
 	roleRepository := repositories.NewRoleRepository(nil)
-	role, err := roleRepository.CreateAppRole("App Role", "", perms)
+	role, err := roleRepository.CreateAppRole("App Role", "", perms, false)
 	if err != nil {
 		t.Fatalf("seed app role: %v", err)
 	}
@@ -322,7 +322,7 @@ func TestPermissionCacheInvalidatedOnRoleDelete(t *testing.T) {
 	// lookup is always fresh, so prime the cache directly for an unassigned role
 	// and verify DeleteRole evicts that role's cached permission list.
 	roleRepository := repositories.NewRoleRepository(nil)
-	role, err := roleRepository.CreateAppRole("Deletable Role", "", []string{permissions.AppUsersRead})
+	role, err := roleRepository.CreateAppRole("Deletable Role", "", []string{permissions.AppUsersRead}, false)
 	if err != nil {
 		t.Fatalf("seed role: %v", err)
 	}

--- a/api/internal/services/receipts_test.go
+++ b/api/internal/services/receipts_test.go
@@ -72,7 +72,7 @@ func seedReceiptMember(
 // giveAppRole assigns an app role with the given permissions to a user.
 func giveAppRole(t *testing.T, userId uint, roleName string, perms []string) {
 	t.Helper()
-	role, err := repositories.NewRoleRepository(nil).CreateAppRole(roleName, "", perms)
+	role, err := repositories.NewRoleRepository(nil).CreateAppRole(roleName, "", perms, false)
 	if err != nil {
 		t.Fatalf("create app role: %v", err)
 	}

--- a/api/internal/services/report_authz_test.go
+++ b/api/internal/services/report_authz_test.go
@@ -22,7 +22,7 @@ func seedAppUser(t *testing.T, username string, appPerms []string) uint {
 	t.Helper()
 	db := repositories.GetDB()
 
-	role, err := repositories.NewRoleRepository(nil).CreateAppRole("App "+username, "", appPerms)
+	role, err := repositories.NewRoleRepository(nil).CreateAppRole("App "+username, "", appPerms, false)
 	if err != nil {
 		t.Fatalf("seed app role: %v", err)
 	}

--- a/api/internal/services/roles.go
+++ b/api/internal/services/roles.go
@@ -49,22 +49,23 @@ func (service RoleService) CreateRole(command commands.UpsertRoleCommand) (struc
 		roleRepository := repositories.NewRoleRepository(tx)
 
 		if command.Scope == permissions.ScopeApp {
-			role, txErr := roleRepository.CreateAppRole(command.Name, command.Description, perms)
+			role, txErr := roleRepository.CreateAppRole(command.Name, command.Description, perms, command.SkipDefaultGroupCreation)
 			if txErr != nil {
 				return txErr
 			}
 
 			roleView = structs.RoleView{
-				Id:                   role.ID,
-				Name:                 role.Name,
-				Description:          role.Description,
-				Scope:                permissions.ScopeApp,
-				IsSystem:             role.IsSystem,
-				Permissions:          perms,
-				CategoryGrants:       []uint{},
-				TagGrants:            []uint{},
-				PaidByUserGrants:     []uint{},
-				ReportTemplateGrants: []structs.ReportTemplateGrantView{},
+				Id:                       role.ID,
+				Name:                     role.Name,
+				Description:              role.Description,
+				Scope:                    permissions.ScopeApp,
+				IsSystem:                 role.IsSystem,
+				Permissions:              perms,
+				SkipDefaultGroupCreation: role.SkipDefaultGroupCreation,
+				CategoryGrants:           []uint{},
+				TagGrants:                []uint{},
+				PaidByUserGrants:         []uint{},
+				ReportTemplateGrants:     []structs.ReportTemplateGrantView{},
 			}
 
 			return nil
@@ -134,23 +135,24 @@ func (service RoleService) UpdateRole(id uint, command commands.UpsertRoleComman
 				return ErrSystemRoleImmutable
 			}
 
-			role, txErr := roleRepository.UpdateAppRole(id, command.Name, command.Description, perms)
+			role, txErr := roleRepository.UpdateAppRole(id, command.Name, command.Description, perms, command.SkipDefaultGroupCreation)
 			if txErr != nil {
 				return txErr
 			}
 
 			roleView = structs.RoleView{
-				Id:                   role.ID,
-				Name:                 role.Name,
-				Description:          role.Description,
-				Scope:                permissions.ScopeApp,
-				IsDefault:            role.IsDefault,
-				IsSystem:             role.IsSystem,
-				Permissions:          perms,
-				CategoryGrants:       []uint{},
-				TagGrants:            []uint{},
-				PaidByUserGrants:     []uint{},
-				ReportTemplateGrants: []structs.ReportTemplateGrantView{},
+				Id:                       role.ID,
+				Name:                     role.Name,
+				Description:              role.Description,
+				Scope:                    permissions.ScopeApp,
+				IsDefault:                role.IsDefault,
+				IsSystem:                 role.IsSystem,
+				Permissions:              perms,
+				SkipDefaultGroupCreation: role.SkipDefaultGroupCreation,
+				CategoryGrants:           []uint{},
+				TagGrants:                []uint{},
+				PaidByUserGrants:         []uint{},
+				ReportTemplateGrants:     []structs.ReportTemplateGrantView{},
 			}
 
 			return nil
@@ -478,17 +480,18 @@ func appRoleToView(role models.AppRole, isDefault bool) structs.RoleView {
 	}
 
 	return structs.RoleView{
-		Id:                   role.ID,
-		Name:                 role.Name,
-		Description:          role.Description,
-		Scope:                permissions.ScopeApp,
-		IsDefault:            isDefault,
-		IsSystem:             role.IsSystem,
-		Permissions:          perms,
-		CategoryGrants:       []uint{},
-		TagGrants:            []uint{},
-		PaidByUserGrants:     []uint{},
-		ReportTemplateGrants: []structs.ReportTemplateGrantView{},
+		Id:                       role.ID,
+		Name:                     role.Name,
+		Description:              role.Description,
+		Scope:                    permissions.ScopeApp,
+		IsDefault:                isDefault,
+		IsSystem:                 role.IsSystem,
+		Permissions:              perms,
+		SkipDefaultGroupCreation: role.SkipDefaultGroupCreation,
+		CategoryGrants:           []uint{},
+		TagGrants:                []uint{},
+		PaidByUserGrants:         []uint{},
+		ReportTemplateGrants:     []structs.ReportTemplateGrantView{},
 	}
 }
 

--- a/api/internal/services/roles_test.go
+++ b/api/internal/services/roles_test.go
@@ -266,7 +266,7 @@ func TestUpdateRolePersistsChanges(t *testing.T) {
 	defer repositories.TruncateTestDb()
 	roleRepository := repositories.NewRoleRepository(nil)
 
-	created, err := roleRepository.CreateAppRole("App Role", "Description", []string{permissions.AppUsersCreate})
+	created, err := roleRepository.CreateAppRole("App Role", "Description", []string{permissions.AppUsersCreate}, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
@@ -299,11 +299,66 @@ func TestUpdateRolePersistsChanges(t *testing.T) {
 	}
 }
 
+func TestCreateAndUpdateRoleRoundTripSkipDefaultGroupCreation(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	service := NewRoleService(nil)
+
+	roleView, err := service.CreateRole(commands.UpsertRoleCommand{
+		Name:                     "Shared Groups Only",
+		Scope:                    permissions.ScopeApp,
+		Permissions:              []string{permissions.AppUsersRead},
+		SkipDefaultGroupCreation: true,
+	})
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	if !roleView.SkipDefaultGroupCreation {
+		utils.PrintTestError(t, roleView.SkipDefaultGroupCreation, true)
+	}
+
+	// Toggling it off through the service must stick.
+	updated, err := service.UpdateRole(roleView.Id, commands.UpsertRoleCommand{
+		Name:                     "Shared Groups Only",
+		Scope:                    permissions.ScopeApp,
+		Permissions:              []string{permissions.AppUsersRead},
+		SkipDefaultGroupCreation: false,
+	})
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	if updated.SkipDefaultGroupCreation {
+		utils.PrintTestError(t, updated.SkipDefaultGroupCreation, false)
+	}
+}
+
+func TestCreateGroupRoleNeverCarriesSkipDefaultGroupCreation(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	service := NewRoleService(nil)
+
+	roleView, err := service.CreateRole(commands.UpsertRoleCommand{
+		Name:        "Group Role",
+		Scope:       permissions.ScopeGroup,
+		Permissions: []string{permissions.GroupReceiptsRead},
+	})
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	if roleView.SkipDefaultGroupCreation {
+		utils.PrintTestError(t, roleView.SkipDefaultGroupCreation, false)
+	}
+}
+
 func TestUpdateRoleBlocksTypeSwitch(t *testing.T) {
 	defer repositories.TruncateTestDb()
 	roleRepository := repositories.NewRoleRepository(nil)
 
-	created, err := roleRepository.CreateAppRole("App Role", "Description", []string{permissions.AppUsersCreate})
+	created, err := roleRepository.CreateAppRole("App Role", "Description", []string{permissions.AppUsersCreate}, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
@@ -372,7 +427,7 @@ func TestSetDefaultRoleApp(t *testing.T) {
 	defer repositories.TruncateTestDb()
 	roleRepository := repositories.NewRoleRepository(nil)
 
-	created, err := roleRepository.CreateAppRole("App Role", "", []string{permissions.AppUsersRead})
+	created, err := roleRepository.CreateAppRole("App Role", "", []string{permissions.AppUsersRead}, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
@@ -429,7 +484,7 @@ func TestSetDefaultRoleTypeMismatch(t *testing.T) {
 	defer repositories.TruncateTestDb()
 	roleRepository := repositories.NewRoleRepository(nil)
 
-	created, err := roleRepository.CreateAppRole("App Role", "", []string{permissions.AppUsersRead})
+	created, err := roleRepository.CreateAppRole("App Role", "", []string{permissions.AppUsersRead}, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
@@ -457,7 +512,7 @@ func TestDeleteRoleRejectsDefault(t *testing.T) {
 	defer repositories.TruncateTestDb()
 	roleRepository := repositories.NewRoleRepository(nil)
 
-	created, err := roleRepository.CreateAppRole("Default App Role", "", []string{permissions.AppUsersRead})
+	created, err := roleRepository.CreateAppRole("Default App Role", "", []string{permissions.AppUsersRead}, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return

--- a/api/internal/services/users_test.go
+++ b/api/internal/services/users_test.go
@@ -50,7 +50,7 @@ func makeUserAdmin(t *testing.T, userId uint) {
 		t.Fatalf("look up admin role: %v", err)
 	}
 	if roleId == nil {
-		role, err := roleRepository.CreateAppRole(adminRoleName, "", []string{permissions.AppUsersRead})
+		role, err := roleRepository.CreateAppRole(adminRoleName, "", []string{permissions.AppUsersRead}, false)
 		if err != nil {
 			t.Fatalf("create admin role: %v", err)
 		}

--- a/api/internal/structs/role_view.go
+++ b/api/internal/structs/role_view.go
@@ -26,6 +26,10 @@ type RoleView struct {
 	// isolation (they see, and are seen by, every member of an isolated group).
 	// Always group-scoped; app roles serialize false.
 	SeesAllMembers bool `json:"seesAllMembers"`
+	// SkipDefaultGroupCreation marks an app role whose new users skip the personal
+	// "My Receipts" group (the virtual "All" group is always created). Always
+	// app-scoped; group roles serialize false.
+	SkipDefaultGroupCreation bool `json:"skipDefaultGroupCreation"`
 	// ReportTemplateGrants restrict which report templates a group role's members
 	// may act on, per action. Empty means unrestricted (every template the role's
 	// group access reaches). Always group-scoped; app roles serialize an empty

--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -3525,6 +3525,13 @@ components:
             Whether a GROUP role exempts its members from member-presence isolation
             (they see, and are seen by, every member of an isolated group). Always
             false for app roles.
+        skipDefaultGroupCreation:
+          type: boolean
+          description: >-
+            Whether users created with this APP role skip the automatic personal
+            "My Receipts" group. The virtual "All" group is always created. Applies
+            at user-creation time only — changing it never adds or removes a group
+            for an existing user. Always false for group roles.
         reportTemplateGrants:
           type: array
           description: >-
@@ -3586,6 +3593,12 @@ components:
             Whether a GROUP role exempts its members from member-presence isolation
             (they see, and are seen by, every member of an isolated group). Only
             valid on group roles.
+        skipDefaultGroupCreation:
+          type: boolean
+          description: >-
+            Whether users created with this APP role skip the automatic personal
+            "My Receipts" group (the virtual "All" group is always created). Only
+            valid on app roles; applies at user-creation time only.
         reportTemplateGrants:
           type: array
           description: >-

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -232,6 +232,16 @@ gated by `appPermissionGuard` requiring `app.roles.read` (see **Permission-based
   permissions grid's `Set` pattern — NOT a FormArray). **All-empty = unrestricted**; a template maps to the
   subset of actions the role may perform on it. Hydrates directly from `role.reportTemplateGrants`,
   serializes back for group scope only, resets on `pickType`. See `api/CLAUDE.md` → "Report-template access".
+- **Group creation (app roles only):** an app-scope-only **"Group creation"** `rw-card` in
+  `role-form` (gated on `showAppOptions()` = `type() === "app"`, the mirror of `showGrants()`) holds a
+  single `app-checkbox` — "Don't create a personal group for new users with this role"
+  (`data-testid="skip-default-group"`) — bound to `skipDefaultGroupCreation` on the
+  `UpsertRoleCommand`. New users normally get a personal "My Receipts" group; turning this on skips it
+  for accounts that should only belong to groups an admin adds them to (the virtual "All" group is
+  always created, so the dashboard still works). It mirrors `seesAllMembers` exactly but in the
+  opposite scope: hydrates on edit, resets in `pickType`, and serializes in the **`else`** branch of
+  `submit`'s `if (showGrants())` so it only ships on APP scope. Creation-time only — toggling it never
+  changes an existing user's groups. See `api/CLAUDE.md` → "Skipping the personal group per app role".
 - **Default roles:** the role-list page shows two `app-select` controls above the filter bar —
   "Default application role" and "Default group role". Each is pre-selected from the role flagged
   `isDefault` for its scope and, on change, calls `RoleService.setDefaultRole(scope, roleId)` then

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -291,6 +291,9 @@ gated by `appPermissionGuard` requiring `app.roles.read` (see **Permission-based
   can see, and be seen by, all members"** `app-checkbox` in `role-form` (a "Member visibility" `rw-card`
   inside the `@if (showGrants())` block), bound to `seesAllMembers` on the `UpsertRoleCommand` (mirrors
   `includeOwnPaidReceipts`; hydrates on edit, resets on type switch, serialized only for GROUP scope).
+  E2E coverage for the group-creation card lives in `e2e/skip-default-group.spec.ts` (card present on
+  APP / absent on GROUP, reset on type switch, round-trip through save including turning it back off,
+  the end-to-end effect on a provisioned account, and the server's 400 on GROUP scope).
   Isolation is resolved **per group** on the backend ("isolated means isolated" — an isolated group hides
   co-members and their settlement/report data regardless of any other group you share; co-members are
   visible only through a shared **non-isolated** group). Everything is enforced **server-side** — the
@@ -628,6 +631,15 @@ real UI** in `beforeAll` and **tears it down through the admin API** in `afterAl
 in `e2e/helpers/provisioning.ts`: `createRole` (role form — type, preset, category toggles, individual
 toggle-offs), `createUserWithRole`, `createGroupWithMember`, `uniqueName`, and the API-teardown
 helpers `withAdminApi` + `apiDeleteUserByName` / `apiDeleteGroupById` / `apiDeleteRoleByName`.
+`createRole` also accepts `skipDefaultGroup` (app roles only — ticks the "Group creation" checkbox).
+
+- **Asserting as a provisioned user without a browser session.** `withApiAsCreds(username, password,
+  fn)` opens an `APIRequestContext` for arbitrary credentials — `withApiAs` is now a thin wrapper over
+  it for the two `E2E_*` fixture accounts. Use it when the assertion is about server state rather than
+  UI, e.g. `apiGroupNames(api)` (the caller's own groups, gated on `app.account.read`) in
+  `skip-default-group.spec.ts`, which checks a new account got the "All" group but no personal
+  "My Receipts". A role built from the **"Read Only"** preset grants every `*.read` permission,
+  including the `app.account.read` those calls need.
 
 - An admin `BrowserContext` (`storageState: 'e2e/.auth/admin.json'`) provisions in `beforeAll`. Tests
   then run **either** as the default e2e-user — for a *group-scoped* member added to a fixture group

--- a/desktop/e2e/helpers/provisioning.ts
+++ b/desktop/e2e/helpers/provisioning.ts
@@ -39,6 +39,12 @@ export interface CreateRoleOptions {
    */
   paidByOwn?: boolean;
   paidByUsers?: string[];
+  /**
+   * App-role only: tick "Don't create a personal group for new users with this
+   * role" in the "Group creation" card, so accounts created with the role skip
+   * the automatic "My Receipts" group (the virtual "All" group is still made).
+   */
+  skipDefaultGroup?: boolean;
 }
 
 /**
@@ -76,6 +82,13 @@ export async function createRole(page: Page, opts: CreateRoleOptions): Promise<v
       openedPanels.add(panelKey);
     }
     await page.getByRole('button', { name: `Toggle ${label}` }).click();
+  }
+
+  if (opts.skipDefaultGroup) {
+    await page
+      .getByTestId('skip-default-group')
+      .getByRole('checkbox')
+      .check();
   }
 
   if (opts.paidByOwn || (opts.paidByUsers?.length ?? 0) > 0) {
@@ -172,6 +185,28 @@ const apiBaseUrl = (): string =>
   process.env.E2E_BASE_URL ?? 'http://localhost:4200';
 
 /**
+ * Opens an `APIRequestContext` authenticated with the given credentials, runs
+ * [fn], and disposes it. Use for a user the test provisioned itself, which has
+ * no `E2E_*` env credentials — for a fixture account use `withApiAs` instead.
+ */
+export async function withApiAsCreds<T>(
+  username: string,
+  password: string,
+  fn: (api: APIRequestContext) => Promise<T>,
+): Promise<T> {
+  const api = await pwRequest.newContext({ baseURL: apiBaseUrl() });
+  try {
+    const res = await api.post('/api/login', { data: { username, password } });
+    if (!res.ok()) {
+      throw new Error(`${username} API login failed: HTTP ${res.status()}`);
+    }
+    return await fn(api);
+  } finally {
+    await api.dispose();
+  }
+}
+
+/**
  * Opens an `APIRequestContext` authenticated as the given e2e [role], runs [fn],
  * and disposes it. Use to drive API calls AS a specific user — e.g. asserting a
  * restricted user's request is denied, or admin teardown.
@@ -180,17 +215,8 @@ export async function withApiAs<T>(
   role: Role,
   fn: (api: APIRequestContext) => Promise<T>,
 ): Promise<T> {
-  const api = await pwRequest.newContext({ baseURL: apiBaseUrl() });
-  try {
-    const { username, password } = creds(role);
-    const res = await api.post('/api/login', { data: { username, password } });
-    if (!res.ok()) {
-      throw new Error(`${role} API login failed: HTTP ${res.status()}`);
-    }
-    return await fn(api);
-  } finally {
-    await api.dispose();
-  }
+  const { username, password } = creds(role);
+  return withApiAsCreds(username, password, fn);
 }
 
 /**
@@ -217,6 +243,22 @@ export async function apiGetUserId(
     throw new Error(`user ${username} not found`);
   }
   return user.id;
+}
+
+/**
+ * Returns the names of the groups the authenticated caller belongs to, including
+ * the virtual "All" group. `GET /api/group/` lists the caller's own groups and is
+ * gated on app.account.read, so the caller's role must grant it.
+ */
+export async function apiGroupNames(api: APIRequestContext): Promise<string[]> {
+  const res = await api.get('/api/group/');
+  if (!res.ok()) {
+    throw new Error(
+      `list groups failed: HTTP ${res.status()} ${await res.text()}`,
+    );
+  }
+  const groups = (await res.json()) as { name: string }[];
+  return groups.map((group) => group.name);
 }
 
 /** Creates a minimal OPEN receipt and returns its id. */

--- a/desktop/e2e/helpers/provisioning.ts
+++ b/desktop/e2e/helpers/provisioning.ts
@@ -125,9 +125,22 @@ export async function createUserWithRole(
   await page.getByTestId('user-add').click();
   const dialog = page.getByRole('dialog').filter({ hasText: 'Create User' });
   await expect(dialog).toBeVisible();
+
+  // The password input is *ngIf-ed in (create mode only) and carries the
+  // generate/visibility buttons, so it settles a tick after the dialog opens.
+  // Wait for it BEFORE filling anything: typing into a half-rendered dialog can
+  // land the password in whichever field currently owns focus (seen as a
+  // username of "<name><password>" and an empty, still-required password).
+  const password = dialog.getByLabel('Password', { exact: true });
+  await expect(password).toBeVisible();
+
   await dialog.getByLabel('Username').fill(opts.username);
   await dialog.getByLabel('Displayname').fill(opts.username);
-  await dialog.getByLabel('Password', { exact: true }).fill(opts.password);
+  await password.fill(opts.password);
+  // Fail here, with the actual values, rather than later on an unexplained
+  // "dialog never closed".
+  await expect(dialog.getByLabel('Username')).toHaveValue(opts.username);
+  await expect(password).toHaveValue(opts.password);
   await dialog.getByRole('combobox', { name: 'App Role' }).click();
   // The option panel is a floating overlay rendered on the page, not the dialog.
   await page.getByRole('option', { name: opts.role, exact: true }).click();

--- a/desktop/e2e/skip-default-group.spec.ts
+++ b/desktop/e2e/skip-default-group.spec.ts
@@ -28,8 +28,14 @@ const PERSONAL_GROUP = 'My Receipts';
 const ALL_GROUP = 'All';
 const PASSWORD = 'a really secure password';
 
+// Each scope-specific card is located by its own <h2>, not by the shared
+// .rw-card styling class — a raw CSS selector would break silently on a styling
+// refactor even though the card is unchanged (see CLAUDE.md → "Locators").
 const groupCreationCard = (page: Page) =>
-  page.locator('.rw-card').filter({ hasText: 'Group creation' });
+  page.getByRole('heading', { name: 'Group creation' });
+
+const memberVisibilityCard = (page: Page) =>
+  page.getByRole('heading', { name: 'Member visibility' });
 
 const skipCheckbox = (page: Page) =>
   page.getByTestId('skip-default-group').getByRole('checkbox');
@@ -99,9 +105,7 @@ test.describe('role editor: the Group creation card is app-scope only', () => {
     // a membership long after the account was created).
     await expect(groupCreationCard(page)).toHaveCount(0);
     // The group-scoped card still renders, proving the form isn't just blank.
-    await expect(
-      page.locator('.rw-card').filter({ hasText: 'Member visibility' }),
-    ).toBeVisible();
+    await expect(memberVisibilityCard(page)).toBeVisible();
   });
 
   test('resets when switching role type', async ({ page }) => {
@@ -157,12 +161,18 @@ test.describe('a flagged role skips the new user\'s personal group', () => {
   let normalRole: string;
   let skipUser: string;
   let normalUser: string;
+  // A third pair, used only by the creation-time-only case, which flips its
+  // role's flag mid-test — so it must not share a role with the cases above.
+  let laterRole: string;
+  let laterUser: string;
 
   test.beforeAll(async ({ browser }) => {
     skipRole = uniqueName('skip-role');
     normalRole = uniqueName('normal-role');
     skipUser = uniqueName('skip-user');
     normalUser = uniqueName('normal-user');
+    laterRole = uniqueName('later-role');
+    laterUser = uniqueName('later-user');
 
     adminContext = await browser.newContext({
       storageState: 'e2e/.auth/admin.json',
@@ -184,6 +194,12 @@ test.describe('a flagged role skips the new user\'s personal group', () => {
       type: 'Application role',
       preset: 'Read Only',
     });
+    // Starts unflagged; the creation-time-only case turns it on afterwards.
+    await createRole(adminPage, {
+      name: laterRole,
+      type: 'Application role',
+      preset: 'Read Only',
+    });
 
     await createUserWithRole(adminPage, {
       username: skipUser,
@@ -195,6 +211,11 @@ test.describe('a flagged role skips the new user\'s personal group', () => {
       password: PASSWORD,
       role: normalRole,
     });
+    await createUserWithRole(adminPage, {
+      username: laterUser,
+      password: PASSWORD,
+      role: laterRole,
+    });
   });
 
   test.afterAll(async () => {
@@ -203,8 +224,10 @@ test.describe('a flagged role skips the new user\'s personal group', () => {
         // Users first — a role cannot be deleted while it is still assigned.
         await apiDeleteUserByName(api, skipUser);
         await apiDeleteUserByName(api, normalUser);
+        await apiDeleteUserByName(api, laterUser);
         await apiDeleteRoleByName(api, skipRole, 'APP');
         await apiDeleteRoleByName(api, normalRole, 'APP');
+        await apiDeleteRoleByName(api, laterRole, 'APP');
       });
     } catch {
       // Best-effort cleanup — don't mask a test failure with a cleanup error.
@@ -226,6 +249,26 @@ test.describe('a flagged role skips the new user\'s personal group', () => {
 
     // Contrast case: proves the skip is driven by the role's flag, not by
     // something else about how these accounts are provisioned.
+    expect(groups).toContain(PERSONAL_GROUP);
+    expect(groups).toContain(ALL_GROUP);
+  });
+
+  test('turning the flag on later leaves an existing user\'s groups alone', async () => {
+    // laterUser was created while its role was unflagged, so it has the group.
+    let groups = await withApiAsCreds(laterUser, PASSWORD, apiGroupNames);
+    expect(groups).toContain(PERSONAL_GROUP);
+
+    // Flip the flag on after the fact.
+    await openRoleEditor(adminPage, laterRole);
+    await skipCheckbox(adminPage).check();
+    await saveRole(adminPage);
+    await expect(adminPage).toHaveURL(/\/roles$/);
+    await openRoleEditor(adminPage, laterRole);
+    await expect(skipCheckbox(adminPage)).toBeChecked();
+
+    // The flag is evaluated once, at user-creation time — it is not a live
+    // property of the account, so the existing user keeps its personal group.
+    groups = await withApiAsCreds(laterUser, PASSWORD, apiGroupNames);
     expect(groups).toContain(PERSONAL_GROUP);
     expect(groups).toContain(ALL_GROUP);
   });

--- a/desktop/e2e/skip-default-group.spec.ts
+++ b/desktop/e2e/skip-default-group.spec.ts
@@ -1,0 +1,253 @@
+import { BrowserContext, expect, Page, test } from '@playwright/test';
+import { stubTokenRefresh } from './helpers/auth';
+import {
+  apiDeleteRoleByName,
+  apiDeleteUserByName,
+  apiGroupNames,
+  createRole,
+  createUserWithRole,
+  uniqueName,
+  withAdminApi,
+  withApiAsCreds,
+} from './helpers/provisioning';
+
+// An app role can opt its new users out of the automatic personal "My Receipts"
+// group, for accounts that only ever belong to a few specific shared groups. The
+// virtual "All" group is always created, so the account keeps a working
+// dashboard. See api/CLAUDE.md → "Skipping the personal group per app role".
+//
+// Three layers are covered: the app-scope-only card in the role editor (present
+// on APP, absent on GROUP, round-trips both ways through save/reload), the
+// end-to-end effect on a real provisioned account, and the server-side scope
+// guard that rejects the flag on a group role.
+
+// Role management is admin-only, so override the default regular-user state.
+test.use({ storageState: 'e2e/.auth/admin.json' });
+
+const PERSONAL_GROUP = 'My Receipts';
+const ALL_GROUP = 'All';
+const PASSWORD = 'a really secure password';
+
+const groupCreationCard = (page: Page) =>
+  page.locator('.rw-card').filter({ hasText: 'Group creation' });
+
+const skipCheckbox = (page: Page) =>
+  page.getByTestId('skip-default-group').getByRole('checkbox');
+
+// Opens a role's editor from the list. The edit icon button has no accessible
+// name (mat-icon is aria-hidden and matTooltip sets none), so it has a testid.
+async function openRoleEditor(page: Page, name: string) {
+  await page.goto('/roles');
+  const row = page.getByRole('row').filter({ hasText: name }).first();
+  await expect(row).toBeVisible();
+  await row.getByTestId('role-edit').click();
+  await expect(page).toHaveURL(/\/roles\/\d+\/edit/);
+  // The form populates from getRoles(); wait for the name before asserting more.
+  await expect(page.getByLabel('Role Name')).toHaveValue(name);
+}
+
+// The submit button sits in a fixed bottom bar under a matTooltip overlay, which
+// makes a direct click flaky on tall forms. Submit through the form's implicit
+// Enter handler instead — a real user action that sidesteps the overlay.
+async function saveRole(page: Page) {
+  const name = page.getByLabel('Role Name');
+  await expect(name).toBeEnabled();
+  await name.press('Enter');
+}
+
+test.describe('role editor: the Group creation card is app-scope only', () => {
+  const createdRoles: string[] = [];
+
+  test.beforeEach(async ({ page }) => {
+    await stubTokenRefresh(page);
+  });
+
+  test.afterAll(async () => {
+    try {
+      await withAdminApi(async (api) => {
+        for (const name of createdRoles) {
+          await apiDeleteRoleByName(api, name, 'APP');
+        }
+      });
+    } catch {
+      // Best-effort cleanup — don't mask a test failure with a cleanup error.
+    }
+  });
+
+  test('renders for an application role and is unchecked by default', async ({
+    page,
+  }) => {
+    await page.goto('/roles/new');
+    await expect(page.getByLabel('Role Name')).toBeVisible();
+    await page.getByRole('button', { name: /Application role/ }).click();
+
+    await expect(groupCreationCard(page)).toBeVisible();
+    await expect(
+      page.getByText("Don't create a personal group for new users with this role"),
+    ).toBeVisible();
+    await expect(skipCheckbox(page)).not.toBeChecked();
+  });
+
+  test('is hidden for a group role, which shows the group-only card instead', async ({
+    page,
+  }) => {
+    await page.goto('/roles/new');
+    await expect(page.getByLabel('Role Name')).toBeVisible();
+    await page.getByRole('button', { name: /Group role/ }).click();
+
+    // Personal-group creation is meaningless on a group role (it is assigned to
+    // a membership long after the account was created).
+    await expect(groupCreationCard(page)).toHaveCount(0);
+    // The group-scoped card still renders, proving the form isn't just blank.
+    await expect(
+      page.locator('.rw-card').filter({ hasText: 'Member visibility' }),
+    ).toBeVisible();
+  });
+
+  test('resets when switching role type', async ({ page }) => {
+    await page.goto('/roles/new');
+    await expect(page.getByLabel('Role Name')).toBeVisible();
+    await page.getByRole('button', { name: /Application role/ }).click();
+    await skipCheckbox(page).check();
+    await expect(skipCheckbox(page)).toBeChecked();
+
+    // Switching scope clears every scope-specific setting; switching back must
+    // not resurrect the old value.
+    await page.getByRole('button', { name: /Group role/ }).click();
+    await expect(groupCreationCard(page)).toHaveCount(0);
+    await page.getByRole('button', { name: /Application role/ }).click();
+    await expect(skipCheckbox(page)).not.toBeChecked();
+  });
+
+  test('round-trips through save, and can be turned back off', async ({ page }) => {
+    const name = uniqueName('skip-roundtrip');
+    createdRoles.push(name);
+
+    await createRole(page, {
+      name,
+      type: 'Application role',
+      preset: 'Read Only',
+      skipDefaultGroup: true,
+    });
+
+    // Reopening reads the persisted value back off the API.
+    await openRoleEditor(page, name);
+    await expect(skipCheckbox(page)).toBeChecked();
+
+    // Turning it back off must stick. This is the regression guard for the
+    // update path: GORM's struct-form Updates skips zero-value bools, so a
+    // toggled-off flag would silently stay on.
+    await skipCheckbox(page).uncheck();
+    await saveRole(page);
+    await expect(page).toHaveURL(/\/roles$/);
+
+    await openRoleEditor(page, name);
+    await expect(skipCheckbox(page)).not.toBeChecked();
+  });
+});
+
+test.describe('a flagged role skips the new user\'s personal group', () => {
+  // One admin context provisions both roles and both users, then the assertions
+  // run against them in order.
+  test.describe.configure({ mode: 'serial' });
+
+  let adminContext: BrowserContext;
+  let adminPage: Page;
+  let skipRole: string;
+  let normalRole: string;
+  let skipUser: string;
+  let normalUser: string;
+
+  test.beforeAll(async ({ browser }) => {
+    skipRole = uniqueName('skip-role');
+    normalRole = uniqueName('normal-role');
+    skipUser = uniqueName('skip-user');
+    normalUser = uniqueName('normal-user');
+
+    adminContext = await browser.newContext({
+      storageState: 'e2e/.auth/admin.json',
+    });
+    adminPage = await adminContext.newPage();
+    await stubTokenRefresh(adminPage);
+
+    // "Read Only" grants every *.read permission, which includes
+    // app.account.read — what GET /api/group/ is gated on, so each provisioned
+    // user can list their own groups below.
+    await createRole(adminPage, {
+      name: skipRole,
+      type: 'Application role',
+      preset: 'Read Only',
+      skipDefaultGroup: true,
+    });
+    await createRole(adminPage, {
+      name: normalRole,
+      type: 'Application role',
+      preset: 'Read Only',
+    });
+
+    await createUserWithRole(adminPage, {
+      username: skipUser,
+      password: PASSWORD,
+      role: skipRole,
+    });
+    await createUserWithRole(adminPage, {
+      username: normalUser,
+      password: PASSWORD,
+      role: normalRole,
+    });
+  });
+
+  test.afterAll(async () => {
+    try {
+      await withAdminApi(async (api) => {
+        // Users first — a role cannot be deleted while it is still assigned.
+        await apiDeleteUserByName(api, skipUser);
+        await apiDeleteUserByName(api, normalUser);
+        await apiDeleteRoleByName(api, skipRole, 'APP');
+        await apiDeleteRoleByName(api, normalRole, 'APP');
+      });
+    } catch {
+      // Best-effort cleanup — don't mask a test failure with a cleanup error.
+    }
+    await adminContext?.close();
+  });
+
+  test('the flagged user gets the All group but no personal group', async () => {
+    const groups = await withApiAsCreds(skipUser, PASSWORD, apiGroupNames);
+
+    expect(groups).not.toContain(PERSONAL_GROUP);
+    // The virtual "All" group is always created, so the account still has a
+    // dashboard to land on.
+    expect(groups).toContain(ALL_GROUP);
+  });
+
+  test('a user on an unflagged role still gets the personal group', async () => {
+    const groups = await withApiAsCreds(normalUser, PASSWORD, apiGroupNames);
+
+    // Contrast case: proves the skip is driven by the role's flag, not by
+    // something else about how these accounts are provisioned.
+    expect(groups).toContain(PERSONAL_GROUP);
+    expect(groups).toContain(ALL_GROUP);
+  });
+});
+
+test.describe('the flag is app-scope only on the server', () => {
+  test('POST /api/role rejects it on a group role', async () => {
+    await withAdminApi(async (api) => {
+      const res = await api.post('/api/role', {
+        data: {
+          name: uniqueName('bad-group-role'),
+          description: '',
+          scope: 'GROUP',
+          permissions: ['group.receipts.read'],
+          skipDefaultGroupCreation: true,
+        },
+      });
+
+      // The UI never sends it on a group role, but the server is the enforcer:
+      // a crafted request must be rejected rather than silently ignored.
+      expect(res.status()).toBe(400);
+      expect(await res.text()).toContain('skipDefaultGroupCreation');
+    });
+  });
+});

--- a/desktop/e2e/skip-default-group.spec.ts
+++ b/desktop/e2e/skip-default-group.spec.ts
@@ -233,22 +233,26 @@ test.describe('a flagged role skips the new user\'s personal group', () => {
     expect(groups).toContain(ALL_GROUP);
   });
 
-  // Unlike the two cases above, this one MUTATES its role mid-test, so it
-  // provisions and tears down its own role/user instead of reading the cohort's
-  // shared fixtures — no other test can be affected by the flag flip, whatever
-  // order they run in. (The admin browser context is still shared: it is a
-  // driving session, not mutable server state.)
-  test('turning the flag on later leaves an existing user\'s groups alone', async () => {
+  // Fully self-contained: it MUTATES its role mid-test, so it provisions and
+  // tears down its own role/user rather than reading the cohort's fixtures, and
+  // it drives the UI through the per-test `page` fixture — a fresh
+  // BrowserContext carrying the file-level admin storageState — instead of the
+  // beforeAll context (CLAUDE.md → "Isolation — each test gets a fresh
+  // BrowserContext"). Nothing about this case is shared with a sibling test.
+  test('turning the flag on later leaves an existing user\'s groups alone', async ({
+    page,
+  }) => {
+    await stubTokenRefresh(page);
     const roleName = uniqueName('later-role');
     const userName = uniqueName('later-user');
 
     try {
-      await createRole(adminPage, {
+      await createRole(page, {
         name: roleName,
         type: 'Application role',
         preset: 'Read Only',
       });
-      await createUserWithRole(adminPage, {
+      await createUserWithRole(page, {
         username: userName,
         password: PASSWORD,
         role: roleName,
@@ -261,12 +265,12 @@ test.describe('a flagged role skips the new user\'s personal group', () => {
       // Flip the flag on after the fact, and confirm it actually persisted —
       // otherwise the "nothing changed" assertion below would pass just as
       // happily on a no-op toggle, proving nothing.
-      await openRoleEditor(adminPage, roleName);
-      await skipCheckbox(adminPage).check();
-      await saveRole(adminPage);
-      await expect(adminPage).toHaveURL(/\/roles$/);
-      await openRoleEditor(adminPage, roleName);
-      await expect(skipCheckbox(adminPage)).toBeChecked();
+      await openRoleEditor(page, roleName);
+      await skipCheckbox(page).check();
+      await saveRole(page);
+      await expect(page).toHaveURL(/\/roles$/);
+      await openRoleEditor(page, roleName);
+      await expect(skipCheckbox(page)).toBeChecked();
 
       // The flag is evaluated once, at user-creation time — it is not a live
       // property of the account, so the existing user keeps its personal group.

--- a/desktop/e2e/skip-default-group.spec.ts
+++ b/desktop/e2e/skip-default-group.spec.ts
@@ -161,18 +161,12 @@ test.describe('a flagged role skips the new user\'s personal group', () => {
   let normalRole: string;
   let skipUser: string;
   let normalUser: string;
-  // A third pair, used only by the creation-time-only case, which flips its
-  // role's flag mid-test — so it must not share a role with the cases above.
-  let laterRole: string;
-  let laterUser: string;
 
   test.beforeAll(async ({ browser }) => {
     skipRole = uniqueName('skip-role');
     normalRole = uniqueName('normal-role');
     skipUser = uniqueName('skip-user');
     normalUser = uniqueName('normal-user');
-    laterRole = uniqueName('later-role');
-    laterUser = uniqueName('later-user');
 
     adminContext = await browser.newContext({
       storageState: 'e2e/.auth/admin.json',
@@ -194,13 +188,6 @@ test.describe('a flagged role skips the new user\'s personal group', () => {
       type: 'Application role',
       preset: 'Read Only',
     });
-    // Starts unflagged; the creation-time-only case turns it on afterwards.
-    await createRole(adminPage, {
-      name: laterRole,
-      type: 'Application role',
-      preset: 'Read Only',
-    });
-
     await createUserWithRole(adminPage, {
       username: skipUser,
       password: PASSWORD,
@@ -211,11 +198,6 @@ test.describe('a flagged role skips the new user\'s personal group', () => {
       password: PASSWORD,
       role: normalRole,
     });
-    await createUserWithRole(adminPage, {
-      username: laterUser,
-      password: PASSWORD,
-      role: laterRole,
-    });
   });
 
   test.afterAll(async () => {
@@ -224,10 +206,8 @@ test.describe('a flagged role skips the new user\'s personal group', () => {
         // Users first — a role cannot be deleted while it is still assigned.
         await apiDeleteUserByName(api, skipUser);
         await apiDeleteUserByName(api, normalUser);
-        await apiDeleteUserByName(api, laterUser);
         await apiDeleteRoleByName(api, skipRole, 'APP');
         await apiDeleteRoleByName(api, normalRole, 'APP');
-        await apiDeleteRoleByName(api, laterRole, 'APP');
       });
     } catch {
       // Best-effort cleanup — don't mask a test failure with a cleanup error.
@@ -253,24 +233,57 @@ test.describe('a flagged role skips the new user\'s personal group', () => {
     expect(groups).toContain(ALL_GROUP);
   });
 
+  // Unlike the two cases above, this one MUTATES its role mid-test, so it
+  // provisions and tears down its own role/user instead of reading the cohort's
+  // shared fixtures — no other test can be affected by the flag flip, whatever
+  // order they run in. (The admin browser context is still shared: it is a
+  // driving session, not mutable server state.)
   test('turning the flag on later leaves an existing user\'s groups alone', async () => {
-    // laterUser was created while its role was unflagged, so it has the group.
-    let groups = await withApiAsCreds(laterUser, PASSWORD, apiGroupNames);
-    expect(groups).toContain(PERSONAL_GROUP);
+    const roleName = uniqueName('later-role');
+    const userName = uniqueName('later-user');
 
-    // Flip the flag on after the fact.
-    await openRoleEditor(adminPage, laterRole);
-    await skipCheckbox(adminPage).check();
-    await saveRole(adminPage);
-    await expect(adminPage).toHaveURL(/\/roles$/);
-    await openRoleEditor(adminPage, laterRole);
-    await expect(skipCheckbox(adminPage)).toBeChecked();
+    try {
+      await createRole(adminPage, {
+        name: roleName,
+        type: 'Application role',
+        preset: 'Read Only',
+      });
+      await createUserWithRole(adminPage, {
+        username: userName,
+        password: PASSWORD,
+        role: roleName,
+      });
 
-    // The flag is evaluated once, at user-creation time — it is not a live
-    // property of the account, so the existing user keeps its personal group.
-    groups = await withApiAsCreds(laterUser, PASSWORD, apiGroupNames);
-    expect(groups).toContain(PERSONAL_GROUP);
-    expect(groups).toContain(ALL_GROUP);
+      // Created while the role was unflagged, so it has the personal group.
+      let groups = await withApiAsCreds(userName, PASSWORD, apiGroupNames);
+      expect(groups).toContain(PERSONAL_GROUP);
+
+      // Flip the flag on after the fact, and confirm it actually persisted —
+      // otherwise the "nothing changed" assertion below would pass just as
+      // happily on a no-op toggle, proving nothing.
+      await openRoleEditor(adminPage, roleName);
+      await skipCheckbox(adminPage).check();
+      await saveRole(adminPage);
+      await expect(adminPage).toHaveURL(/\/roles$/);
+      await openRoleEditor(adminPage, roleName);
+      await expect(skipCheckbox(adminPage)).toBeChecked();
+
+      // The flag is evaluated once, at user-creation time — it is not a live
+      // property of the account, so the existing user keeps its personal group.
+      groups = await withApiAsCreds(userName, PASSWORD, apiGroupNames);
+      expect(groups).toContain(PERSONAL_GROUP);
+      expect(groups).toContain(ALL_GROUP);
+    } finally {
+      try {
+        await withAdminApi(async (api) => {
+          // User first — a role cannot be deleted while it is still assigned.
+          await apiDeleteUserByName(api, userName);
+          await apiDeleteRoleByName(api, roleName, 'APP');
+        });
+      } catch {
+        // Best-effort cleanup — don't mask a test failure with a cleanup error.
+      }
+    }
   });
 });
 

--- a/desktop/src/open-api/model/role.ts
+++ b/desktop/src/open-api/model/role.ts
@@ -48,6 +48,10 @@ export interface Role {
      */
     seesAllMembers?: boolean;
     /**
+     * Whether users created with this APP role skip the automatic personal \"My Receipts\" group. The virtual \"All\" group is always created. Applies at user-creation time only — changing it never adds or removes a group for an existing user. Always false for group roles.
+     */
+    skipDefaultGroupCreation?: boolean;
+    /**
      * Per-template action grants restricting which report templates a GROUP role\'s members may act on. Empty means unrestricted (every template the role\'s group access reaches). Always empty for app roles.
      */
     reportTemplateGrants?: Array<ReportTemplateGrant>;

--- a/desktop/src/open-api/model/upsertRoleCommand.ts
+++ b/desktop/src/open-api/model/upsertRoleCommand.ts
@@ -38,6 +38,10 @@ export interface UpsertRoleCommand {
      */
     seesAllMembers?: boolean;
     /**
+     * Whether users created with this APP role skip the automatic personal \"My Receipts\" group (the virtual \"All\" group is always created). Only valid on app roles; applies at user-creation time only.
+     */
+    skipDefaultGroupCreation?: boolean;
+    /**
      * Per-template action grants for a GROUP role, restricting which report templates its members may act on. Only valid on group roles; omit or leave empty for unrestricted access.
      */
     reportTemplateGrants?: Array<ReportTemplateGrant>;

--- a/desktop/src/roles/role-form/role-form.component.html
+++ b/desktop/src/roles/role-form/role-form.component.html
@@ -191,6 +191,29 @@
           }
         </div>
 
+        <!-- Personal group creation (app roles only) -->
+        @if (showAppOptions()) {
+          <div class="rw-card rw-form-section">
+            <div class="rw-perm-header">
+              <div>
+                <h2>Group creation</h2>
+                <div class="hint hint-inline">
+                  New users normally get their own "My Receipts" group. Turn this
+                  on for roles whose users should only belong to the groups you
+                  add them to.
+                </div>
+              </div>
+            </div>
+
+            <app-checkbox
+              data-testid="skip-default-group"
+              label="Don't create a personal group for new users with this role"
+              [inputFormControl]="form | formGet: 'skipDefaultGroupCreation'"
+              [readonly]="isViewMode()"
+            ></app-checkbox>
+          </div>
+        }
+
         <!-- Category & tag grants (group roles only) -->
         @if (showGrants()) {
           <div class="rw-card rw-form-section">
@@ -206,6 +229,7 @@
             </div>
 
             <app-checkbox
+              data-testid="sees-all-members"
               label="Members with this role can see, and be seen by, all members"
               [inputFormControl]="form | formGet: 'seesAllMembers'"
               [readonly]="isViewMode()"

--- a/desktop/src/roles/role-form/role-form.component.spec.ts
+++ b/desktop/src/roles/role-form/role-form.component.spec.ts
@@ -306,6 +306,7 @@ describe("RoleFormComponent", () => {
       description: "Runs the app",
       scope: "APP",
       permissions: ["app.users.create"],
+      skipDefaultGroupCreation: false,
     });
   });
 
@@ -465,6 +466,49 @@ describe("RoleFormComponent", () => {
     expect(component.form.controls.seesAllMembers.value).toBe(false);
   });
 
+  it("includes skipDefaultGroupCreation in an APP payload when enabled", async () => {
+    const { component } = await setup();
+    component.form.controls.name.setValue("Restricted App Role");
+    component.toggle("app.users.read");
+    component.form.controls.skipDefaultGroupCreation.setValue(true);
+
+    component.submit();
+
+    expect(component.lastPayload?.scope).toBe("APP");
+    expect(component.lastPayload?.skipDefaultGroupCreation).toBe(true);
+  });
+
+  it("defaults skipDefaultGroupCreation to false in an APP payload", async () => {
+    const { component } = await setup();
+    component.form.controls.name.setValue("Plain App Role");
+    component.toggle("app.users.read");
+
+    component.submit();
+
+    expect(component.lastPayload?.skipDefaultGroupCreation).toBe(false);
+  });
+
+  it("omits skipDefaultGroupCreation from a GROUP payload", async () => {
+    const { component } = await setup();
+    component.pickType("group");
+    component.form.controls.name.setValue("Group Role");
+    component.toggle("group.receipts.read");
+    // Even if the control somehow held true, a group payload must not carry it.
+    component.form.controls.skipDefaultGroupCreation.setValue(true);
+
+    component.submit();
+
+    expect(component.lastPayload?.skipDefaultGroupCreation).toBeUndefined();
+  });
+
+  it("resets skipDefaultGroupCreation when switching role type", async () => {
+    const { component } = await setup();
+    component.form.controls.skipDefaultGroupCreation.setValue(true);
+
+    component.pickType("group");
+    expect(component.form.controls.skipDefaultGroupCreation.value).toBe(false);
+  });
+
   it("includes report template grants in a GROUP payload", async () => {
     const { component } = await setup();
     component.pickType("group");
@@ -541,6 +585,7 @@ describe("RoleFormComponent", () => {
       description: "",
       scope: "APP",
       permissions: ["app.users.create"],
+      skipDefaultGroupCreation: false,
     });
     expect(snackbar.success).toHaveBeenCalled();
     expect(navigateSpy).toHaveBeenCalledWith(["/roles"]);
@@ -606,6 +651,7 @@ describe("RoleFormComponent", () => {
         description: "Manages the app",
         scope: "APP",
         permissions: ["app.users.create", "app.users.read"],
+        skipDefaultGroupCreation: false,
       });
       expect(snackbar.success).toHaveBeenCalled();
       expect(navigateSpy).toHaveBeenCalledWith(["/roles"]);
@@ -673,6 +719,25 @@ describe("RoleFormComponent", () => {
       });
 
       expect(component.form.controls.seesAllMembers.value).toBe(true);
+    });
+
+    it("rehydrates skipDefaultGroupCreation on edit", async () => {
+      const restrictedAppRole: Role = {
+        id: 14,
+        name: "Restricted App Role",
+        scope: "APP",
+        isDefault: false,
+        isSystem: false,
+        permissions: ["app.users.read"],
+        skipDefaultGroupCreation: true,
+      };
+      const { component } = await setup(ALL_DESCRIPTORS, {
+        routeId: "14",
+        routeScope: "app",
+        roles: [restrictedAppRole],
+      });
+
+      expect(component.form.controls.skipDefaultGroupCreation.value).toBe(true);
     });
 
     it("rehydrates report template grants on edit", async () => {

--- a/desktop/src/roles/role-form/role-form.component.ts
+++ b/desktop/src/roles/role-form/role-form.component.ts
@@ -74,6 +74,10 @@ export class RoleFormComponent {
     // Group-role-only flag: holders can see, and be seen by, all members of an
     // isolated group. Ignored for app roles (serialized only when showGrants()).
     seesAllMembers: new FormControl<boolean>(false, { nonNullable: true }),
+    // App-role-only flag: users created with this role skip the personal
+    // "My Receipts" group. Ignored for group roles (serialized only when
+    // showAppOptions()).
+    skipDefaultGroupCreation: new FormControl<boolean>(false, { nonNullable: true }),
   });
 
   // ----- State signals -----
@@ -146,6 +150,9 @@ export class RoleFormComponent {
 
   /** Grants are a group-role concept; hidden for app roles. */
   public readonly showGrants = computed<boolean>(() => this.type() === "group");
+
+  /** Personal-group creation is an app-role concept; hidden for group roles. */
+  public readonly showAppOptions = computed<boolean>(() => this.type() === "app");
 
   // ----- Mode-derived state -----
   public readonly isEditMode = computed<boolean>(() => this.mode() === FormMode.edit);
@@ -362,6 +369,7 @@ export class RoleFormComponent {
           name: role.name,
           description: role.description ?? "",
           seesAllMembers: role.seesAllMembers ?? false,
+          skipDefaultGroupCreation: role.skipDefaultGroupCreation ?? false,
         });
         this.type.set(role.scope === PermissionScope.Group ? "group" : "app");
         this.granted.set(new Set(role.permissions));
@@ -435,6 +443,8 @@ export class RoleFormComponent {
     this.setGrantArray(this.grantedPaidByUsers, []);
     this.reportTemplateGrants.set(new Map());
     this.form.controls.seesAllMembers.setValue(false);
+    // Personal-group creation only applies to app roles — reset it too.
+    this.form.controls.skipDefaultGroupCreation.setValue(false);
   }
 
   // ----- Report template matrix helpers -----
@@ -571,6 +581,11 @@ export class RoleFormComponent {
       // Supervisor exemption: holders see, and are seen by, all members of an
       // isolated group. Only meaningful on group roles.
       payload.seesAllMembers = this.form.controls.seesAllMembers.value;
+    } else {
+      // Personal-group creation is an app-role concept: users created with this
+      // role skip the automatic "My Receipts" group.
+      payload.skipDefaultGroupCreation =
+        this.form.controls.skipDefaultGroupCreation.value;
     }
 
     this.lastPayload = payload;


### PR DESCRIPTION
## Summary
Adds a new `SkipDefaultGroupCreation` flag to app roles that allows administrators to opt users out of the automatic personal "My Receipts" group. This is useful for accounts that should only belong to specific shared groups managed by administrators. The virtual "All" group is always created to ensure users still have a working dashboard.

## Key Changes

### Backend (API)
- **Models**: Added `SkipDefaultGroupCreation` boolean field to `AppRole` model (defaults to `false`)
- **Repositories**:
  - Updated `CreateAppRole` and `UpdateAppRole` to accept and persist the flag
  - Added `AppRoleSkipsDefaultGroup` method to query the flag
  - Used map-based updates in `UpdateAppRole` to ensure false values persist (GORM struct updates skip zero-value bools)
- **Services**:
  - Updated `RoleService.CreateRole` and `UpdateRole` to handle the flag
  - Ensured flag is included in `RoleView` responses
- **Commands**: Added validation in `UpsertRoleCommand.Validate` to reject the flag on GROUP scope (app-scope only). This is the single enforcement point — the `/role` handlers call it through the existing parse-and-validate path, so a crafted group-scoped request gets a 400 without a separate handler-layer check.
- **User Creation**: Modified `UserRepository.CreateUser` to check the flag and skip personal group creation when set

### Frontend (Desktop)
- **Role Form**:
  - Added "Group creation" card (app-scope only) with checkbox for "Don't create a personal group for new users with this role"
  - Card is hidden for group roles and resets when switching role types
  - Checkbox bound to `skipDefaultGroupCreation` form control
- **Serialization**: Only includes flag in payloads for app roles; omitted for group roles
- **OpenAPI Models**: Updated generated `Role` and `UpsertRoleCommand` TypeScript interfaces

### E2E Tests
- Added comprehensive test suite covering:
  - UI rendering and behavior (checkbox visibility, default state, persistence through save/reload, and turning the flag back off)
  - Role type switching resets the flag
  - End-to-end effect: flagged users get "All" group but not "My Receipts"
  - Unflagged users still get both groups (contrast case)
  - Turning the flag on after the fact leaves an existing user's groups untouched (the creation-time-only guarantee)
  - Server-side validation rejects the flag on group roles

### Documentation
- Updated `api/CLAUDE.md` with a detailed explanation of the feature, implementation approach, and scope restrictions
- Updated `desktop/CLAUDE.md` with the app-scope-only "Group creation" card under "Roles & Permissions (Manage Roles)", plus the new `createRole` / `withApiAsCreds` / `apiGroupNames` e2e helpers

## Implementation Details

- **Creation-time only**: The flag is evaluated when a user is created and assigned to a role. Changing the flag on an existing role does not affect already-created users.
- **Scope enforcement**: The flag is app-scope only, mirroring the group-scope-only `seesAllMembers` flag in the opposite direction.
- **Backward compatible**: Existing roles and installations are unaffected; the column defaults to `false` with no data migration required.
- **Always-present "All" group**: Even when the personal group is skipped, the virtual "All" group is always created so users have a working dashboard landing page.
- **Best-effort role lookup**: A nil or missing role falls back to creating the personal group rather than failing user creation; any other lookup error propagates and rolls the creation back, so a transient DB failure can't silently decide which groups an account gets.

https://claude.ai/code/session_011xzVFFok5Mm3QgKjCcrUY2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App roles can prevent automatic creation of users’ personal “My Receipts” group while retaining the “All” group.
  * Added a role editor option for configuring this behavior on app-scoped roles.
  * The setting is available when creating or editing roles and in API responses.

* **Validation**
  * The option is restricted to app roles and rejected for group roles.
  * Changes affect users created after the setting is applied; existing users remain unchanged.

* **Documentation & Tests**
  * Added API documentation and coverage for role configuration and user creation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->