### PR TITLE
Remove Azure URL sniffing; use configured URLs verbatim

### DIFF
--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -94,6 +94,19 @@ ImageMagick PDF-policy edit in `set-up-dependencies.sh` (it targets `/etc/ImageM
 source build's policy is at `/usr/local/etc/ImageMagick-7/policy.xml` and doesn't block PDF by
 default). Those only matter for exercising email-OCR / PDF-receipt processing, not for a running API.
 
+**Running the Go test suite in the sandbox — set `CHROMIUM_BINARY_PATH`.** Steps 1-4 above are enough
+to *compile* the module, but two tests additionally need a browser:
+`TestHtmlToPdfService_Render_BasicHtml` and `TestReportService_Generate_PdfDocument` drive the
+HTML-to-PDF pipeline through headless Chromium. `services/html_to_pdf.go` defaults to
+`/usr/bin/chromium`, which **does not exist** in this sandbox — the pre-installed Playwright build is
+at `/opt/pw-browsers/chromium`. Without the override both fail and `internal/services` reports FAIL,
+which looks like a code regression and is not one:
+```bash
+CHROMIUM_BINARY_PATH=/opt/pw-browsers/chromium go test -count=1 ./...
+```
+Do **not** run `playwright install` to get `/usr/bin/chromium` — the download is blocked, and the
+pre-installed binary works.
+
 ### Testing
 - `go test -v ./...` - Run all Go tests with verbose output
 - `go test -coverprofile=coverage.out -covermode=atomic -v ./...` - Run tests with coverage

--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -147,6 +147,22 @@ default). Those only matter for exercising email-OCR / PDF-receipt processing, n
 - Supports multiple AI providers: OpenAI, Google Gemini, and Ollama
 - AI clients implement a common interface defined in `internal/ai/base_client.go`
 - Used for receipt data extraction and processing
+- **The configured URL is used verbatim.** `internal/ai/open_ai.go` treats
+  `ReceiptProcessingSettings.Url` as an OpenAI-compatible **base** url and appends only
+  `/chat/completions`, authenticating with `Authorization: Bearer <key>`. There is no
+  provider-specific rewriting: the client does **not** inspect the url, inject a deployment path, or
+  add an `api-version` query param. An empty url (the plain `OPEN_AI` type, which
+  `UpsertReceiptProcessingSettingsCommand.Validate` requires to be empty) falls back to go-openai's
+  `https://api.openai.com/v1`. Ollama is the same — `internal/ai/ollama.go` posts to the url exactly
+  as entered, with no suffix.
+- **Azure must be configured with its OpenAI-compatible endpoint**, i.e.
+  `https://<resource>.services.ai.azure.com/openai/v1` (with `Model` set to the *deployment* name), not
+  a bare resource origin. Earlier versions sniffed the url for the substring `azure` and switched
+  go-openai into Azure mode (`DefaultAzureConfig`), which rewrote the path to
+  `/openai/deployments/<model>/chat/completions` and pinned `api-version=2023-05-15`. That heuristic
+  was **removed**: it mangled the modern Foundry `/openai/v1` endpoint into a 404, and it could never
+  match an Azure resource behind a custom domain. Pinned by
+  `TestOpenAiGetChatCompletion_AzureUrlIsUsedVerbatim`.
 
 ### Configuration
 - Configuration loaded from JSON files in `config/` directory

--- a/api/internal/ai/open_ai.go
+++ b/api/internal/ai/open_ai.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"receipt-wrangler/api/internal/models"
 	"receipt-wrangler/api/internal/structs"
-	"strings"
 
 	"github.com/sashabaranov/go-openai"
 	"golang.org/x/net/context"
@@ -29,19 +28,16 @@ func NewOpenAiClient(
 
 func (openAi OpenAiClient) GetChatCompletion() (structs.ChatCompletionResult, error) {
 	result := structs.ChatCompletionResult{}
-	var config openai.ClientConfig
 
 	key, err := openAi.getKey(openAi.Options.DecryptKey)
 	if err != nil {
 		return result, err
 	}
 
-	if strings.Contains(openAi.ReceiptProcessingSettings.Url, "azure") {
-		config = openai.DefaultAzureConfig(key, openAi.ReceiptProcessingSettings.Url)
-	} else {
-		config = openai.DefaultConfig(key)
-	}
-
+	// The configured URL is used verbatim as an OpenAI-compatible base URL, with no
+	// provider-specific rewriting. Providers that serve their compatible API under a path
+	// must include it, e.g. https://<resource>.services.ai.azure.com/openai/v1 for Azure.
+	config := openai.DefaultConfig(key)
 	if len(openAi.ReceiptProcessingSettings.Url) > 0 {
 		config.BaseURL = openAi.ReceiptProcessingSettings.Url
 	}

--- a/api/internal/ai/open_ai_test.go
+++ b/api/internal/ai/open_ai_test.go
@@ -15,7 +15,9 @@ import (
 type capturedOpenAiRequest struct {
 	Method      string
 	Path        string
+	RawQuery    string
 	ContentType string
+	Header      http.Header
 	Body        map[string]interface{}
 }
 
@@ -26,7 +28,9 @@ func newMockOpenAiServer(t *testing.T, statusCode int, responseBody string) (*ht
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		captured.Method = r.Method
 		captured.Path = r.URL.Path
+		captured.RawQuery = r.URL.RawQuery
 		captured.ContentType = r.Header.Get("Content-Type")
+		captured.Header = r.Header.Clone()
 
 		bodyBytes, err := io.ReadAll(r.Body)
 		if err == nil && len(bodyBytes) > 0 {
@@ -250,25 +254,47 @@ func TestOpenAiGetChatCompletion_EmptyChoicesReturnsError(t *testing.T) {
 	}
 }
 
-// Azure branch (URL contains "azure"): verifies the conditional path compiles
-// and executes without panicking. Points at a server whose URL path contains
-// "azure" to trigger the DefaultAzureConfig branch; the mock happily responds
-// to whatever path the SDK actually uses.
-func TestOpenAiGetChatCompletion_AzureBranch(t *testing.T) {
-	server, _ := newMockOpenAiServer(t, http.StatusOK, openAiSuccessBody("azure-ok"))
+// An Azure URL must be used verbatim, exactly like any other OpenAI-compatible
+// endpoint. The client used to sniff the URL for "azure" and switch the SDK into
+// Azure mode, which rewrote a correct Foundry base URL
+// (https://<resource>.services.ai.azure.com/openai/v1) into
+// .../openai/v1/openai/deployments/<model>/chat/completions?api-version=2023-05-15
+// and swapped Bearer auth for the api-key header — a 404 from Azure.
+func TestOpenAiGetChatCompletion_AzureUrlIsUsedVerbatim(t *testing.T) {
+	server, captured := newMockOpenAiServer(t, http.StatusOK, openAiSuccessBody("azure-ok"))
 
-	// Embed "azure" in the path so the URL string contains "azure" but the
-	// httptest server still handles the request.
-	url := server.URL + "/azure-deployment"
+	// The mock's host has no "azure" in it, so put it in the path to reproduce a
+	// URL the old heuristic would have matched.
+	url := server.URL + "/my-resource.services.ai.azure.com/openai/v1"
 
-	client := newOpenAiClient(url, "gpt-4o-mini", "test-key", false, []structs.AiClientMessage{
+	// A dotted deployment name: Azure mode also ran the model through
+	// AzureModelMapperFunc, which stripped "." and ":".
+	client := newOpenAiClient(url, "gpt-4.1", "test-key", false, []structs.AiClientMessage{
 		{Role: "user", Content: "hi"},
 	})
-	result, _ := client.GetChatCompletion()
-	// We don't assert on err — Azure SDK may build a different URL structure
-	// the mock doesn't fully satisfy; coverage of the branch is the goal.
-	// But if it succeeded, the response content should round-trip.
-	if result.Response != "" && result.Response != "azure-ok" {
+	result, err := client.GetChatCompletion()
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	if result.Response != "azure-ok" {
 		utils.PrintTestError(t, result.Response, "azure-ok")
+	}
+
+	expectedPath := "/my-resource.services.ai.azure.com/openai/v1/chat/completions"
+	if captured.Path != expectedPath {
+		utils.PrintTestError(t, captured.Path, expectedPath)
+	}
+	// Azure mode appended ?api-version=<hardcoded>; the plain path adds no query.
+	if captured.RawQuery != "" {
+		utils.PrintTestError(t, captured.RawQuery, "no query string")
+	}
+	if captured.Header.Get("Authorization") != "Bearer test-key" {
+		utils.PrintTestError(t, captured.Header.Get("Authorization"), "Bearer test-key")
+	}
+	if captured.Header.Get("api-key") != "" {
+		utils.PrintTestError(t, captured.Header.Get("api-key"), "no api-key header")
+	}
+	if captured.Body["model"] != "gpt-4.1" {
+		utils.PrintTestError(t, captured.Body["model"], "gpt-4.1")
 	}
 }

--- a/desktop/src/receipt-processing-settings/pipes/url-hint.pipe.spec.ts
+++ b/desktop/src/receipt-processing-settings/pipes/url-hint.pipe.spec.ts
@@ -1,0 +1,33 @@
+import { AiType } from "../../open-api/index";
+import { UrlHintPipe } from "./url-hint.pipe";
+
+describe("UrlHintPipe", () => {
+  let pipe: UrlHintPipe;
+
+  beforeEach(() => {
+    pipe = new UrlHintPipe();
+  });
+
+  it("create an instance", () => {
+    expect(pipe).toBeTruthy();
+  });
+
+  it("tells OpenAI-custom users to include the endpoint's path", () => {
+    const hint = pipe.transform(AiType.OpenAiCustom);
+
+    expect(hint).toContain("/openai/v1");
+    expect(hint).toContain("bare origin will not work");
+  });
+
+  it("tells Ollama users the url is used as entered", () => {
+    const hint = pipe.transform(AiType.Ollama);
+
+    expect(hint).toContain("Ollama");
+    expect(hint).toContain("exactly as entered");
+  });
+
+  it("returns no hint for ai types that do not take a url", () => {
+    expect(pipe.transform(AiType.OpenAi)).toEqual("");
+    expect(pipe.transform(AiType.Gemini)).toEqual("");
+  });
+});

--- a/desktop/src/receipt-processing-settings/pipes/url-hint.pipe.ts
+++ b/desktop/src/receipt-processing-settings/pipes/url-hint.pipe.ts
@@ -1,0 +1,19 @@
+import { Pipe, PipeTransform } from "@angular/core";
+import { AiType } from "../../open-api/index";
+
+@Pipe({
+  name: "urlHint"
+})
+export class UrlHintPipe implements PipeTransform {
+  public transform(aiType: AiType): string {
+    if (aiType === AiType.OpenAiCustom) {
+      return "Full OpenAI-compatible base url, including any path. /chat/completions is appended automatically. Azure endpoints must include their path, e.g. https://your-resource.services.ai.azure.com/openai/v1 — a bare origin will not work.";
+    }
+
+    if (aiType === AiType.Ollama) {
+      return "Full url of the Ollama chat endpoint, used exactly as entered, e.g. http://localhost:11434/api/chat.";
+    }
+
+    return "";
+  }
+}

--- a/desktop/src/receipt-processing-settings/receipt-processing-settings-form/receipt-processing-settings-form.component.html
+++ b/desktop/src/receipt-processing-settings/receipt-processing-settings-form/receipt-processing-settings-form.component.html
@@ -67,6 +67,7 @@
       (form | formGet: 'aiType')?.value === AiType.Ollama) {
         <app-input
           [label]="(form | formGet: 'aiType')?.value | urlLabel"
+          [hint]="(form | formGet: 'aiType')?.value | urlHint"
           [readonly]="formConfig.mode | inputReadonly"
           [inputFormControl]="form | formGet: 'url'"
         ></app-input>

--- a/desktop/src/receipt-processing-settings/receipt-processing-settings.module.ts
+++ b/desktop/src/receipt-processing-settings/receipt-processing-settings.module.ts
@@ -14,6 +14,7 @@ import { SharedUiModule } from "../shared-ui/shared-ui.module";
 import { TableModule } from "../table/table.module";
 import { AiTypePipe } from "./pipes/ai-type.pipe";
 import { OcrEnginePipe } from "./pipes/ocr-engine.pipe";
+import { UrlHintPipe } from "./pipes/url-hint.pipe";
 import { UrlLabelPipe } from "./pipes/url-label.pipe";
 import {
   ReceiptProcessingSettingsChildSystemTaskAccordionComponent
@@ -38,6 +39,7 @@ import { ReceiptProcessingSettingsTableComponent } from "./receipt-processing-se
     AiTypePipe,
     OcrEnginePipe,
     UrlLabelPipe,
+    UrlHintPipe,
     ButtonModule,
     MatTooltip,
     CheckboxModule


### PR DESCRIPTION
## Summary
Removes the URL-sniffing heuristic that detected "azure" in the configured endpoint and switched the OpenAI client into Azure SDK mode. The client now treats all configured URLs as OpenAI-compatible base URLs and uses them verbatim, with no provider-specific rewriting.

## Changes

### Backend (api/)
- **`internal/ai/open_ai.go`**: Removed the `strings.Contains(url, "azure")` check that conditionally called `openai.DefaultAzureConfig()`. Now always uses `openai.DefaultConfig()` and sets `BaseURL` to the configured URL as-is.
- **`internal/ai/open_ai_test.go`**: 
  - Enhanced `capturedOpenAiRequest` struct to capture `RawQuery` and full `Header` for assertion.
  - Renamed and rewrote `TestOpenAiGetChatCompletion_AzureBranch` → `TestOpenAiGetChatCompletion_AzureUrlIsUsedVerbatim` with comprehensive assertions:
    - Verifies the path is used exactly as configured (no `/openai/deployments/<model>/chat/completions` rewrite)
    - Confirms no `api-version` query parameter is appended
    - Asserts `Authorization: Bearer` header is used (not `api-key`)
    - Validates the model name is passed through unchanged (e.g., `gpt-4.1` with dots intact)
- **`api/CLAUDE.md`**: Added detailed documentation explaining that configured URLs are used verbatim, with specific guidance for Azure endpoints (must include `/openai/v1` path) and rationale for removing the heuristic.

### Frontend (desktop/)
- **`receipt-processing-settings/pipes/url-hint.pipe.ts`** (new): Angular pipe that provides context-specific URL hints based on AI provider type:
  - OpenAI Custom: explains that the full base URL including path is required, with Azure example
  - Ollama: clarifies the URL is used exactly as entered
  - Others: returns empty string
- **`receipt-processing-settings/pipes/url-hint.pipe.spec.ts`** (new): Unit tests for the hint pipe covering all AI types.
- **`receipt-processing-settings/receipt-processing-settings.module.ts`**: Registered `UrlHintPipe` in the module declarations.
- **`receipt-processing-settings/receipt-processing-settings-form/receipt-processing-settings-form.component.html`**: Added `[hint]` binding to the URL input field to display provider-specific guidance.

## Implementation Details
- The old heuristic would mangle modern Azure Foundry endpoints (`https://<resource>.services.ai.azure.com/openai/v1`) into a 404 by rewriting the path to `/openai/deployments/<model>/chat/completions` and pinning `api-version=2023-05-15`.
- The heuristic could never match Azure resources behind custom domains.
- Users must now explicitly configure the full OpenAI-compatible base URL, including any required path component (e.g., `/openai/v1` for Azure).
- The test validates that a URL containing "azure" in the path is handled correctly without triggering the removed Azure SDK mode.

https://claude.ai/code/session_01FbsmbD8DjvcidKTB9iAXmA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added provider-specific guidance beneath the receipt-processing URL field.
  * Added support for using OpenAI-compatible and Ollama endpoint URLs as configured.
  * Improved Azure-compatible endpoint handling while preserving authentication and model settings.

* **Tests**
  * Added coverage for URL guidance and provider-specific endpoint behavior.

* **Documentation**
  * Documented supported endpoint formats and local test setup instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->