### PR TITLE
Extract login QR into shared component for reuse

### DIFF
--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -440,15 +440,31 @@ gated by `appPermissionGuard` requiring `app.roles.read` (see **Permission-based
 
 ## Login QR (mobile app setup)
 
-The login page (`src/auth/sign-up/auth-form.component.*`, shared by login + sign-up) renders a QR that
-deep-links users into the mobile app to set it up. It is **self-contained** — generated locally with
-the `qrcode` package (no external QR service), from the derived `featureConfig.loginQrUrl` string the
-backend composes (see `api/CLAUDE.md` → "Login QR & mobile deep link"). The component reads
-`FeatureConfigState.loginQrUrl` via `store.selectSignal`, regenerates a `data:` URL in an `effect()`
-(the `qrDataUrl` signal), and the template shows it only when non-empty (`@if (qrDataUrl())`), so the
-QR appears only when an admin enabled it. Generation is async, so the effect takes an `onCleanup`
-cancellation flag — a URL change leaves the previous `QRCode.toDataURL` in flight, and without the
-guard a late-resolving stale QR could overwrite the current one. `FeatureConfigState` gained a `loginQrUrl` default (`""`), a
+A QR that deep-links users into the mobile app to set it up. It renders in **two** places — the login
+page (`src/auth/sign-up/auth-form.component.*`, shared by login + sign-up) and the **About dialog**
+(`src/about/about/about.component.*`), so a user who is already signed in can reach it without logging
+out. Both consume the shared standalone **`app-login-qr`** (`src/shared-ui/login-qr/`), which owns the
+whole generation path; do not re-implement it at a third call site.
+
+It is **self-contained** — generated locally with the `qrcode` package (no external QR service), from
+the derived `featureConfig.loginQrUrl` string the backend composes (see `api/CLAUDE.md` → "Login QR &
+mobile deep link"). The component reads `FeatureConfigState.loginQrUrl` via `store.selectSignal`,
+regenerates a `data:` URL in an `effect()` (the `qrDataUrl` signal), and its template renders
+**nothing** unless that signal is set (`@if (qrDataUrl())`), so the QR appears only when an admin
+enabled it and neither call site carries generation-state logic. Generation is async, so the effect
+takes an `onCleanup` cancellation flag — a URL change leaves the previous `QRCode.toDataURL` in flight,
+and without the guard a late-resolving stale QR could overwrite the current one. Its two inputs are
+presentation only: an optional `headerText` (renders the divider row; the login page passes
+"Set up the mobile app", About omits it) and a `caption` with the default scan-instruction text. The
+`.login-qr*` styles live in the component (encapsulated), **not** in the login page's
+`ViewEncapsulation.None` stylesheet.
+
+Availability differs per call site but needs no extra plumbing: the login page is pre-auth and gets
+`loginQrUrl` from `GET /featureConfig`, while About rides on the authenticated `GET /appData`
+(`setAppData` already dispatches `SetFeatureConfig`). About is the one call site that also gates on the
+**setting** — `@if (loginQrUrl())` around its "Mobile App" `app-form-section` — because an
+`app-form-section` would otherwise render an empty header when the feature is off. No permission gate:
+`loginQrUrl` is a public, pre-auth value. `FeatureConfigState` gained a `loginQrUrl` default (`""`), a
 selector, and — the load-bearing bit — the field in the `SetFeatureConfig` `patchState` block (that
 block lists each field explicitly, so a new field is silently dropped unless added there; guarded by
 `feature-config.state.spec.ts`).
@@ -479,9 +495,13 @@ whole list, so the format check must be re-supplied on every toggle rather than 
 **E2E:** `e2e/login-qr.spec.ts` (serial, admin `storageState` + a fresh unauthenticated context for the
 login page) drives the whole flow — admin enables the toggle + URL in System Settings and it persists,
 the QR `<img>` then renders on `/auth/login` with the `featureConfig.loginQrUrl` decoding back to the
-configured server URL, and disabling hides it. It reverts `showLoginQr` via the admin API in `afterAll`
-(the setting is global). Component-level specs live alongside the code: `feature-config.state.spec.ts`,
-`auth-form.component.spec.ts`, `system-settings-form.component.spec.ts`.
+configured server URL, the **About dialog** shows the same QR in an admin session (sidebar avatar →
+About; the avatar carries `data-testid="sidebar-avatar-menu"` for this), and disabling hides it. It
+reverts `showLoginQr` via the admin API in `afterAll` (the setting is global). Component-level specs
+live alongside the code: `login-qr.component.spec.ts` (the generation unit cases — empty, generated,
+divider-only-with-`headerText`, turned back off, and the stale-generation guard),
+`feature-config.state.spec.ts`, `auth-form.component.spec.ts` and `about.component.spec.ts` (each
+pinning that its page wires the shared component up), and `system-settings-form.component.spec.ts`.
 
 ## Signals & Zoneless Change Detection
 

--- a/desktop/e2e/login-qr.spec.ts
+++ b/desktop/e2e/login-qr.spec.ts
@@ -121,6 +121,38 @@ test.describe.serial('Login QR (System Settings → login page)', () => {
     await context.close();
   });
 
+  test('the QR also shows on the About dialog while logged in', async ({
+    browser,
+  }) => {
+    // The whole point of the About QR: a signed-in user can reach it without
+    // logging out. This context rides on appData (not GET /featureConfig).
+    const context = await browser.newContext({
+      storageState: 'e2e/.auth/admin.json',
+    });
+    const page = await context.newPage();
+    await stubTokenRefresh(page);
+    // The sidebar holding the About menu defaults to closed and its open/closed
+    // flag is persisted, so seed it rather than blind-clicking the toggle (which
+    // would CLOSE it if a saved session already had it open).
+    await page.addInitScript(() => {
+      const layout = JSON.parse(localStorage.getItem('layout') ?? '{}');
+      localStorage.setItem(
+        'layout',
+        JSON.stringify({ ...layout, isSidebarOpen: true }),
+      );
+    });
+
+    await page.goto('/');
+    await page.getByTestId('sidebar-avatar-menu').click();
+    await page.getByRole('menuitem', { name: 'About' }).click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog.getByText('Mobile App')).toBeVisible();
+    await expect(dialog.getByRole('img', { name: QR_IMG_NAME })).toBeVisible();
+
+    await context.close();
+  });
+
   test('disabling the toggle hides the QR on the login page', async ({
     browser,
   }) => {

--- a/desktop/src/about/about/about.component.html
+++ b/desktop/src/about/about/about.component.html
@@ -14,17 +14,27 @@
       </div>
     </app-form-section>
   </div>
-  <app-form-section
-    headerText="Build"
-  >
-    <div class="d-flex flex-column m-2">
-      <span>Version: {{ about()?.version || 'unknown' }}</span>
-      @if (about()?.buildDate !== "unknown") {
-        <span>Build Date: {{ (about()?.buildDate | date) || 'unknown' }}</span>
-      } @else {
-        <span>Build Date: unknown</span>
-      }
-
-    </div>
-  </app-form-section>
+  <div class="mb-3">
+    <app-form-section
+      headerText="Build"
+    >
+      <div class="d-flex flex-column m-2">
+        <span>Version: {{ about()?.version || 'unknown' }}</span>
+        @if (about()?.buildDate !== "unknown") {
+          <span>Build Date: {{ (about()?.buildDate | date) || 'unknown' }}</span>
+        } @else {
+          <span>Build Date: unknown</span>
+        }
+      </div>
+    </app-form-section>
+  </div>
+  @if (loginQrUrl()) {
+    <app-form-section
+      headerText="Mobile App"
+    >
+      <div class="m-2">
+        <app-login-qr></app-login-qr>
+      </div>
+    </app-form-section>
+  }
 </app-dialog>

--- a/desktop/src/about/about/about.component.spec.ts
+++ b/desktop/src/about/about/about.component.spec.ts
@@ -1,22 +1,32 @@
 import { provideHttpClientTesting } from "@angular/common/http/testing";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
-import { provideStore } from "@ngxs/store";
+import { provideStore, Store } from "@ngxs/store";
+import * as QRCode from "qrcode";
+
+jest.mock("qrcode", () => ({
+  __esModule: true,
+  toDataURL: jest.fn(),
+}));
 
 import { AboutComponent } from "./about.component";
 import { provideHttpClient, withInterceptorsFromDi } from "@angular/common/http";
 import { AboutState } from "../../store/about.state";
+import { FeatureConfigState } from "../../store/feature-config.state";
+import { SetFeatureConfig } from "../../store/feature-config.state.actions";
 
 describe("AboutComponent", () => {
   let component: AboutComponent;
   let fixture: ComponentFixture<AboutComponent>;
 
   beforeEach(async () => {
+    (QRCode.toDataURL as jest.Mock).mockReset();
+
     await TestBed.configureTestingModule({
       imports: [AboutComponent],
       providers: [
         provideHttpClient(withInterceptorsFromDi()),
         provideHttpClientTesting(),
-        provideStore([AboutState])
+        provideStore([AboutState, FeatureConfigState])
       ]
     })
       .compileComponents();
@@ -28,5 +38,33 @@ describe("AboutComponent", () => {
 
   it("should create", () => {
     expect(component).toBeTruthy();
+  });
+
+  it("does not render the mobile app section when the login QR is not configured", () => {
+    // Default featureConfig carries an empty loginQrUrl.
+    expect(fixture.nativeElement.textContent).not.toContain("Mobile App");
+    expect(fixture.nativeElement.querySelector("app-login-qr")).toBeNull();
+  });
+
+  it("renders the mobile app setup QR when loginQrUrl is set", async () => {
+    (QRCode.toDataURL as jest.Mock).mockResolvedValue(
+      "data:image/png;base64,QR"
+    );
+
+    TestBed.inject(Store).dispatch(
+      new SetFeatureConfig({
+        enableLocalSignUp: false,
+        aiPoweredReceipts: false,
+        loginQrUrl: "https://receiptwrangler.io/app/setup#url=x",
+      })
+    );
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain("Mobile App");
+    expect(
+      fixture.nativeElement.querySelector("img.login-qr-code")
+    ).toBeTruthy();
   });
 });

--- a/desktop/src/about/about/about.component.ts
+++ b/desktop/src/about/about/about.component.ts
@@ -4,6 +4,7 @@ import { Store } from "@ngxs/store";
 import { About } from "../../open-api/index";
 import { SharedUiModule } from "../../shared-ui/shared-ui.module";
 import { AboutState } from "../../store/about.state";
+import { FeatureConfigState } from "../../store/feature-config.state";
 
 interface Link {
   url: string;
@@ -22,6 +23,7 @@ interface Link {
 export class AboutComponent {
   private store = inject(Store);
   public about = this.store.selectSignal(AboutState.about);
+  public loginQrUrl = this.store.selectSignal(FeatureConfigState.loginQrUrl);
 
   public links: Link[] = [
     {

--- a/desktop/src/auth/auth.module.ts
+++ b/desktop/src/auth/auth.module.ts
@@ -6,6 +6,7 @@ import { ButtonModule } from "../button/button.module";
 import { DirectivesModule } from "../directives/directives.module";
 import { InputModule } from "../input/input.module";
 import { PipesModule } from "../pipes/pipes.module";
+import { LoginQrComponent } from "../shared-ui/login-qr/login-qr.component";
 import { AuthRoutingModule } from "./auth-routing.module";
 import { AuthForm } from "./sign-up/auth-form.component";
 
@@ -21,6 +22,7 @@ import { AuthForm } from "./sign-up/auth-form.component";
     ReactiveFormsModule,
     NgOptimizedImage,
     MatProgressSpinner,
+    LoginQrComponent,
   ],
   exports: [AuthForm],
 })

--- a/desktop/src/auth/sign-up/auth-form.component.html
+++ b/desktop/src/auth/sign-up/auth-form.component.html
@@ -69,19 +69,7 @@
       </form>
 
       <!-- Mobile app setup QR (shown only when configured in System Settings) -->
-      @if (qrDataUrl(); as qr) {
-        <div class="login-qr">
-          <div class="login-qr-divider"><span>Set up the mobile app</span></div>
-          <img
-            [src]="qr"
-            class="login-qr-code"
-            alt="Scan to set up the Receipt Wrangler mobile app"
-          >
-          <p class="login-qr-caption">
-            Scan with your phone to open the app and connect it to this server.
-          </p>
-        </div>
-      }
+      <app-login-qr headerText="Set up the mobile app"></app-login-qr>
     </div>
   </div>
 }

--- a/desktop/src/auth/sign-up/auth-form.component.scss
+++ b/desktop/src/auth/sign-up/auth-form.component.scss
@@ -191,47 +191,6 @@ app-auth-form {
     }
   }
 
-  .login-qr {
-    margin-top: variables.$spacing-lg;
-    text-align: center;
-
-    .login-qr-divider {
-      display: flex;
-      align-items: center;
-      gap: variables.$spacing-sm;
-      margin-bottom: variables.$spacing-md;
-      color: #64748b;
-      font-size: 0.85rem;
-      font-weight: 600;
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
-
-      &::before,
-      &::after {
-        content: "";
-        flex: 1;
-        height: 1px;
-        background: #e2e8f0;
-      }
-    }
-
-    .login-qr-code {
-      width: 180px;
-      height: 180px;
-      border-radius: variables.$border-radius-xl;
-      border: 2px solid #e2e8f0;
-      padding: variables.$spacing-xs;
-      background: white;
-    }
-
-    .login-qr-caption {
-      margin-top: variables.$spacing-sm;
-      margin-bottom: 0;
-      font-size: 0.85rem;
-      color: #64748b;
-    }
-  }
-
   // Fun animations
   @keyframes wave {
     0%, 100% {

--- a/desktop/src/auth/sign-up/auth-form.component.spec.ts
+++ b/desktop/src/auth/sign-up/auth-form.component.spec.ts
@@ -24,6 +24,7 @@ import { AuthForm } from './auth-form.component';
 import { AuthState } from '../../store/auth.state';
 import { FeatureConfigState } from '../../store/feature-config.state';
 import { AuthFormUtil } from './auth-form.util';
+import { LoginQrComponent } from '../../shared-ui/login-qr/login-qr.component';
 import { RouterTestingModule } from '@angular/router/testing';
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
 
@@ -42,6 +43,7 @@ describe('AuthForm', () => {
         PipesModule,
         ReactiveFormsModule,
         ApiModule,
+        LoginQrComponent,
         RouterTestingModule],
     providers: [
         SnackbarService,
@@ -67,15 +69,16 @@ describe('AuthForm', () => {
     expect(component).toBeTruthy();
   });
 
+  // The QR itself is unit-tested in shared-ui/login-qr; these two only pin that
+  // the login page still wires the shared component up.
   it('does not render the login QR when loginQrUrl is empty', () => {
     // Default featureConfig carries an empty loginQrUrl.
-    expect(component.qrDataUrl()).toBeNull();
     expect(
       fixture.nativeElement.querySelector('img.login-qr-code')
     ).toBeNull();
   });
 
-  it('renders a locally-generated QR when loginQrUrl is set', async () => {
+  it('renders the login QR when loginQrUrl is set', async () => {
     (QRCode.toDataURL as jest.Mock).mockResolvedValue(
       'data:image/png;base64,QR'
     );
@@ -98,41 +101,11 @@ describe('AuthForm', () => {
       loginQrUrl,
       expect.anything()
     );
-    expect(component.qrDataUrl()).toBe('data:image/png;base64,QR');
     expect(
       fixture.nativeElement.querySelector('img.login-qr-code')
     ).toBeTruthy();
-  });
-
-  it('ignores a stale QR generation that resolves after a newer one', async () => {
-    // Hand out manually-resolved promises so the two generations can be
-    // completed out of order.
-    const resolvers: Array<(dataUrl: string) => void> = [];
-    (QRCode.toDataURL as jest.Mock).mockImplementation(
-      () => new Promise<string>((resolve) => resolvers.push(resolve))
-    );
-    const store = TestBed.inject(Store);
-
-    const setLoginQrUrl = (loginQrUrl: string) => {
-      store.dispatch(
-        new SetFeatureConfig({
-          enableLocalSignUp: false,
-          aiPoweredReceipts: false,
-          loginQrUrl,
-        })
-      );
-      fixture.detectChanges();
-    };
-
-    setLoginQrUrl('https://receiptwrangler.io/app/setup#url=stale');
-    setLoginQrUrl('https://receiptwrangler.io/app/setup#url=current');
-    expect(resolvers.length).toBe(2);
-
-    // Reverse order: the current generation finishes first, then the stale one.
-    resolvers[1]('data:image/png;base64,CURRENT');
-    resolvers[0]('data:image/png;base64,STALE');
-    await fixture.whenStable();
-
-    expect(component.qrDataUrl()).toBe('data:image/png;base64,CURRENT');
+    expect(
+      fixture.nativeElement.querySelector('.login-qr-divider').textContent
+    ).toContain('Set up the mobile app');
   });
 });

--- a/desktop/src/auth/sign-up/auth-form.component.ts
+++ b/desktop/src/auth/sign-up/auth-form.component.ts
@@ -1,14 +1,13 @@
-import { Component, effect, OnInit, signal, ViewEncapsulation } from "@angular/core";
+import { Component, OnInit, ViewEncapsulation } from "@angular/core";
 import { FormBuilder, FormControl, FormGroup, Validators, } from "@angular/forms";
 import { ActivatedRoute, Router } from "@angular/router";
 import { Store } from "@ngxs/store";
-import * as QRCode from "qrcode";
 import { BehaviorSubject, catchError, finalize, of, switchMap, tap, } from "rxjs";
 import { AppData, AuthService } from "src/open-api";
 import { SnackbarService } from "src/services";
 import { setAppData } from "src/utils";
 import { fadeIn, fadeInOut } from "../../animations";
-import { FeatureConfigState, GroupState } from "../../store";
+import { GroupState } from "../../store";
 import { UserValidators } from "../../validators";
 
 @Component({
@@ -30,9 +29,6 @@ export class AuthForm implements OnInit {
   public secondaryButtonText: string = "";
   public secondaryButtonRouterLink: string[] = [];
   public isLoading = false;
-  // Rendered locally from featureConfig.loginQrUrl; null when the login QR is
-  // disabled/unset, which hides the QR block on the login page.
-  public qrDataUrl = signal<string | null>(null);
 
   constructor(
     private authSerivce: AuthService,
@@ -43,33 +39,6 @@ export class AuthForm implements OnInit {
     protected store: Store,
     protected userValidators: UserValidators
   ) {
-    const loginQrUrl = this.store.selectSignal(FeatureConfigState.loginQrUrl);
-    effect((onCleanup) => {
-      const url = loginQrUrl();
-      if (!url) {
-        this.qrDataUrl.set(null);
-        return;
-      }
-
-      // Generation runs async, so a URL change can leave an earlier call in
-      // flight. Cleanup runs before the next execution (and on destroy), so
-      // only the latest generation is allowed to write the signal — otherwise
-      // a late-resolving older QR could overwrite the current one.
-      let cancelled = false;
-      onCleanup(() => (cancelled = true));
-
-      QRCode.toDataURL(url, { margin: 2, width: 220 })
-        .then((dataUrl) => {
-          if (!cancelled) {
-            this.qrDataUrl.set(dataUrl);
-          }
-        })
-        .catch(() => {
-          if (!cancelled) {
-            this.qrDataUrl.set(null);
-          }
-        });
-    });
   }
 
   public ngOnInit(): void {

--- a/desktop/src/layout/sidebar/sidebar.component.html
+++ b/desktop/src/layout/sidebar/sidebar.component.html
@@ -9,6 +9,7 @@
       >
         <app-avatar
           class="cursor-pointer"
+          data-testid="sidebar-avatar-menu"
           [user]="loggedInUser() ?? $any({})"
           [matMenuTriggerFor]="menu"
         ></app-avatar>

--- a/desktop/src/shared-ui/login-qr/login-qr.component.html
+++ b/desktop/src/shared-ui/login-qr/login-qr.component.html
@@ -1,0 +1,13 @@
+@if (qrDataUrl(); as qr) {
+  <div class="login-qr">
+    @if (headerText(); as header) {
+      <div class="login-qr-divider"><span>{{ header }}</span></div>
+    }
+    <img
+      [src]="qr"
+      class="login-qr-code"
+      alt="Scan to set up the Receipt Wrangler mobile app"
+    >
+    <p class="login-qr-caption">{{ caption() }}</p>
+  </div>
+}

--- a/desktop/src/shared-ui/login-qr/login-qr.component.scss
+++ b/desktop/src/shared-ui/login-qr/login-qr.component.scss
@@ -1,0 +1,46 @@
+@use "../../variables.scss" as variables;
+
+:host {
+  display: block;
+}
+
+.login-qr {
+  margin-top: variables.$spacing-lg;
+  text-align: center;
+
+  .login-qr-divider {
+    display: flex;
+    align-items: center;
+    gap: variables.$spacing-sm;
+    margin-bottom: variables.$spacing-md;
+    color: #64748b;
+    font-size: 0.85rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+
+    &::before,
+    &::after {
+      content: "";
+      flex: 1;
+      height: 1px;
+      background: #e2e8f0;
+    }
+  }
+
+  .login-qr-code {
+    width: 180px;
+    height: 180px;
+    border-radius: variables.$border-radius-xl;
+    border: 2px solid #e2e8f0;
+    padding: variables.$spacing-xs;
+    background: white;
+  }
+
+  .login-qr-caption {
+    margin-top: variables.$spacing-sm;
+    margin-bottom: 0;
+    font-size: 0.85rem;
+    color: #64748b;
+  }
+}

--- a/desktop/src/shared-ui/login-qr/login-qr.component.spec.ts
+++ b/desktop/src/shared-ui/login-qr/login-qr.component.spec.ts
@@ -1,0 +1,133 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { provideStore, Store } from "@ngxs/store";
+import * as QRCode from "qrcode";
+
+jest.mock("qrcode", () => ({
+  __esModule: true,
+  toDataURL: jest.fn(),
+}));
+
+import { FeatureConfigState } from "../../store/feature-config.state";
+import { SetFeatureConfig } from "../../store/feature-config.state.actions";
+import { LoginQrComponent } from "./login-qr.component";
+
+describe("LoginQrComponent", () => {
+  let component: LoginQrComponent;
+  let fixture: ComponentFixture<LoginQrComponent>;
+  let store: Store;
+
+  const setLoginQrUrl = (loginQrUrl: string) => {
+    store.dispatch(
+      new SetFeatureConfig({
+        enableLocalSignUp: false,
+        aiPoweredReceipts: false,
+        loginQrUrl,
+      })
+    );
+    fixture.detectChanges();
+  };
+
+  beforeEach(async () => {
+    (QRCode.toDataURL as jest.Mock).mockReset();
+
+    await TestBed.configureTestingModule({
+      imports: [LoginQrComponent],
+      providers: [provideStore([FeatureConfigState])],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(LoginQrComponent);
+    component = fixture.componentInstance;
+    store = TestBed.inject(Store);
+    fixture.detectChanges();
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+
+  it("renders nothing when loginQrUrl is empty", () => {
+    // Default featureConfig carries an empty loginQrUrl.
+    expect(component.qrDataUrl()).toBeNull();
+    expect(fixture.nativeElement.querySelector("img.login-qr-code")).toBeNull();
+  });
+
+  it("renders a locally-generated QR when loginQrUrl is set", async () => {
+    (QRCode.toDataURL as jest.Mock).mockResolvedValue(
+      "data:image/png;base64,QR"
+    );
+    const loginQrUrl = "https://receiptwrangler.io/app/setup#url=x";
+
+    setLoginQrUrl(loginQrUrl);
+    // Effect regenerates the data URL (async) from the new store value.
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(QRCode.toDataURL).toHaveBeenCalledWith(loginQrUrl, {
+      margin: 2,
+      width: 220,
+    });
+    expect(component.qrDataUrl()).toBe("data:image/png;base64,QR");
+    expect(
+      fixture.nativeElement.querySelector("img.login-qr-code").getAttribute("src")
+    ).toBe("data:image/png;base64,QR");
+  });
+
+  it("renders the divider only when headerText is provided", async () => {
+    (QRCode.toDataURL as jest.Mock).mockResolvedValue(
+      "data:image/png;base64,QR"
+    );
+
+    setLoginQrUrl("https://receiptwrangler.io/app/setup#url=x");
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(
+      fixture.nativeElement.querySelector(".login-qr-divider")
+    ).toBeNull();
+
+    fixture.componentRef.setInput("headerText", "Set up the mobile app");
+    fixture.detectChanges();
+
+    expect(
+      fixture.nativeElement.querySelector(".login-qr-divider").textContent
+    ).toContain("Set up the mobile app");
+  });
+
+  it("hides the QR again when the feature is turned off", async () => {
+    (QRCode.toDataURL as jest.Mock).mockResolvedValue(
+      "data:image/png;base64,QR"
+    );
+
+    setLoginQrUrl("https://receiptwrangler.io/app/setup#url=x");
+    await fixture.whenStable();
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector("img.login-qr-code")).toBeTruthy();
+
+    setLoginQrUrl("");
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(component.qrDataUrl()).toBeNull();
+    expect(fixture.nativeElement.querySelector("img.login-qr-code")).toBeNull();
+  });
+
+  it("ignores a stale QR generation that resolves after a newer one", async () => {
+    // Hand out manually-resolved promises so the two generations can be
+    // completed out of order.
+    const resolvers: Array<(dataUrl: string) => void> = [];
+    (QRCode.toDataURL as jest.Mock).mockImplementation(
+      () => new Promise<string>((resolve) => resolvers.push(resolve))
+    );
+
+    setLoginQrUrl("https://receiptwrangler.io/app/setup#url=stale");
+    setLoginQrUrl("https://receiptwrangler.io/app/setup#url=current");
+    expect(resolvers.length).toBe(2);
+
+    // Reverse order: the current generation finishes first, then the stale one.
+    resolvers[1]("data:image/png;base64,CURRENT");
+    resolvers[0]("data:image/png;base64,STALE");
+    await fixture.whenStable();
+
+    expect(component.qrDataUrl()).toBe("data:image/png;base64,CURRENT");
+  });
+});

--- a/desktop/src/shared-ui/login-qr/login-qr.component.spec.ts
+++ b/desktop/src/shared-ui/login-qr/login-qr.component.spec.ts
@@ -93,6 +93,55 @@ describe("LoginQrComponent", () => {
     ).toContain("Set up the mobile app");
   });
 
+  it("renders the default caption, and an override when one is passed", async () => {
+    (QRCode.toDataURL as jest.Mock).mockResolvedValue(
+      "data:image/png;base64,QR"
+    );
+
+    setLoginQrUrl("https://receiptwrangler.io/app/setup#url=x");
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(
+      fixture.nativeElement.querySelector(".login-qr-caption").textContent
+    ).toContain(
+      "Scan with your phone to open the app and connect it to this server."
+    );
+
+    fixture.componentRef.setInput("caption", "Scan me from the About dialog");
+    fixture.detectChanges();
+
+    expect(
+      fixture.nativeElement.querySelector(".login-qr-caption").textContent
+    ).toContain("Scan me from the About dialog");
+  });
+
+  it("clears the QR when generation fails", async () => {
+    // Generate one successfully first, so this proves the catch CLEARS a
+    // displayed QR — rejecting on the first generation would pass even with
+    // the catch removed, since the signal starts null.
+    (QRCode.toDataURL as jest.Mock).mockResolvedValue(
+      "data:image/png;base64,QR"
+    );
+    setLoginQrUrl("https://receiptwrangler.io/app/setup#url=ok");
+    await fixture.whenStable();
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector("img.login-qr-code")).toBeTruthy();
+
+    (QRCode.toDataURL as jest.Mock).mockRejectedValue(
+      new Error("generation failed")
+    );
+    setLoginQrUrl("https://receiptwrangler.io/app/setup#url=bad");
+    // Two flushes: the rejection reaches the `.catch` a microtask AFTER the
+    // (skipped) `.then`, so a single whenStable() can resolve in between.
+    await fixture.whenStable();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(component.qrDataUrl()).toBeNull();
+    expect(fixture.nativeElement.querySelector("img.login-qr-code")).toBeNull();
+  });
+
   it("hides the QR again when the feature is turned off", async () => {
     (QRCode.toDataURL as jest.Mock).mockResolvedValue(
       "data:image/png;base64,QR"

--- a/desktop/src/shared-ui/login-qr/login-qr.component.ts
+++ b/desktop/src/shared-ui/login-qr/login-qr.component.ts
@@ -1,0 +1,60 @@
+import { Component, effect, inject, input, signal } from "@angular/core";
+import { Store } from "@ngxs/store";
+import * as QRCode from "qrcode";
+import { FeatureConfigState } from "../../store/feature-config.state";
+
+/**
+ * Renders the mobile app setup QR for `featureConfig.loginQrUrl`, or nothing at
+ * all when the feature is disabled/unset. Used by the login page and the About
+ * dialog so both share one generation path.
+ */
+@Component({
+  selector: "app-login-qr",
+  templateUrl: "./login-qr.component.html",
+  styleUrls: ["./login-qr.component.scss"],
+  standalone: true,
+})
+export class LoginQrComponent {
+  /** Optional divider label rendered above the QR. Omit to render just the code. */
+  public readonly headerText = input<string | undefined>(undefined);
+
+  public readonly caption = input<string>(
+    "Scan with your phone to open the app and connect it to this server."
+  );
+
+  // Rendered locally from featureConfig.loginQrUrl; null when the login QR is
+  // disabled/unset, which hides the whole block.
+  public qrDataUrl = signal<string | null>(null);
+
+  private store = inject(Store);
+
+  constructor() {
+    const loginQrUrl = this.store.selectSignal(FeatureConfigState.loginQrUrl);
+    effect((onCleanup) => {
+      const url = loginQrUrl();
+      if (!url) {
+        this.qrDataUrl.set(null);
+        return;
+      }
+
+      // Generation runs async, so a URL change can leave an earlier call in
+      // flight. Cleanup runs before the next execution (and on destroy), so
+      // only the latest generation is allowed to write the signal — otherwise
+      // a late-resolving older QR could overwrite the current one.
+      let cancelled = false;
+      onCleanup(() => (cancelled = true));
+
+      QRCode.toDataURL(url, { margin: 2, width: 220 })
+        .then((dataUrl) => {
+          if (!cancelled) {
+            this.qrDataUrl.set(dataUrl);
+          }
+        })
+        .catch(() => {
+          if (!cancelled) {
+            this.qrDataUrl.set(null);
+          }
+        });
+    });
+  }
+}

--- a/desktop/src/shared-ui/shared-ui.module.ts
+++ b/desktop/src/shared-ui/shared-ui.module.ts
@@ -65,6 +65,7 @@ import { TaskTableComponent } from "./task-table/task-table.component";
 import { EditableListComponent } from './editable-list/editable-list.component';
 import { IconAutocompleteComponent } from './icon-autocomplete/icon-autocomplete.component';
 import { PieChartUiComponent } from './pie-chart/pie-chart.component';
+import { LoginQrComponent } from './login-qr/login-qr.component';
 
 @NgModule({
   declarations: [
@@ -137,6 +138,7 @@ import { PieChartUiComponent } from './pie-chart/pie-chart.component';
     TableModule,
     UserAutocompleteModule,
     PieChartUiComponent,
+    LoginQrComponent,
   ],
   exports: [
     AddButtonComponent,
@@ -180,6 +182,7 @@ import { PieChartUiComponent } from './pie-chart/pie-chart.component';
     EditableListComponent,
     IconAutocompleteComponent,
     PieChartUiComponent,
+    LoginQrComponent,
   ],
   providers: [CurrencyPipe],
 })


### PR DESCRIPTION
## Summary
Refactors the login QR code generation into a standalone, reusable `LoginQrComponent` that can be shared across multiple pages. The component is now used by both the login page and the About dialog, eliminating code duplication and centralizing QR generation logic.

## Key Changes

- **New shared component** (`src/shared-ui/login-qr/`):
  - Standalone `LoginQrComponent` owns all QR generation logic (reading `featureConfig.loginQrUrl`, async QR code generation with cancellation guards, signal-based state)
  - Accepts optional `headerText` input for the divider label and customizable `caption` text
  - Encapsulated styles (`.login-qr*` classes) moved from auth-form stylesheet
  - Comprehensive unit tests covering generation, stale-QR cancellation, and feature toggle behavior

- **Login page** (`auth-form.component.*`):
  - Removed QR generation logic (effect, signal, QRCode imports)
  - Simplified template to use `<app-login-qr headerText="Set up the mobile app"></app-login-qr>`
  - Removed `.login-qr*` styles (now in component)
  - Reduced test scope to only verify the component is wired up (detailed QR logic tested in shared component)

- **About dialog** (`about.component.*`):
  - Added "Mobile App" section that renders `<app-login-qr>` when `loginQrUrl` is configured
  - Conditionally gates the entire section with `@if (loginQrUrl())` to avoid empty headers when feature is disabled
  - Rides on authenticated `GET /appData` (which already dispatches `SetFeatureConfig`)
  - Added unit tests verifying the section appears/disappears with feature state

- **E2E tests** (`login-qr.spec.ts`):
  - Added test confirming the QR also renders on the About dialog while logged in (the key use case: signed-in users can reach it without logging out)

- **Minor improvements**:
  - Added `data-testid="sidebar-avatar-menu"` to sidebar avatar for E2E test reliability
  - Updated `CLAUDE.md` documentation to clarify the two call sites and shared ownership model

## Implementation Details

The component uses Angular's `effect()` with an `onCleanup` cancellation flag to handle async QR generation safely — if the URL changes before a previous `QRCode.toDataURL` resolves, the stale result is discarded. This prevents race conditions where a late-resolving older QR could overwrite the current one. The component renders nothing (hides the entire block) when `qrDataUrl` is null, so both call sites automatically respect the feature toggle without extra plumbing.

https://claude.ai/code/session_01WwDWLRjnm8EhJvXAmTmDYr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added login QR code support to the authenticated About dialog.
  * Reused a shared QR code presentation across the login flow and About dialog.
  * QR display adapts to feature availability and includes configurable messaging and captions.
  * Added consistent QR styling and presentation across supported screens.

* **Bug Fixes**
  * Improved QR generation reliability when configuration changes or generation fails.

* **Tests**
  * Added coverage for QR rendering, feature availability, and About-dialog behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->