### PR TITLE
Support custom fields in report grouping and aggregation

### DIFF
--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -1248,7 +1248,34 @@ association resolves to no value, which surfaces as a `(None)` bucket — not an
 calendar period, `receiptsource` also offers derived **string** fields `<base>_day` / `_month` /
 `_year` (e.g. `date_month`, `created_at_year`, `resolved_date_day`) — zero-padded ISO in **UTC**, so
 they sort chronologically as plain text. A report groups by one of these instead of the raw date field;
-a nil `resolved_date` emits none of its period fields (→ `(None)`).
+a nil `resolved_date` emits none of its period fields (→ `(None)`). A **date custom field** gets the
+same treatment: `CustomFieldPeriodKeys(id)` yields `custom_<id>_day` / `_month` / `_year`, labelled off
+the field's own name (`"Due Date (Month)"`) through the shared `dateFieldRefs` / `setDateParts` helpers.
+They cannot collide with another field's key — `CustomFieldKey` is always `custom_` plus digits alone —
+and only a `models.DATE` field derives them. When duplicate values force the lowest-id-wins tie-break,
+the period parts are rewritten with the winner, so they always describe the value that survived.
+
+**Every field can cut; only numeric fields can be measured.** `Role` (`field.go`) bounds *measuring*
+only — `compileGroupBy` / `compileDetail` accept any field in the catalog, so a **currency custom field
+is both groupable and summable** (and a plain label column always accepted any field). Grouping by a
+number is well defined: bucket keys are canonical for decimals and `compareValues` orders them, so
+`15.60` and `15.6` share one bucket. `ErrGroupByNotDimension` / `ErrDetailByNotDimension` are **gone** —
+a spec that used to be rejected for grouping by a measure now compiles. Tests that needed an
+*invalid* spec use an unknown field key (`ErrUnknownField`) instead; don't reintroduce "group by
+amount" as the invalid-spec fixture.
+
+**Typed dimension and label rendering.** The engine emits raw typed values, so a renderer needs the
+field's type to present them: without it a bool prints `true`, a date an RFC 3339 instant, and money a
+bare decimal. `render.Dimension` therefore carries a `DataType` (populated by `buildDimensions` from the
+catalog), and `render/value.go`'s shared `formatLabelValue` is used by **every** label-ish cell —
+`formatDimension` (the CSV walk *and* `walk.go`, so HTML/PDF and XLSX too) and `joinLabel` (XLSX) —
+mapping bool → `Yes`/`No`, date → `2006-01-02` **UTC** (matching the derived `_day` field), currency →
+`Meta.Currency`'s format (bare 2dp when unset). A declared type that disagrees with a value's payload
+falls through to the value's own rendering rather than substituting a zero. A label column is still a
+**string** cell in XLSX even when it holds money — it names a bucket rather than measuring one, and a
+multi-value label has no numeric reading; aggregate columns are what carry native numbers. Note this
+changed existing reports that group by the built-in `date` / `resolved_date` / `created_at`: their
+bucket text went from RFC 3339 to a plain calendar day.
 
 **`services.ReportDataService`** (`internal/services/report_data.go`) is the first DB-backed caller of
 the engine — it follows the `pie_chart.go` pattern. `Rows(userId, groupId, filter)` fetches the group's

--- a/api/internal/handlers/report_test.go
+++ b/api/internal/handlers/report_test.go
@@ -150,9 +150,10 @@ func TestGenerateReport_MapsInvalidSpecToBadRequest(t *testing.T) {
 	grantGroupPerms(t, 1, 1, permissions.GroupReportsRead)
 	seedReportReceipt(1, 1)
 
-	// The command validates, but grouping by a measure is an invalid spec the
-	// engine rejects — the handler must map that ReportSpecError to a 400, not a 500.
-	body := strings.Replace(recordsReportBody, `"detail": {"mode": "records"},`, `"groupBy": ["amount"],
+	// The command validates, but grouping by a field the catalog does not know is an
+	// invalid spec the engine rejects — the handler must map that ReportSpecError to a
+	// 400, not a 500.
+	body := strings.Replace(recordsReportBody, `"detail": {"mode": "records"},`, `"groupBy": ["not_a_field"],
   "detail": {"mode": "records"},`, 1)
 	w, r := generateReportRequest(1, body)
 	GenerateReport(w, r)
@@ -236,7 +237,7 @@ func TestPreviewReport_MapsInvalidSpecToBadRequest(t *testing.T) {
 	grantGroupPerms(t, 1, 1, permissions.GroupReportsRead)
 	seedReportReceipt(1, 1)
 
-	body := strings.Replace(recordsReportBody, `"detail": {"mode": "records"},`, `"groupBy": ["amount"],
+	body := strings.Replace(recordsReportBody, `"detail": {"mode": "records"},`, `"groupBy": ["not_a_field"],
   "detail": {"mode": "records"},`, 1)
 	w, r := generateReportRequest(1, body)
 	PreviewReport(w, r)
@@ -1009,9 +1010,9 @@ func TestRenderReportTemplate_RestrictedWhenTemplateAccessRevoked(t *testing.T) 
 	}
 }
 
-// A stored config that is valid JSON but an invalid spec (grouping by a measure) is
-// caught by the engine as a *ReportSpecError, which the handler maps to 400 — not the
-// 500 a generic failure would produce.
+// A stored config that is valid JSON but an invalid spec (grouping by a field the
+// catalog does not know) is caught by the engine as a *ReportSpecError, which the
+// handler maps to 400 — not the 500 a generic failure would produce.
 func TestRenderReportTemplate_MapsInvalidSpecToBadRequest(t *testing.T) {
 	defer tearDownReportTest()
 	repositories.CreateTestGroupWithUsers()
@@ -1025,7 +1026,7 @@ func TestRenderReportTemplate_MapsInvalidSpecToBadRequest(t *testing.T) {
 		Name:     "Invalid Spec",
 		GroupIds: []string{"1"},
 		Period:   commands.ReportPeriod{Preset: "this_month"},
-		GroupBy:  []string{"amount"}, // grouping by a measure is rejected by the engine
+		GroupBy:  []string{"not_a_field"}, // no such field in the catalog
 		Detail:   commands.ReportDetail{Mode: "records"},
 		Columns:  []commands.ReportColumn{{Kind: "dimension", Name: "Name", Label: "Name", Field: "name"}},
 		Formats:  []string{"csv"},

--- a/api/internal/reporting/README.md
+++ b/api/internal/reporting/README.md
@@ -73,12 +73,21 @@ report full of empty cells.
 DataType                Role         May be used as
 ────────────────────────────────────────────────────────────────
 TypeNumber, TypeCurrency  →  Measure    the input to SUM/AVG/MIN/MAX
-TypeString, TypeDate,     →  Dimension  a groupBy level, or the key
-TypeBool                                of an aggregated detail row
+TypeString, TypeDate,     →  Dimension  cutting only
+TypeBool
 ```
 
-`RoleForDataType` (`field.go`) is the whole rule. A template can therefore never group by a dollar
-amount or sum a status — the spec simply will not compile.
+`RoleForDataType` (`field.go`) is the whole rule, and it bounds **measuring only**: a template can
+never sum a status — the spec will not compile.
+
+**Every field can cut, measures included.** A groupBy level, an aggregate detail row's key, and a
+label column accept any field in the catalog. Grouping by a number is well defined — bucket keys are
+canonical for decimals (`decimal.String()`) and `compareValues` orders them — so grouping by a
+currency custom field buckets receipts by amount exactly as grouping by a category buckets them by
+name. The alternative would make a custom field's *type* decide whether it is reportable at all,
+which is not a distinction the engine should be making. Presenting those buckets is a renderer's job:
+`render.Dimension` carries the field's `DataType` so a bool reads Yes/No, a date reads as a calendar
+day, and money reads per the report's currency configuration.
 
 ### Three column kinds, declared not inferred
 

--- a/api/internal/reporting/engine_test.go
+++ b/api/internal/reporting/engine_test.go
@@ -1054,3 +1054,48 @@ func TestRun_NumbersDifferingOnlyInScaleShareABucket(t *testing.T) {
 	model := mustRun(t, spec, []Row{{"category": {Str("Clothing")}, "amount": {Num(dec("200.00"))}}})
 	assertRow(t, model.Root.Children[0].DetailRows[0].Cells, map[string]string{"Total": "200"})
 }
+
+// A currency custom field is a measure, but measuring is the only thing its type
+// restricts: a report may cut by it too. Buckets key on the canonical decimal, so
+// 15.60 and 15.6 are one bucket, and a receipt carrying no value lands in (None).
+func TestRun_GroupByACurrencyField(t *testing.T) {
+	spec := ReportSpec{
+		GroupBy: []FieldKey{"custom_1"},
+		Columns: []Column{
+			{Name: "Hst", Kind: ColumnLabel, Field: "custom_1"},
+			{Name: "Count", Kind: ColumnAggregate, Agg: Aggregate{Func: AggCount}},
+			{Name: "Total", Kind: ColumnAggregate, Agg: Aggregate{Func: AggSum, Field: "amount"}},
+		},
+		GrandTotals: true,
+	}
+
+	rows := []Row{
+		receiptRow("Dana", "Alex", "Clothing", "100.00", "15.60"),
+		receiptRow("Sam", "Alex", "Medical", "50.00", "15.6"),
+		receiptRow("Dana", "Sam", "Clothing", "20.00", "2.00"),
+		receiptRow("Sam", "Sam", "Medical", "10.00", ""),
+	}
+
+	model := mustRun(t, spec, rows)
+
+	if len(model.Root.Children) != 3 {
+		t.Fatalf("got %d buckets, want 3 (2.00, 15.60, (None))", len(model.Root.Children))
+	}
+
+	two, fifteen, none := model.Root.Children[0], model.Root.Children[1], model.Root.Children[2]
+
+	if number, isNumber := two.Value.Decimal(); !isNumber || !number.Equal(dec("2.00")) {
+		t.Errorf("first bucket = %v, want 2.00 (numbers sort ascending)", two.Value)
+	}
+	// 15.60 and 15.6 are the same amount, so they share one bucket.
+	if number, _ := fifteen.Value.Decimal(); !number.Equal(dec("15.60")) || fifteen.RecordCount != 2 {
+		t.Errorf("second bucket = %v with %d records, want 15.60 with 2", fifteen.Value, fifteen.RecordCount)
+	}
+	if !none.IsNone || none.RecordCount != 1 {
+		t.Errorf("(None) bucket = %+v, want 1 record", none)
+	}
+
+	// The label column reads the bucket, so a grouped currency value is displayable.
+	assertRow(t, fifteen.DetailRows[0].Cells, map[string]string{"Hst": "15.60"})
+	assertRow(t, model.GrandTotals, map[string]string{"Count": "4", "Total": "180.00"})
+}

--- a/api/internal/reporting/field.go
+++ b/api/internal/reporting/field.go
@@ -52,17 +52,23 @@ func (d DataType) IsNumeric() bool {
 	return d == TypeNumber || d == TypeCurrency
 }
 
-// Role is what a field may be used for. It is derived from the data type rather
-// than declared, so a template can never group by a dollar amount or sum a
-// status.
+// Role is what a field is for. It is derived from the data type rather than
+// declared, so a template can never sum a status.
+//
+// It bounds measuring only: every field can cut the data, so a dimension is not
+// restricted to RoleDimension fields. Grouping by a currency custom field is as
+// meaningful as grouping by a category, and refusing it would make a custom
+// field's type decide whether it is reportable at all.
 type Role uint8
 
 const (
-	// RoleDimension is a way to cut the data: a groupBy level, or the dimension
-	// an aggregated detail row is keyed on.
+	// RoleDimension is a field that only cuts: it can be a groupBy level, the
+	// dimension an aggregated detail row is keyed on, or a label column, but it
+	// cannot be measured.
 	RoleDimension Role = iota
 
-	// RoleMeasure is a thing to measure: the input to an aggregate column.
+	// RoleMeasure is a thing to measure: the input to an aggregate column. A
+	// measure can still cut, so a currency field is both summable and groupable.
 	RoleMeasure
 )
 
@@ -77,7 +83,7 @@ func (r Role) String() string {
 }
 
 // RoleForDataType derives a field's role from its type. Numbers measure;
-// everything else cuts.
+// everything else only cuts.
 func RoleForDataType(dataType DataType) Role {
 	if dataType.IsNumeric() {
 		return RoleMeasure

--- a/api/internal/reporting/mutation-check.sh
+++ b/api/internal/reporting/mutation-check.sh
@@ -371,10 +371,15 @@ add 'cycle-path-truncated' 'validate.go' \
 'strings.Join(append(path, columns[index].name), " -> ")' \
 'strings.Join(path, " -> ")'
 
-# TestValidate_Rejects/groupBy a measure
-add 'groupby-accepts-a-measure' 'validate.go' \
-'		if field.Role() != RoleDimension {
-			return nil, fmt.Errorf("%w: %s is a %s", ErrGroupByNotDimension, key, field.DataType)
+# TestValidate_Rejects/duplicate groupBy level
+#
+# There is deliberately no "groupBy a measure" mutation: every field may cut, so
+# a numeric groupBy is accepted by design (TestValidate_AcceptsVariations/a
+# measure may be grouped on and aggregated by). The duplicate guard is what is
+# left to break here.
+add 'groupby-accepts-duplicates' 'validate.go' \
+'		if _, duplicate := seen[key]; duplicate {
+			return nil, fmt.Errorf("%w: %s", ErrDuplicateGroupBy, key)
 		}
 ' \
 ''

--- a/api/internal/reporting/receiptsource/receiptsource.go
+++ b/api/internal/reporting/receiptsource/receiptsource.go
@@ -62,6 +62,21 @@ func CustomFieldKey(customFieldID uint) reporting.FieldKey {
 	return reporting.FieldKey(customFieldKeyPrefix + strconv.FormatUint(uint64(customFieldID), 10))
 }
 
+// CustomFieldPeriodKeys returns the day/month/year keys derived from a date
+// custom field, the custom-field counterpart of date_day / date_month /
+// date_year. A report groups by one of these to bucket by calendar period;
+// grouping by the raw field buckets on the exact instant, which puts every
+// receipt in its own group.
+//
+// They cannot collide with another custom field's key: CustomFieldKey is always
+// "custom_" followed by digits alone, so no id produces "custom_7_month".
+func CustomFieldPeriodKeys(customFieldID uint) (day, month, year reporting.FieldKey) {
+	base := string(CustomFieldKey(customFieldID))
+	return reporting.FieldKey(base + "_day"),
+		reporting.FieldKey(base + "_month"),
+		reporting.FieldKey(base + "_year")
+}
+
 // builtinFields returns the fields every receipt report may reference.
 //
 // Categories and tags are multi-valued: grouping on one fans a receipt out into
@@ -150,6 +165,11 @@ func New(customFields []models.CustomField) (Source, error) {
 			Label:    customField.Name,
 			DataType: dataTypeFor(customField.Type),
 		})
+
+		if customField.Type == models.DATE {
+			day, month, year := CustomFieldPeriodKeys(customField.ID)
+			fields = append(fields, dateFieldRefs(day, month, year, customField.Name)...)
+		}
 	}
 
 	catalog, err := reporting.NewFieldCatalog(fields...)
@@ -162,7 +182,8 @@ func New(customFields []models.CustomField) (Source, error) {
 }
 
 // Catalog returns the fields a report run against this source may reference:
-// every built-in, plus one per custom field.
+// every built-in, plus one per custom field — and, for a date custom field,
+// its three derived calendar-period fields as well.
 func (s Source) Catalog() reporting.FieldCatalog { return s.catalog }
 
 // dataTypeFor maps a custom field's type onto the engine's. A currency custom
@@ -242,8 +263,9 @@ func setDateParts(row reporting.Row, dayKey, monthKey, yearKey reporting.FieldKe
 }
 
 // addCustomFields resolves each of a receipt's custom field values against its
-// definition. A field the receipt carries no value for simply has no entry,
-// which reads as null when measured and as (None) when grouped.
+// definition, writing a date field's calendar-period parts alongside its value.
+// A field the receipt carries no value for simply has no entry, which reads as
+// null when measured and as (None) when grouped.
 //
 // Where a receipt holds several values for one field, the one with the lowest id
 // wins. Nothing stops it holding several: custom_field_values carries no unique
@@ -274,6 +296,14 @@ func (s Source) addCustomFields(row reporting.Row, receipt *models.Receipt) {
 
 		winners[key] = customFieldValue.ID
 		row[key] = []reporting.Value{value}
+
+		// A date field also carries its calendar-period fields. This runs again
+		// whenever a lower-id value takes over, and setDateParts overwrites, so
+		// the parts always describe the value that actually won.
+		if moment, isDate := value.Time(); isDate {
+			day, month, year := CustomFieldPeriodKeys(customFieldValue.CustomFieldId)
+			setDateParts(row, day, month, year, moment)
+		}
 	}
 }
 

--- a/api/internal/reporting/receiptsource/receiptsource_test.go
+++ b/api/internal/reporting/receiptsource/receiptsource_test.go
@@ -109,6 +109,122 @@ func TestSource_CatalogTypesCustomFields(t *testing.T) {
 	}
 }
 
+func TestCustomFieldPeriodKeys(t *testing.T) {
+	day, month, year := CustomFieldPeriodKeys(dueDateFieldID)
+	if day != "custom_4_day" || month != "custom_4_month" || year != "custom_4_year" {
+		t.Errorf("CustomFieldPeriodKeys(%d) = %q, %q, %q", dueDateFieldID, day, month, year)
+	}
+}
+
+// Only a date custom field derives calendar-period fields, and they are labelled
+// off the field's own name so a builder can offer "Due Date (Month)" beside it.
+func TestSource_CatalogHasCustomDatePeriodFields(t *testing.T) {
+	catalog := mustNew(t).Catalog()
+
+	tests := []struct {
+		key   reporting.FieldKey
+		label string
+	}{
+		{"custom_4_day", "Due Date (Day)"},
+		{"custom_4_month", "Due Date (Month)"},
+		{"custom_4_year", "Due Date (Year)"},
+	}
+	for _, test := range tests {
+		t.Run(string(test.key), func(t *testing.T) {
+			field, exists := catalog.Get(test.key)
+			if !exists {
+				t.Fatalf("catalog is missing %s", test.key)
+			}
+			if field.Label != test.label {
+				t.Errorf("label = %q, want %q", field.Label, test.label)
+			}
+			// String so the engine buckets on the exact label, single-valued, and
+			// a dimension so a report may group by it.
+			if field.DataType != reporting.TypeString {
+				t.Errorf("dataType = %v, want %v", field.DataType, reporting.TypeString)
+			}
+			if field.Multi {
+				t.Errorf("%s is single-valued", test.key)
+			}
+		})
+	}
+
+	// A field of any other type derives nothing — periods only make sense for a date.
+	for _, key := range []reporting.FieldKey{
+		"custom_1_month", "custom_2_month", "custom_3_month", "custom_5_month",
+	} {
+		if _, exists := catalog.Get(key); exists {
+			t.Errorf("catalog has %s, want no period fields on a non-date custom field", key)
+		}
+	}
+}
+
+func TestSource_DerivesCustomDatePeriodFields(t *testing.T) {
+	row := mustNew(t).Rows([]models.Receipt{fullReceipt()})[0]
+
+	tests := []struct {
+		key  reporting.FieldKey
+		want string
+	}{
+		// custom_4 (Due Date) = 2026-06-01
+		{"custom_4_day", "2026-06-01"},
+		{"custom_4_month", "2026-06"},
+		{"custom_4_year", "2026"},
+	}
+	for _, test := range tests {
+		t.Run(string(test.key), func(t *testing.T) {
+			text, isText := row.Measure(test.key).Text()
+			if !isText || text != test.want {
+				t.Errorf("%s = %v, want %q", test.key, row.Measure(test.key), test.want)
+			}
+		})
+	}
+}
+
+// A receipt carrying no value for a date custom field emits none of its period
+// fields either, so it lands in the (None) bucket whichever one a report groups by.
+func TestSource_MissingCustomDateOmitsPeriodFields(t *testing.T) {
+	receipt := models.Receipt{CustomFields: []models.CustomFieldValue{
+		{CustomFieldId: dueDateFieldID},
+	}}
+
+	row := mustNew(t).Rows([]models.Receipt{receipt})[0]
+
+	for _, key := range []reporting.FieldKey{"custom_4", "custom_4_day", "custom_4_month", "custom_4_year"} {
+		if values := row.Get(key); len(values) != 0 {
+			t.Errorf("%s = %v, want no value", key, values)
+		}
+	}
+}
+
+// The period fields must describe whichever duplicate value actually won, not
+// whichever one was written last.
+func TestSource_DuplicateCustomDateValuesDerivePeriodsFromTheWinner(t *testing.T) {
+	lower := time.Date(2026, 1, 9, 0, 0, 0, 0, time.UTC)
+	higher := time.Date(2027, 11, 30, 0, 0, 0, 0, time.UTC)
+
+	ascending := models.Receipt{CustomFields: []models.CustomFieldValue{
+		{BaseModel: models.BaseModel{ID: 10}, CustomFieldId: dueDateFieldID, DateValue: &lower},
+		{BaseModel: models.BaseModel{ID: 20}, CustomFieldId: dueDateFieldID, DateValue: &higher},
+	}}
+	descending := models.Receipt{CustomFields: []models.CustomFieldValue{
+		{BaseModel: models.BaseModel{ID: 20}, CustomFieldId: dueDateFieldID, DateValue: &higher},
+		{BaseModel: models.BaseModel{ID: 10}, CustomFieldId: dueDateFieldID, DateValue: &lower},
+	}}
+
+	source := mustNew(t)
+	for name, receipt := range map[string]models.Receipt{"ascending": ascending, "descending": descending} {
+		t.Run(name, func(t *testing.T) {
+			row := source.Rows([]models.Receipt{receipt})[0]
+
+			text, isText := row.Measure("custom_4_month").Text()
+			if !isText || text != "2026-01" {
+				t.Errorf("custom_4_month = %v, want 2026-01 (the value with the lowest id)", row.Measure("custom_4_month"))
+			}
+		})
+	}
+}
+
 func TestSource_CatalogBuiltins(t *testing.T) {
 	catalog := mustNew(t).Catalog()
 

--- a/api/internal/reporting/render/csv.go
+++ b/api/internal/reporting/render/csv.go
@@ -13,17 +13,23 @@ import (
 	"receipt-wrangler/api/internal/reporting"
 )
 
-// Dimension is one group-by level: the field it cuts on and the header a
-// renderer prints for it.
+// Dimension is one group-by level: the field it cuts on, the header a renderer
+// prints for it, and the type of the values it buckets.
 //
 // The ReportModel carries a dimension key on each group node but not its label,
 // and a flat table needs the levels up front and in order — an empty report
 // still needs its dimension columns. So a caller supplies them, in the same
-// order as the spec's GroupBy. A future orchestrator builds this from the spec
-// and the field catalog.
+// order as the spec's GroupBy, reading both the label and the data type off the
+// field catalog.
+//
+// DataType is what lets a bucket value be presented rather than dumped: without
+// it a date bucket prints an RFC 3339 instant and a currency bucket a bare
+// decimal. Leaving it at its zero value (TypeString) renders every bucket as
+// plain text, which is what a caller that has no catalog gets.
 type Dimension struct {
-	Key   reporting.FieldKey
-	Label string
+	Key      reporting.FieldKey
+	Label    string
+	DataType reporting.DataType
 }
 
 const (
@@ -156,7 +162,7 @@ func buildRecord(model reporting.ReportModel, groupBy []Dimension, rowType strin
 
 	for index := range groupBy {
 		if index < len(path) {
-			record = append(record, formatDimension(path[index], model.Meta.NoneLabel))
+			record = append(record, formatDimension(path[index], groupBy[index], model.Meta.Currency, model.Meta.NoneLabel))
 		} else {
 			record = append(record, "")
 		}
@@ -175,13 +181,11 @@ func columnHeading(column reporting.ColumnDescriptor) string {
 	return SanitizeCSVField(column.Name)
 }
 
-// formatDimension renders a group bucket's value for a leading column. The
-// (None) bucket — a null value — gets the report's name for it.
-func formatDimension(value reporting.Value, noneLabel string) string {
-	if value.IsNull() {
-		return SanitizeCSVField(noneLabel)
-	}
-	return SanitizeCSVField(value.String())
+// formatDimension renders a group bucket's value for a leading column, per the
+// dimension's declared type. The (None) bucket — a null value — gets the
+// report's name for it.
+func formatDimension(value reporting.Value, dimension Dimension, currency *reporting.CurrencyFormat, noneLabel string) string {
+	return SanitizeCSVField(formatLabelValue(value, dimension.DataType, currency, noneLabel))
 }
 
 // formatCell renders one report cell the way this format presents it: money per
@@ -201,11 +205,7 @@ func formatCell(column reporting.ColumnDescriptor, cell reporting.Cell, noneLabe
 	if column.Kind == reporting.ColumnLabel {
 		parts := make([]string, 0, len(cell.Values))
 		for _, value := range cell.Values {
-			if value.IsNull() {
-				parts = append(parts, SanitizeCSVField(noneLabel))
-				continue
-			}
-			parts = append(parts, SanitizeCSVField(value.String()))
+			parts = append(parts, SanitizeCSVField(formatLabelValue(value, column.DataType, currency, noneLabel)))
 		}
 		return strings.Join(parts, ", ")
 	}

--- a/api/internal/reporting/render/csv_test.go
+++ b/api/internal/reporting/render/csv_test.go
@@ -515,6 +515,9 @@ func TestFormatCell_ByTypeAndKind(t *testing.T) {
 	currency := reporting.ColumnDescriptor{Kind: reporting.ColumnAggregate, DataType: reporting.TypeCurrency}
 	number := reporting.ColumnDescriptor{Kind: reporting.ColumnAggregate, DataType: reporting.TypeNumber}
 	label := reporting.ColumnDescriptor{Kind: reporting.ColumnLabel, DataType: reporting.TypeString}
+	dateLabel := reporting.ColumnDescriptor{Kind: reporting.ColumnLabel, DataType: reporting.TypeDate}
+	boolLabel := reporting.ColumnDescriptor{Kind: reporting.ColumnLabel, DataType: reporting.TypeBool}
+	currencyLabel := reporting.ColumnDescriptor{Kind: reporting.ColumnLabel, DataType: reporting.TypeCurrency}
 
 	date := time.Date(2026, 5, 15, 0, 0, 0, 0, time.UTC)
 
@@ -530,8 +533,14 @@ func TestFormatCell_ByTypeAndKind(t *testing.T) {
 		{"plain integer", number, reporting.Cell{Values: []reporting.Value{num(2)}}, "2"},
 		{"non-number in a measure column", number, reporting.Cell{Values: []reporting.Value{reporting.Str("n/a")}}, "n/a"},
 		{"string label", label, reporting.Cell{Values: []reporting.Value{reporting.Str("Food")}}, "Food"},
-		{"date label utc", label, reporting.Cell{Values: []reporting.Value{reporting.DateVal(date)}}, "2026-05-15T00:00:00Z"},
-		{"bool label", label, reporting.Cell{Values: []reporting.Value{reporting.Bool(true)}}, "true"},
+		{"date label utc", dateLabel, reporting.Cell{Values: []reporting.Value{reporting.DateVal(date)}}, "2026-05-15"},
+		{"bool label true", boolLabel, reporting.Cell{Values: []reporting.Value{reporting.Bool(true)}}, "Yes"},
+		{"bool label false", boolLabel, reporting.Cell{Values: []reporting.Value{reporting.Bool(false)}}, "No"},
+		{"currency label two places", currencyLabel, reporting.Cell{Values: []reporting.Value{money("15.6")}}, "15.60"},
+		// A value whose payload disagrees with the column's declared type falls
+		// back to its own rendering rather than to a zero of the declared type.
+		{"date payload in a string label", label, reporting.Cell{Values: []reporting.Value{reporting.DateVal(date)}}, "2026-05-15T00:00:00Z"},
+		{"string payload in a bool label", boolLabel, reporting.Cell{Values: []reporting.Value{reporting.Str("maybe")}}, "maybe"},
 		{"null measure is blank", currency, reporting.Cell{Values: []reporting.Value{reporting.Null()}}, ""},
 		{"null label is none", label, reporting.Cell{Values: []reporting.Value{reporting.Null()}}, "(None)"},
 		{"no values is blank", label, reporting.Cell{}, ""},
@@ -547,10 +556,12 @@ func TestFormatCell_ByTypeAndKind(t *testing.T) {
 }
 
 func TestFormatDimension_NullIsNoneLabel(t *testing.T) {
-	if got := formatDimension(reporting.Null(), "(None)"); got != "(None)" {
+	paidBy := Dimension{Key: "paid_by", Label: "Paid By", DataType: reporting.TypeString}
+
+	if got := formatDimension(reporting.Null(), paidBy, nil, "(None)"); got != "(None)" {
 		t.Errorf("null dimension = %q, want (None)", got)
 	}
-	if got := formatDimension(reporting.Str("Dana"), "(None)"); got != "Dana" {
+	if got := formatDimension(reporting.Str("Dana"), paidBy, nil, "(None)"); got != "Dana" {
 		t.Errorf("string dimension = %q, want Dana", got)
 	}
 }
@@ -632,8 +643,8 @@ func TestCSV_SubtotalsWithoutGrandTotal(t *testing.T) {
 	}
 }
 
-// A boolean grouping dimension renders its bucket value as true/false, with
-// false sorting before true.
+// A boolean grouping dimension renders its bucket value as Yes/No, with false
+// sorting before true.
 func TestCSV_BoolGroupDimension(t *testing.T) {
 	catalog := mustCatalog(t,
 		reporting.FieldRef{Key: "reimbursable", Label: "Reimbursable", DataType: reporting.TypeBool},
@@ -653,19 +664,21 @@ func TestCSV_BoolGroupDimension(t *testing.T) {
 		{"reimbursable": {reporting.Bool(true)}, "category": {reporting.Str("Food")}, "amount": {money("50")}},
 	}
 
-	got := mustCSV(t, mustRun(t, spec, catalog, rows), []Dimension{{Key: "reimbursable", Label: "Reimbursable"}})
+	got := mustCSV(t, mustRun(t, spec, catalog, rows),
+		[]Dimension{{Key: "reimbursable", Label: "Reimbursable", DataType: reporting.TypeBool}})
 	want := crlf(
 		"Row Type,Reimbursable,Category,Total",
-		"Detail,false,Food,100.00",
-		"Detail,true,Food,50.00",
+		"Detail,No,Food,100.00",
+		"Detail,Yes,Food,50.00",
 	)
 	if got != want {
 		t.Errorf("csv mismatch\n--- got ---\n%s\n--- want ---\n%s", got, want)
 	}
 }
 
-// A date grouping dimension renders its bucket as the instant in UTC (RFC 3339),
-// which sorts chronologically.
+// A date grouping dimension renders its bucket as the calendar day in UTC, the
+// same text the derived date-period fields carry. Buckets still sort by instant,
+// so the rows stay chronological.
 func TestCSV_DateGroupDimension(t *testing.T) {
 	catalog := mustCatalog(t,
 		reporting.FieldRef{Key: "date", Label: "Date", DataType: reporting.TypeDate},
@@ -685,11 +698,49 @@ func TestCSV_DateGroupDimension(t *testing.T) {
 		{"date": {reporting.DateVal(time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC))}, "category": {reporting.Str("Food")}, "amount": {money("100")}},
 	}
 
-	got := mustCSV(t, mustRun(t, spec, catalog, rows), []Dimension{{Key: "date", Label: "Date"}})
+	got := mustCSV(t, mustRun(t, spec, catalog, rows),
+		[]Dimension{{Key: "date", Label: "Date", DataType: reporting.TypeDate}})
 	want := crlf(
 		"Row Type,Date,Category,Total",
-		"Detail,2026-01-15T00:00:00Z,Food,100.00",
-		"Detail,2026-02-20T00:00:00Z,Food,50.00",
+		"Detail,2026-01-15,Food,100.00",
+		"Detail,2026-02-20,Food,50.00",
+	)
+	if got != want {
+		t.Errorf("csv mismatch\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+}
+
+// Grouping by a currency custom field is legal, and its buckets read as money —
+// per the report's currency configuration, exactly like an aggregate column.
+func TestCSV_CurrencyGroupDimension(t *testing.T) {
+	catalog := mustCatalog(t,
+		reporting.FieldRef{Key: "custom_1", Label: "HST", DataType: reporting.TypeCurrency},
+		reporting.FieldRef{Key: "category", Label: "Category", DataType: reporting.TypeString, Multi: true},
+		reporting.FieldRef{Key: "amount", Label: "Amount", DataType: reporting.TypeCurrency},
+	)
+	spec := reporting.ReportSpec{
+		GroupBy: []reporting.FieldKey{"custom_1"},
+		Detail:  reporting.DetailSpec{Mode: reporting.DetailAggregate, By: "category"},
+		Columns: []reporting.Column{
+			{Name: "Hst", Label: "HST", Kind: reporting.ColumnLabel, Field: "custom_1"},
+			{Name: "Total", Label: "Total", Kind: reporting.ColumnAggregate, AggSrc: "SUM(amount)"},
+		},
+	}
+	rows := []reporting.Row{
+		{"custom_1": {money("1500.5")}, "category": {reporting.Str("Food")}, "amount": {money("50")}},
+		{"custom_1": {money("2")}, "category": {reporting.Str("Food")}, "amount": {money("100")}},
+		{"category": {reporting.Str("Food")}, "amount": {money("10")}},
+	}
+
+	model := mustRun(t, spec, catalog, rows)
+	model.Meta.Currency = &reporting.CurrencyFormat{Symbol: "$", ThousandsSeparator: ",", DecimalSeparator: "."}
+
+	got := mustCSV(t, model, []Dimension{{Key: "custom_1", Label: "HST", DataType: reporting.TypeCurrency}})
+	want := crlf(
+		"Row Type,HST,HST,Total",
+		"Detail,$2.00,$2.00,$100.00",
+		`Detail,"$1,500.50","$1,500.50",$50.00`,
+		"Detail,(None),(None),$10.00",
 	)
 	if got != want {
 		t.Errorf("csv mismatch\n--- got ---\n%s\n--- want ---\n%s", got, want)

--- a/api/internal/reporting/render/html_test.go
+++ b/api/internal/reporting/render/html_test.go
@@ -589,3 +589,36 @@ func TestHTML_ChromeIsEscaped(t *testing.T) {
 		t.Errorf("unescaped markup leaked from chrome:\n%s", rendered)
 	}
 }
+
+// The live preview and the PDF share the faithful walk with XLSX, so a typed
+// dimension and a typed label column read the same in both: a boolean as Yes/No,
+// a date as its calendar day, and money per the report's currency configuration.
+func TestHTML_TypedDimensionsAndLabels(t *testing.T) {
+	due := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	spec := reporting.ReportSpec{
+		GroupBy: []reporting.FieldKey{"reimbursable", "custom_1"},
+		Detail:  reporting.DetailSpec{Mode: reporting.DetailAggregate, By: "due"},
+		Columns: []reporting.Column{
+			{Name: "Due", Label: "Due", Kind: reporting.ColumnLabel, Field: "due"},
+			{Name: "Hst", Label: "HST", Kind: reporting.ColumnLabel, Field: "custom_1"},
+			{Name: "Total", Label: "Total", Kind: reporting.ColumnAggregate, AggSrc: "SUM(custom_1)"},
+		},
+	}
+	rows := []reporting.Row{
+		{"reimbursable": {reporting.Bool(true)}, "due": {reporting.DateVal(due)}, "custom_1": {money("1500.5")}},
+		{"reimbursable": {reporting.Bool(false)}, "due": {reporting.DateVal(due)}, "custom_1": {money("2")}},
+	}
+
+	model := mustRun(t, spec, typedCatalog(t), rows)
+	model.Meta.Currency = &reporting.CurrencyFormat{Symbol: "$", ThousandsSeparator: ",", DecimalSeparator: "."}
+
+	grid := htmlGrid(t, model, []Dimension{
+		{Key: "reimbursable", Label: "Reimbursable", DataType: reporting.TypeBool},
+		{Key: "custom_1", Label: "HST", DataType: reporting.TypeCurrency},
+	})
+	assertGrid(t, grid, [][]string{
+		{"Reimbursable", "HST", "Due", "HST", "Total"},
+		{"No", "$2.00", "2026-06-01", "$2.00", "$2.00"},
+		{"Yes", "$1,500.50", "2026-06-01", "$1,500.50", "$1,500.50"},
+	})
+}

--- a/api/internal/reporting/render/value.go
+++ b/api/internal/reporting/render/value.go
@@ -1,0 +1,59 @@
+package render
+
+import "receipt-wrangler/api/internal/reporting"
+
+// dimensionDateLayout is how a date reads when it names a bucket or fills a
+// label column. It matches the derived date-period fields receiptsource emits
+// (receiptsource.setDateParts), so grouping by "Date" and grouping by
+// "Date (Day)" print the same text for the same day.
+const dimensionDateLayout = "2006-01-02"
+
+// formatLabelValue renders a value that names something — a group bucket, or a
+// label column's cell — as the text a reader sees.
+//
+// The engine emits raw typed values and leaves presentation to a renderer, so
+// without this a boolean prints "true", a date prints an RFC 3339 instant, and a
+// currency amount prints a bare decimal with no symbol. Which of those a value
+// is cannot be read off the value alone in every case, so the caller supplies
+// the field's declared data type. Dates are printed in UTC because the engine
+// emits date buckets in UTC; printing them in another zone would name a
+// different calendar day than the one the bucket was built from.
+//
+// The type is a declaration, not a guarantee: a producer may hand over a value
+// whose payload disagrees with it. Each branch therefore checks the payload and
+// falls through to the value's own rendering rather than substituting a zero.
+func formatLabelValue(
+	value reporting.Value,
+	dataType reporting.DataType,
+	currency *reporting.CurrencyFormat,
+	noneLabel string,
+) string {
+	if value.IsNull() {
+		return noneLabel
+	}
+
+	switch dataType {
+	case reporting.TypeBool:
+		if boolean, isBool := value.Boolean(); isBool {
+			if boolean {
+				return "Yes"
+			}
+			return "No"
+		}
+
+	case reporting.TypeDate:
+		if moment, isDate := value.Time(); isDate {
+			return moment.UTC().Format(dimensionDateLayout)
+		}
+
+	case reporting.TypeCurrency:
+		if number, isNumber := value.Decimal(); isNumber {
+			if currency != nil {
+				return formatCurrency(number, *currency)
+			}
+			return number.StringFixed(2)
+		}
+	}
+
+	return value.String()
+}

--- a/api/internal/reporting/render/walk.go
+++ b/api/internal/reporting/render/walk.go
@@ -82,6 +82,7 @@ func faithfulWalk(model reporting.ReportModel, groupBy []Dimension, sink faithfu
 
 	walker := &faithfulWalker{
 		model:     model,
+		groupBy:   groupBy,
 		numDims:   len(groupBy),
 		totalCols: len(groupBy) + len(model.Columns),
 		sink:      sink,
@@ -98,7 +99,10 @@ func faithfulWalk(model reporting.ReportModel, groupBy []Dimension, sink faithfu
 // faithfulWalker carries the walk's running state: the sink, the grid width, and
 // the previous detail row's group path for dimension blanking.
 type faithfulWalker struct {
-	model     reporting.ReportModel
+	model reporting.ReportModel
+	// groupBy carries each level's data type, which is what turns a bucket value
+	// into the text a reader expects rather than the engine's raw rendering.
+	groupBy   []Dimension
 	numDims   int
 	totalCols int
 	sink      faithfulSink
@@ -141,7 +145,10 @@ func (w *faithfulWalker) walk(node reporting.GroupNode, level int, path []report
 func (w *faithfulWalker) emitDetail(path []reporting.Value, cells []reporting.Cell) error {
 	row := make([]faithfulCell, w.totalCols)
 	for index := w.firstDiff(path); index < len(path); index++ {
-		row[index] = faithfulCell{kind: textCell, text: formatDimension(path[index], w.model.Meta.NoneLabel)}
+		row[index] = faithfulCell{
+			kind: textCell,
+			text: formatDimension(path[index], w.groupBy[index], w.model.Meta.Currency, w.model.Meta.NoneLabel),
+		}
 	}
 	for offset, descriptor := range w.model.Columns {
 		row[w.numDims+offset] = faithfulCell{kind: reportCell, descriptor: descriptor, cell: cells[offset]}

--- a/api/internal/reporting/render/xlsx.go
+++ b/api/internal/reporting/render/xlsx.go
@@ -100,7 +100,7 @@ func (s *xlsxSink) writeRow(kind rowKind, cells []faithfulCell) error {
 // left blank. bold styles the whole cell (subtotal/grand-total rows).
 func (s *xlsxSink) writeReportCell(column, row int, descriptor reporting.ColumnDescriptor, cell reporting.Cell, bold bool) error {
 	if descriptor.Kind == reporting.ColumnLabel {
-		return s.setString(column, row, joinLabel(cell, s.model.Meta.NoneLabel), bold)
+		return s.setString(column, row, joinLabel(cell, descriptor, s.model.Meta.Currency, s.model.Meta.NoneLabel), bold)
 	}
 
 	value := cell.Value()
@@ -192,19 +192,21 @@ func (s *xlsxSink) styleID(numberFormat string, bold bool) (int, error) {
 	return id, nil
 }
 
-// joinLabel renders a label cell: its values joined with commas, a null as the
-// report's (None) name, and no values (a subtotal's label column) as empty.
-func joinLabel(cell reporting.Cell, noneLabel string) string {
+// joinLabel renders a label cell: its values formatted per the column's declared
+// type and joined with commas, a null as the report's (None) name, and no values
+// (a subtotal's label column) as empty.
+//
+// A label column is always a string cell, even when it displays money — its
+// values name a bucket rather than measure one, and a comma-joined multi-value
+// label has no numeric reading at all. Aggregate columns are what carry native,
+// analyzable numbers into the workbook.
+func joinLabel(cell reporting.Cell, descriptor reporting.ColumnDescriptor, currency *reporting.CurrencyFormat, noneLabel string) string {
 	if len(cell.Values) == 0 {
 		return ""
 	}
 	parts := make([]string, 0, len(cell.Values))
 	for _, value := range cell.Values {
-		if value.IsNull() {
-			parts = append(parts, noneLabel)
-			continue
-		}
-		parts = append(parts, value.String())
+		parts = append(parts, formatLabelValue(value, descriptor.DataType, currency, noneLabel))
 	}
 	return strings.Join(parts, ", ")
 }

--- a/api/internal/reporting/render/xlsx_test.go
+++ b/api/internal/reporting/render/xlsx_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"reflect"
 	"testing"
+	"time"
 
 	"receipt-wrangler/api/internal/reporting"
 
@@ -98,6 +99,19 @@ func oneLevelRows() []reporting.Row {
 }
 
 func paidByDimension() []Dimension { return []Dimension{{Key: "paid_by", Label: "Paid By"}} }
+
+// typedCatalog is the fixture for the non-string dimensions: a boolean, a date,
+// and a currency custom field, each of which a report may group by.
+func typedCatalog(t *testing.T) reporting.FieldCatalog {
+	t.Helper()
+	return mustCatalog(t,
+		reporting.FieldRef{Key: "reimbursable", Label: "Reimbursable", DataType: reporting.TypeBool},
+		reporting.FieldRef{Key: "due", Label: "Due Date", DataType: reporting.TypeDate},
+		reporting.FieldRef{Key: "custom_1", Label: "HST", DataType: reporting.TypeCurrency},
+		reporting.FieldRef{Key: "category", Label: "Category", DataType: reporting.TypeString, Multi: true},
+		reporting.FieldRef{Key: "amount", Label: "Amount", DataType: reporting.TypeCurrency},
+	)
+}
 
 // --- headline: sums, aggregates, non-linear roll-up -----------------------
 
@@ -440,4 +454,65 @@ func TestXLSX_NativeTypesFormatsAndBold(t *testing.T) {
 	if isBold(cellStyle(t, file, "D2")) {
 		t.Error("detail D2 should not be bold")
 	}
+}
+
+// A dimension and a label column are presented by their declared type — a
+// boolean as Yes/No, a date as its calendar day, and money per the report's
+// currency configuration — rather than by the engine's raw rendering. Label
+// cells stay strings even when they hold money: they name a bucket, they do not
+// measure one.
+func TestXLSX_TypedDimensionsAndLabels(t *testing.T) {
+	due := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	spec := reporting.ReportSpec{
+		GroupBy: []reporting.FieldKey{"reimbursable"},
+		Detail:  reporting.DetailSpec{Mode: reporting.DetailAggregate, By: "due"},
+		Columns: []reporting.Column{
+			{Name: "Due", Label: "Due", Kind: reporting.ColumnLabel, Field: "due"},
+			{Name: "Reimbursable", Label: "Reimbursable", Kind: reporting.ColumnLabel, Field: "reimbursable"},
+			{Name: "Total", Label: "Total", Kind: reporting.ColumnAggregate, AggSrc: "SUM(custom_1)"},
+		},
+	}
+	rows := []reporting.Row{
+		{"reimbursable": {reporting.Bool(true)}, "due": {reporting.DateVal(due)}, "custom_1": {money("1500.5")}},
+		{"reimbursable": {reporting.Bool(false)}, "due": {reporting.DateVal(due)}, "custom_1": {money("2")}},
+	}
+
+	model := mustRun(t, spec, typedCatalog(t), rows)
+	model.Meta.Currency = &reporting.CurrencyFormat{Symbol: "$", ThousandsSeparator: ",", DecimalSeparator: "."}
+
+	grid := xlsxGrid(t, model, []Dimension{{Key: "reimbursable", Label: "Reimbursable", DataType: reporting.TypeBool}})
+	assertGrid(t, grid, [][]string{
+		{"Reimbursable", "Due", "Reimbursable", "Total"},
+		{"No", "2026-06-01", "No", "$2.00"},
+		{"Yes", "2026-06-01", "Yes", "$1,500.50"},
+	})
+}
+
+// Grouping by a currency field renders its buckets as money, and a receipt with
+// no value for it falls into the (None) bucket like any other dimension.
+func TestXLSX_CurrencyGroupDimension(t *testing.T) {
+	spec := reporting.ReportSpec{
+		GroupBy: []reporting.FieldKey{"custom_1"},
+		Detail:  reporting.DetailSpec{Mode: reporting.DetailAggregate, By: "category"},
+		Columns: []reporting.Column{
+			{Name: "Category", Label: "Category", Kind: reporting.ColumnLabel, Field: "category"},
+			{Name: "Total", Label: "Total", Kind: reporting.ColumnAggregate, AggSrc: "SUM(amount)"},
+		},
+	}
+	rows := []reporting.Row{
+		{"custom_1": {money("15.60")}, "category": {reporting.Str("Food")}, "amount": {money("100")}},
+		{"custom_1": {money("15.6")}, "category": {reporting.Str("Food")}, "amount": {money("50")}},
+		{"category": {reporting.Str("Gas")}, "amount": {money("10")}},
+	}
+
+	model := mustRun(t, spec, typedCatalog(t), rows)
+	model.Meta.Currency = &reporting.CurrencyFormat{Symbol: "$", ThousandsSeparator: ",", DecimalSeparator: "."}
+
+	grid := xlsxGrid(t, model, []Dimension{{Key: "custom_1", Label: "HST", DataType: reporting.TypeCurrency}})
+	assertGrid(t, grid, [][]string{
+		{"HST", "Category", "Total"},
+		// 15.60 and 15.6 are one bucket, so the two receipts sum together.
+		{"$15.60", "Food", "$150.00"},
+		{"(None)", "Gas", "$10.00"},
+	})
 }

--- a/api/internal/reporting/validate.go
+++ b/api/internal/reporting/validate.go
@@ -16,14 +16,12 @@ var (
 	ErrDuplicateColumn    = errors.New("duplicate column name")
 	ErrUnknownColumnKind  = errors.New("unknown column kind")
 
-	ErrUnknownField        = errors.New("field not found in catalog")
-	ErrGroupByNotDimension = errors.New("groupBy field is not a dimension")
-	ErrDuplicateGroupBy    = errors.New("duplicate groupBy field")
+	ErrUnknownField     = errors.New("field not found in catalog")
+	ErrDuplicateGroupBy = errors.New("duplicate groupBy field")
 
-	ErrUnknownDetailMode    = errors.New("unknown detail mode")
-	ErrDetailByRequired     = errors.New("aggregate detail mode requires a dimension")
-	ErrDetailByOnRecords    = errors.New("records detail mode must not set a dimension")
-	ErrDetailByNotDimension = errors.New("detail field is not a dimension")
+	ErrUnknownDetailMode = errors.New("unknown detail mode")
+	ErrDetailByRequired  = errors.New("aggregate detail mode requires a dimension")
+	ErrDetailByOnRecords = errors.New("records detail mode must not set a dimension")
 
 	ErrLabelFieldRequired      = errors.New("label column requires a field")
 	ErrLabelColumnUnresolvable = errors.New("label column has no value on an aggregated detail row")
@@ -168,6 +166,13 @@ func validateConfig(config EngineConfig) error {
 	return nil
 }
 
+// compileGroupBy resolves the grouping levels against the catalog.
+//
+// Any field may cut the data, including a numeric one: bucket keys are canonical
+// for decimals and compareValues orders them, so grouping by a currency field
+// buckets receipts by value the same way grouping by a category buckets them by
+// name. Only measuring is type-restricted (see compileAggregateColumn), which is
+// what makes a custom field of any kind a usable grouping level.
 func compileGroupBy(keys []FieldKey, catalog FieldCatalog) ([]FieldRef, error) {
 	seen := make(map[FieldKey]struct{}, len(keys))
 	refs := make([]FieldRef, 0, len(keys))
@@ -176,9 +181,6 @@ func compileGroupBy(keys []FieldKey, catalog FieldCatalog) ([]FieldRef, error) {
 		field, exists := catalog.Get(key)
 		if !exists {
 			return nil, fmt.Errorf("%w: groupBy %s", ErrUnknownField, key)
-		}
-		if field.Role() != RoleDimension {
-			return nil, fmt.Errorf("%w: %s is a %s", ErrGroupByNotDimension, key, field.DataType)
 		}
 		if _, duplicate := seen[key]; duplicate {
 			return nil, fmt.Errorf("%w: %s", ErrDuplicateGroupBy, key)
@@ -210,10 +212,6 @@ func compileDetail(detail DetailSpec, catalog FieldCatalog) (FieldRef, error) {
 	if !exists {
 		return FieldRef{}, fmt.Errorf("%w: detail %s", ErrUnknownField, detail.By)
 	}
-	if field.Role() != RoleDimension {
-		return FieldRef{}, fmt.Errorf("%w: %s is a %s", ErrDetailByNotDimension, detail.By, field.DataType)
-	}
-
 	return field, nil
 }
 

--- a/api/internal/reporting/validate_test.go
+++ b/api/internal/reporting/validate_test.go
@@ -143,6 +143,28 @@ func TestValidate_AcceptsVariations(t *testing.T) {
 			},
 		},
 		{
+			// A currency custom field is a measure, but measuring is the only
+			// thing its type restricts: it still cuts, so a report can group by
+			// a tax or tip field the same way it groups by a category.
+			name: "a measure may be grouped on and aggregated by",
+			spec: ReportSpec{
+				GroupBy: []FieldKey{"custom_1"},
+				Detail:  DetailSpec{Mode: DetailAggregate, By: "amount"},
+				Columns: []Column{
+					{Name: "Hst", Kind: ColumnLabel, Field: "custom_1"},
+					{Name: "Amount", Kind: ColumnLabel, Field: "amount"},
+					{Name: "Count", Kind: ColumnAggregate, Agg: Aggregate{Func: AggCount}},
+				},
+			},
+		},
+		{
+			name: "a date or boolean may be grouped on",
+			spec: ReportSpec{
+				GroupBy: []FieldKey{"date", "resolved"},
+				Columns: []Column{{Name: "Count", Kind: ColumnAggregate, Agg: Aggregate{Func: AggCount}}},
+			},
+		},
+		{
 			name: "COUNT is unaffected by multi-valued fields",
 			spec: ReportSpec{
 				GroupBy: []FieldKey{"category"},
@@ -253,12 +275,6 @@ func TestValidate_Rejects(t *testing.T) {
 			wantErr: ErrUnknownField,
 		},
 		{
-			// You cut by a tag; you sum a dollar amount.
-			name:    "groupBy a measure",
-			spec:    ReportSpec{GroupBy: []FieldKey{"amount"}, Columns: []Column{countColumn}},
-			wantErr: ErrGroupByNotDimension,
-		},
-		{
 			name:    "duplicate groupBy level",
 			spec:    ReportSpec{GroupBy: []FieldKey{"tag", "tag"}, Columns: []Column{countColumn}},
 			wantErr: ErrDuplicateGroupBy,
@@ -279,11 +295,6 @@ func TestValidate_Rejects(t *testing.T) {
 			name:    "aggregate detail on an unknown field",
 			spec:    ReportSpec{Detail: DetailSpec{Mode: DetailAggregate, By: "nope"}, Columns: []Column{countColumn}},
 			wantErr: ErrUnknownField,
-		},
-		{
-			name:    "aggregate detail on a measure",
-			spec:    ReportSpec{Detail: DetailSpec{Mode: DetailAggregate, By: "amount"}, Columns: []Column{countColumn}},
-			wantErr: ErrDetailByNotDimension,
 		},
 
 		// label columns

--- a/api/internal/services/report_service.go
+++ b/api/internal/services/report_service.go
@@ -506,15 +506,20 @@ func aggregateSource(aggFunc string, measure string) string {
 }
 
 // buildDimensions mirrors the spec's group-by into render dimensions, pulling each
-// heading label from the catalog.
+// heading label and data type from the catalog. The data type is what lets a
+// renderer present a bucket — a boolean as Yes/No, a date as a calendar day,
+// money per the report's currency configuration — instead of dumping the engine's
+// raw value. A key the catalog does not know falls back to the key as its own
+// heading and to plain text, which is what an unresolvable dimension can offer.
 func buildDimensions(groupBy []reporting.FieldKey, catalog reporting.FieldCatalog) []render.Dimension {
 	dimensions := make([]render.Dimension, len(groupBy))
 	for index, key := range groupBy {
-		label := string(key)
+		dimension := render.Dimension{Key: key, Label: string(key)}
 		if field, ok := catalog.Get(key); ok {
-			label = field.Label
+			dimension.Label = field.Label
+			dimension.DataType = field.DataType
 		}
-		dimensions[index] = render.Dimension{Key: key, Label: label}
+		dimensions[index] = dimension
 	}
 	return dimensions
 }

--- a/api/internal/services/report_service_test.go
+++ b/api/internal/services/report_service_test.go
@@ -14,6 +14,7 @@ import (
 	"receipt-wrangler/api/internal/models"
 	"receipt-wrangler/api/internal/permissions"
 	"receipt-wrangler/api/internal/reporting"
+	"receipt-wrangler/api/internal/reporting/render"
 	"receipt-wrangler/api/internal/repositories"
 )
 
@@ -239,6 +240,38 @@ func TestReportService_AggregateSource(t *testing.T) {
 		if got := aggregateSource(test.fn, test.measure); got != test.want {
 			t.Errorf("aggregateSource(%q,%q) = %q, want %q", test.fn, test.measure, got, test.want)
 		}
+	}
+}
+
+// A render dimension carries the catalog's label AND data type, which is what
+// lets a renderer present a bucket rather than dump it — a boolean as Yes/No, a
+// date as a calendar day, money per the report's currency configuration. A key
+// the catalog does not know falls back to itself as the heading, and to plain
+// text.
+func TestReportService_BuildDimensions(t *testing.T) {
+	catalog, err := reporting.NewFieldCatalog(
+		reporting.FieldRef{Key: "paid_by", Label: "Paid By", DataType: reporting.TypeString},
+		reporting.FieldRef{Key: "date", Label: "Date", DataType: reporting.TypeDate},
+		reporting.FieldRef{Key: "custom_1", Label: "HST", DataType: reporting.TypeCurrency},
+		reporting.FieldRef{Key: "custom_5", Label: "Reimbursed", DataType: reporting.TypeBool},
+	)
+	if err != nil {
+		t.Fatalf("NewFieldCatalog() error = %v", err)
+	}
+
+	got := buildDimensions(
+		[]reporting.FieldKey{"paid_by", "date", "custom_1", "custom_5", "gone"},
+		catalog,
+	)
+	want := []render.Dimension{
+		{Key: "paid_by", Label: "Paid By", DataType: reporting.TypeString},
+		{Key: "date", Label: "Date", DataType: reporting.TypeDate},
+		{Key: "custom_1", Label: "HST", DataType: reporting.TypeCurrency},
+		{Key: "custom_5", Label: "Reimbursed", DataType: reporting.TypeBool},
+		{Key: "gone", Label: "gone", DataType: reporting.TypeString},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("buildDimensions() = %+v, want %+v", got, want)
 	}
 }
 
@@ -486,11 +519,11 @@ func TestReportService_Generate_InvalidSpecIsClientError(t *testing.T) {
 	createReportReceipt(t, "household-1", userId, groupIds[0], nil)
 
 	command := aggregateReportCommand("Bad", groupIds, []string{commands.ReportFormatCsv})
-	command.GroupBy = []string{"amount"} // a measure cannot be grouped by
+	command.GroupBy = []string{"not_a_field"} // no such field in the catalog
 
 	_, err := NewReportService(nil).Generate(userId, command)
 	if err == nil {
-		t.Fatal("expected an error grouping by a measure, got none")
+		t.Fatal("expected an error grouping by an unknown field, got none")
 	}
 	var specErr *ReportSpecError
 	if !errors.As(err, &specErr) {
@@ -612,7 +645,7 @@ func TestReportService_Preview_InvalidSpecIsClientError(t *testing.T) {
 	createReportReceipt(t, "household-1", userId, groupIds[0], nil)
 
 	command := aggregateReportCommand("Bad", groupIds, nil)
-	command.GroupBy = []string{"amount"} // a measure cannot be grouped by
+	command.GroupBy = []string{"not_a_field"} // no such field in the catalog
 
 	_, err := NewReportService(nil).Preview(userId, command)
 	var specErr *ReportSpecError

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -1011,8 +1011,23 @@ endpoint); the builder's own ad-hoc generate still gates on `app.reports.generat
   generate/preview are one-shot calls through `ReportRunnerService` (mirrors `ReceiptExportService`:
   generate → `Blob` → `downloadFile`). `ReportCatalogService` supplies the dimension/measure dropdown
   options: a built-in engine-key→label constant (`report-catalog.constants.ts`) plus custom fields from
-  `CustomFieldService` (CURRENCY → measure, else dimension, keyed `custom_<id>`). `report-command.mapper.ts`
-  maps the form to the generated `ReportRequestCommand`.
+  `CustomFieldService`, keyed `custom_<id>`. `report-command.mapper.ts` maps the form to the generated
+  `ReportRequestCommand`.
+- **Custom fields in the catalog.** *Every* custom field is a **dimension** whatever its type — the
+  engine restricts measuring, not cutting — so a **CURRENCY** field appears in **both** lists (groupable
+  *and* summable), and a **DATE** field additionally contributes the three calendar-period dimensions the
+  backend derives (`custom_<id>_day|_month|_year`, labelled `"Due Date (Month)"`); grouping by the raw
+  date buckets on the exact instant, i.e. one bucket per receipt. Keys and labels mirror
+  `receiptsource.CustomFieldPeriodKeys` / `dateFieldRefs` — a mismatch is a 400 from the engine, not a
+  silent fallback. Every custom-field entry carries `isCustom: true`, which drives the **"Custom" badge**:
+  `toFieldOptions()` (the one mapping all four field dropdowns share) turns it into an option `badge`,
+  and the shared **`app-select` gained an optional `optionBadgeKey`** input that draws it beside the
+  option text. Because `MatOption.viewValue` is the option's `textContent`, a badged option would read
+  "HSTCustom" in the closed select — so a badged select also renders its own `<mat-select-trigger>`.
+  Both are opt-in and default off, so every other `app-select` call site is unchanged. The already-picked
+  grouping levels and column rows carry the same badge (`isCustom` on `groupByLevels()` / `columnRows()`,
+  resolved through the catalog rather than by matching the key's shape, so a user without
+  `app.custom-fields.read` sees no badge instead of one on a field the builder cannot name).
 - **Live preview** (`report-preview-panel`): the container debounces the form (~450ms, `switchMap`) into
   `POST /report/preview` and renders the engine's returned HTML in a **sandboxed `<iframe srcdoc>`**
   (`sandbox="allow-same-origin"`, scripts disabled; sized to content on load). The response's
@@ -1074,8 +1089,12 @@ endpoint); the builder's own ad-hoc generate still gates on `app.reports.generat
   (`BaseTableComponent` + `ReportTemplateTableService` + the NGXS `ReportTemplateTableState`, mirroring the
   groups/roles list pages) of saved templates. Columns Name (+ column count), Scope, Grouping, Detail,
   Formats, Updated — the JSON-blob-derived ones are non-sortable; only `name`/`updated_at` sort
-  server-side. The derived display strings come from a pure `report-template-summary.ts` util (group ids →
-  names via `GroupState.groupsWithoutAll`). Row actions carry `data-testid="report-template-<action>"` and
+  server-side. The derived display strings come from a pure `report-template-summary.ts` util, which takes
+  its lookups as arguments (group ids → names via `GroupState.groupsWithoutAll`; custom-field keys → names
+  via a `FieldLabelResolver` the page builds from `ReportCatalogService`, whose `load()` this page calls
+  too — otherwise a stored `custom_7` grouping renders as the raw key). An unresolvable key still falls
+  back to itself, which is what a user without `app.custom-fields.read` gets. The list shows names only;
+  the Custom badge is builder-only. Row actions carry `data-testid="report-template-<action>"` and
   gate on the matching permission: **generate** (`AppReportsGenerate`, runs the stored config through the
   builder's generate path), **open/edit** (read — routes to `/reports/:id/edit`), **duplicate**
   (`AppReportsDuplicate`), **delete** (`AppReportsDelete`, via `ConfirmationDialogComponent`). The header

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -1028,6 +1028,24 @@ endpoint); the builder's own ad-hoc generate still gates on `app.reports.generat
   grouping levels and column rows carry the same badge (`isCustom` on `groupByLevels()` / `columnRows()`,
   resolved through the catalog rather than by matching the key's shape, so a user without
   `app.custom-fields.read` sees no badge instead of one on a field the builder cannot name).
+  - **E2E:** `e2e/report-custom-fields.spec.ts` (serial, admin storageState) seeds its own group +
+    a CURRENCY/DATE/BOOLEAN field trio + four receipts through the admin API, so the live preview
+    contains exactly its own data, and covers: the grouping picker offering every custom field badged
+    (including the three derived `(Day|Month|Year)` levels), grouping by a **currency** field, a
+    boolean rendering **Yes/No**, a date field bucketing by **calendar month**, `SUM` over a custom
+    currency measure, and a saved template naming its fields rather than showing `custom_<id>`.
+    Teardown deletes the group (cascading the receipts, whose custom field values a field-delete would
+    otherwise orphan) then the fields — a leaked field shows up in every other spec's pickers.
+    Each assertion was verified to **FAIL** with its feature reverted (the renderer's typed
+    formatting, the catalog's currency-as-dimension + period entries, and the list's field-name
+    resolver).
+    - Two gotchas it encodes: the "Custom" badge is inside the `mat-option`, so an option's accessible
+      name reads `"Tip Custom"` — `addGroupingLevel` therefore takes a `string | RegExp` (a plain
+      string still matches exactly, which is what every other caller wants). And money is asserted
+      with a **separator-tolerant** regex (`/1[,. ]500[.,]50/`) rather than a symbol, because the
+      currency configuration is a global System Setting on the shared CI backend that this spec must
+      not mutate; the seeded value is `1500.50` precisely so the thousands separator and trailing
+      zero prove formatting ran.
 - **Live preview** (`report-preview-panel`): the container debounces the form (~450ms, `switchMap`) into
   `POST /report/preview` and renders the engine's returned HTML in a **sandboxed `<iframe srcdoc>`**
   (`sandbox="allow-same-origin"`, scripts disabled; sized to content on load). The response's

--- a/desktop/e2e/helpers/provisioning.ts
+++ b/desktop/e2e/helpers/provisioning.ts
@@ -326,10 +326,30 @@ export async function apiGroupNames(api: APIRequestContext): Promise<string[]> {
   return groups.map((group) => group.name);
 }
 
+/**
+ * One custom field value on a receipt. Exactly one of the typed columns is
+ * populated, chosen by the field's own type — a currency field reads
+ * currencyValue, a date field dateValue, and so on (the server stores whatever
+ * it is given, so a mismatched column simply resolves to no value in a report).
+ */
+export interface ReceiptCustomFieldValue {
+  customFieldId: number;
+  stringValue?: string;
+  dateValue?: string;
+  selectValue?: number;
+  currencyValue?: string;
+  booleanValue?: boolean;
+}
+
 /** Creates a minimal OPEN receipt and returns its id. */
 export async function apiCreateReceipt(
   api: APIRequestContext,
-  opts: { groupId: number | string; paidByUserId: number; name: string },
+  opts: {
+    groupId: number | string;
+    paidByUserId: number;
+    name: string;
+    customFields?: ReceiptCustomFieldValue[];
+  },
 ): Promise<number> {
   const res = await api.post('/api/receipt', {
     data: {
@@ -339,6 +359,7 @@ export async function apiCreateReceipt(
       groupId: Number(opts.groupId),
       paidByUserId: opts.paidByUserId,
       status: 'OPEN',
+      ...(opts.customFields ? { customFields: opts.customFields } : {}),
     },
   });
   if (!res.ok()) {
@@ -464,7 +485,18 @@ export async function apiFirstReportCategory(
  */
 export async function apiCreateReportTemplate(
   api: APIRequestContext,
-  opts?: { name?: string; groupIds?: string[]; formats?: string[]; filter?: unknown },
+  opts?: {
+    name?: string;
+    groupIds?: string[];
+    formats?: string[];
+    filter?: unknown;
+    // The shape of the report itself. Defaulted to the records-mode config every
+    // caller wanted before; override to store a grouped/aggregated template, e.g.
+    // one grouped by a custom field's `custom_<id>` key.
+    groupBy?: string[];
+    detail?: { mode: 'records' | 'aggregate'; by?: string };
+    columns?: unknown[];
+  },
 ): Promise<{ id: number; name: string }> {
   const name = opts?.name ?? uniqueName('report-template');
   // Scope a real group the caller can report on, so generating over it isn't
@@ -475,9 +507,12 @@ export async function apiCreateReportTemplate(
       name,
       groupIds,
       period: { preset: 'this_month' },
-      detail: { mode: 'records' },
-      columns: [{ kind: 'dimension', name: 'Name', label: 'Name', field: 'name' }],
+      detail: opts?.detail ?? { mode: 'records' },
+      columns: opts?.columns ?? [
+        { kind: 'dimension', name: 'Name', label: 'Name', field: 'name' },
+      ],
       formats: opts?.formats ?? ['csv'],
+      ...(opts?.groupBy ? { groupBy: opts.groupBy } : {}),
       ...(opts?.filter ? { filter: opts.filter } : {}),
     },
   });
@@ -627,6 +662,46 @@ export async function apiDeleteTagById(
   id: number,
 ): Promise<void> {
   await warnOnFailedDelete(api, `/api/tag/${id}`, `tag ${id}`);
+}
+
+// --- Custom fields -----------------------------------------------------------
+//
+// Like categories and tags the pool is GLOBAL, so mint uniqueName-suffixed fields
+// and delete them in teardown — a leaked one shows up in every other spec's
+// pickers. There is no update endpoint, and deleting a field destroys every value
+// stored against it, so a spec that seeds receipts with values must delete those
+// receipts (or their group) too.
+
+export type CustomFieldType = 'TEXT' | 'DATE' | 'SELECT' | 'CURRENCY' | 'BOOLEAN';
+
+/** Creates a custom field and returns its id + name. */
+export async function apiCreateCustomField(
+  api: APIRequestContext,
+  opts: { name: string; type: CustomFieldType; options?: string[] },
+): Promise<{ id: number; name: string }> {
+  const res = await api.post('/api/customField/', {
+    data: {
+      name: opts.name,
+      type: opts.type,
+      description: '',
+      options: (opts.options ?? []).map((value) => ({ value })),
+    },
+  });
+  if (!res.ok()) {
+    throw new Error(
+      `create custom field failed: HTTP ${res.status()} ${await res.text()}`,
+    );
+  }
+  const customField = (await res.json()) as { id: number; name: string };
+  return { id: customField.id, name: customField.name };
+}
+
+/** Deletes a custom field. Requires app.custom-fields.delete (admin-only). */
+export async function apiDeleteCustomFieldById(
+  api: APIRequestContext,
+  id: number,
+): Promise<void> {
+  await warnOnFailedDelete(api, `/api/customField/${id}`, `custom field ${id}`);
 }
 
 // --- Per-member category/tag grants ------------------------------------------

--- a/desktop/e2e/helpers/provisioning.ts
+++ b/desktop/e2e/helpers/provisioning.ts
@@ -186,13 +186,22 @@ export async function createUserWithRole(
   const password = dialog.getByLabel('Password', { exact: true });
   await expect(password).toBeVisible();
 
-  await dialog.getByLabel('Username').fill(opts.username);
-  await dialog.getByLabel('Displayname').fill(opts.username);
-  await password.fill(opts.password);
-  // Fail here, with the actual values, rather than later on an unexplained
-  // "dialog never closed".
-  await expect(dialog.getByLabel('Username')).toHaveValue(opts.username);
-  await expect(password).toHaveValue(opts.password);
+  // Waiting for the password field narrows that race but does not close it — a
+  // fill can still land in a neighbouring input while the dialog settles, and
+  // because Username and Displayname carry the SAME value the damage reads as a
+  // doubled username ("<name><name>") rather than as an obvious mis-type. So
+  // fill and verify as one retryable unit: a misdirected round re-fills from
+  // scratch instead of failing the whole spec's beforeAll. Same idiom as
+  // openComboboxAndPick in helpers/reports.ts.
+  await expect(async () => {
+    await dialog.getByLabel('Username').fill(opts.username);
+    await dialog.getByLabel('Displayname').fill(opts.username);
+    await password.fill(opts.password);
+
+    await expect(dialog.getByLabel('Username')).toHaveValue(opts.username, { timeout: 2000 });
+    await expect(dialog.getByLabel('Displayname')).toHaveValue(opts.username, { timeout: 2000 });
+    await expect(password).toHaveValue(opts.password, { timeout: 2000 });
+  }).toPass({ timeout: 15_000 });
   await dialog.getByRole('combobox', { name: 'App Role' }).click();
   // The option panel is a floating overlay rendered on the page, not the dialog.
   await page.getByRole('option', { name: opts.role, exact: true }).click();

--- a/desktop/e2e/helpers/reports.ts
+++ b/desktop/e2e/helpers/reports.ts
@@ -63,9 +63,16 @@ export function waitForPreview(page: Page) {
  * Add a grouping level via the "Add grouping level…" picker and settle the
  * resulting debounced preview before returning, so a following pick on the same
  * (re-rendering) select doesn't race the refresh.
+ *
+ * A string matches the option's accessible name exactly. Pass a RegExp for a
+ * custom field: its "Custom" badge lives inside the option, so the accessible
+ * name reads "Tip Custom" and an exact-string match would never resolve.
  */
-export async function addGroupingLevel(page: Page, label: string): Promise<void> {
+export async function addGroupingLevel(page: Page, label: string | RegExp): Promise<void> {
   const combobox = page.getByRole('combobox', { name: /Add grouping level/ });
-  const option = page.getByRole('option', { name: label, exact: true });
+  const option =
+    typeof label === 'string'
+      ? page.getByRole('option', { name: label, exact: true })
+      : page.getByRole('option', { name: label });
   await Promise.all([waitForPreview(page), openComboboxAndPick(page, combobox, option)]);
 }

--- a/desktop/e2e/report-custom-fields.spec.ts
+++ b/desktop/e2e/report-custom-fields.spec.ts
@@ -1,0 +1,281 @@
+import { expect, Page, test } from '@playwright/test';
+import { creds, stubTokenRefresh } from './helpers/auth';
+import {
+  apiCreateCustomField,
+  apiCreateGroup,
+  apiCreateReceipt,
+  apiCreateReportTemplate,
+  apiDeleteCustomFieldById,
+  apiDeleteGroupById,
+  apiDeleteReportTemplateById,
+  apiGetUserId,
+  uniqueName,
+  withAdminApi,
+} from './helpers/provisioning';
+import {
+  addGroupingLevel,
+  addGroupToScopeByName,
+  gotoReportBuilder,
+  gotoReports,
+  openComboboxAndPick,
+  waitForPreview,
+} from './helpers/reports';
+
+// The builder is gated by app.reports.read, and creating/deleting custom fields
+// needs app.custom-fields.create/.delete — all Legacy Admin.
+test.use({ storageState: 'e2e/.auth/admin.json' });
+
+// Serial: every test shares one seeded group + custom-field pool, and the pool is
+// global, so running them concurrently would multiply the seeding.
+test.describe.configure({ mode: 'serial' });
+
+/**
+ * Custom fields in the Report Builder: a field of ANY type can be grouped by, a
+ * currency one can also be aggregated, a date one offers derived calendar-period
+ * levels, and every one is badged "Custom".
+ *
+ * The spec seeds its own group so the live preview contains exactly these four
+ * receipts — the assertions are about rendered bucket text, which shared data
+ * would make non-deterministic. Deleting the group cascades the receipts, which
+ * matters because deleting a custom field destroys every value stored against it.
+ */
+test.describe('Report Builder — custom fields', () => {
+  const groupName = uniqueName('cf-report-grp');
+  const tipName = uniqueName('Tip');
+  const dueName = uniqueName('Due');
+  const reimbursedName = uniqueName('Reimbursed');
+
+  let groupId: number;
+  let tipId: number;
+  let dueId: number;
+  let reimbursedId: number;
+  let templateId: number;
+
+  test.beforeAll(async () => {
+    await withAdminApi(async (api) => {
+      const adminId = await apiGetUserId(api, creds('admin').username);
+      groupId = (await apiCreateGroup(api, groupName)).id;
+
+      tipId = (await apiCreateCustomField(api, { name: tipName, type: 'CURRENCY' })).id;
+      dueId = (await apiCreateCustomField(api, { name: dueName, type: 'DATE' })).id;
+      reimbursedId = (await apiCreateCustomField(api, { name: reimbursedName, type: 'BOOLEAN' })).id;
+
+      // 1500.50 and 1500.5 are the same amount written two ways: they must land in
+      // ONE bucket (bucket keys are canonical decimals). The fourth receipt carries
+      // no custom field values at all, which is the (None) bucket.
+      const receipts: { name: string; tip?: string; due?: string; reimbursed?: boolean }[] = [
+        { name: 'cf-a', tip: '1500.50', due: '2024-03-15T00:00:00Z', reimbursed: true },
+        { name: 'cf-b', tip: '1500.5', due: '2024-03-20T00:00:00Z', reimbursed: false },
+        { name: 'cf-c', tip: '2.00', due: '2024-04-05T00:00:00Z', reimbursed: true },
+        { name: 'cf-none' },
+      ];
+
+      for (const receipt of receipts) {
+        const customFields = [];
+        if (receipt.tip !== undefined) {
+          customFields.push({ customFieldId: tipId, currencyValue: receipt.tip });
+        }
+        if (receipt.due !== undefined) {
+          customFields.push({ customFieldId: dueId, dateValue: receipt.due });
+        }
+        if (receipt.reimbursed !== undefined) {
+          customFields.push({ customFieldId: reimbursedId, booleanValue: receipt.reimbursed });
+        }
+        await apiCreateReceipt(api, {
+          groupId,
+          paidByUserId: adminId,
+          name: uniqueName(receipt.name),
+          customFields,
+        });
+      }
+    });
+  });
+
+  // Each id is checked because a seeding failure leaves the later ones unassigned,
+  // and deleting `undefined` turns one real error into a wall of cleanup noise.
+  test.afterAll(async () => {
+    try {
+      await withAdminApi(async (api) => {
+        if (templateId) {
+          await apiDeleteReportTemplateById(api, templateId);
+        }
+        // The group takes its receipts (and their custom field values) with it, so
+        // the fields are safe to drop afterwards.
+        if (groupId) {
+          await apiDeleteGroupById(api, String(groupId));
+        }
+        for (const id of [tipId, dueId, reimbursedId]) {
+          if (id) {
+            await apiDeleteCustomFieldById(api, id);
+          }
+        }
+      });
+    } catch {
+      // Best-effort cleanup — don't mask a test failure with a cleanup error.
+    }
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await stubTokenRefresh(page);
+  });
+
+  /**
+   * Open the builder on the seeded group over a window that contains the receipts
+   * (they are dated 2024-01-01), so nothing depends on the wall clock.
+   */
+  async function openBuilderOnSeededData(page: Page): Promise<void> {
+    await gotoReportBuilder(page);
+    await addGroupToScopeByName(page, groupName);
+
+    await openComboboxAndPick(
+      page,
+      page.getByRole('combobox', { name: /Period covering/ }),
+      page.getByRole('option', { name: /Custom range/ }),
+    );
+    await page.getByLabel('Start', { exact: true }).fill('01/01/2023');
+    await page.getByLabel('End', { exact: true }).fill('12/31/2024');
+    await page.getByLabel('End', { exact: true }).blur();
+
+    await expect(page.getByTestId('report-receipt-count')).toContainText('4 receipts', {
+      timeout: 20_000,
+    });
+  }
+
+  /** The preview is server-rendered HTML in an iframe; assert against its srcdoc. */
+  function preview(page: Page) {
+    return page.getByTitle('Report preview');
+  }
+
+  test('offers every custom field in the grouping picker, badged', async ({ page }) => {
+    await openBuilderOnSeededData(page);
+
+    await page.getByRole('combobox', { name: /Add grouping level/ }).click();
+
+    // Every type is groupable — a CURRENCY field is a measure, but measuring is the
+    // only thing its type restricts.
+    for (const name of [tipName, dueName, reimbursedName]) {
+      await expect(page.getByRole('option', { name: new RegExp(`^${name} Custom$`) })).toBeVisible();
+    }
+
+    // A DATE field also contributes the derived calendar-period levels.
+    for (const period of ['Day', 'Month', 'Year']) {
+      await expect(
+        page.getByRole('option', { name: new RegExp(`^${dueName} \\(${period}\\) Custom$`) }),
+      ).toBeVisible();
+    }
+
+    // The badge marks custom fields only — a built-in carries none.
+    await expect(page.getByRole('option', { name: 'Paid By', exact: true })).toBeVisible();
+  });
+
+  test('groups by a currency custom field and formats its buckets as money', async ({ page }) => {
+    await openBuilderOnSeededData(page);
+    await addGroupingLevel(page, new RegExp(`^${tipName} Custom$`));
+
+    // The picked level keeps the badge, so a custom field stays identifiable after
+    // it has been chosen.
+    await expect(page.getByTestId('report-grouping-label')).toHaveText([tipName]);
+    await expect(page.getByTestId('report-grouping-custom')).toHaveCount(1);
+
+    // Money is formatted per the app's currency configuration, whose symbol and
+    // separators are global settings this spec must not mutate — so assert the
+    // thousands separator and the two decimal places rather than a symbol. The
+    // engine's raw rendering of 1500.5 has neither, so this fails if the
+    // type-aware formatting regresses.
+    await expect(preview(page)).toHaveAttribute('srcdoc', /1[,. ]500[.,]50/, { timeout: 20_000 });
+    await expect(preview(page)).toHaveAttribute('srcdoc', /2[.,]00/);
+    // A receipt carrying no value for the field is its own bucket, never dropped.
+    await expect(preview(page)).toHaveAttribute('srcdoc', /\(None\)/);
+  });
+
+  test('renders a boolean custom field as Yes/No', async ({ page }) => {
+    await openBuilderOnSeededData(page);
+    await addGroupingLevel(page, new RegExp(`^${reimbursedName} Custom$`));
+
+    // Assert through the retrying matcher first: the preview is debounced, so a
+    // plain getAttribute can still be holding the pre-grouping render.
+    await expect(preview(page)).toHaveAttribute('srcdoc', />\s*Yes\s*</, { timeout: 20_000 });
+    await expect(preview(page)).toHaveAttribute('srcdoc', />\s*No\s*</);
+    await expect(preview(page)).toHaveAttribute('srcdoc', /\(None\)/);
+
+    // The grouped preview is on screen now, so one read is safe for the negatives —
+    // and they must be one-shot: a `not.toHaveAttribute` would pass simply by
+    // catching a stale render that hasn't got there yet.
+    const srcdoc = await preview(page).getAttribute('srcdoc');
+    expect(srcdoc).not.toMatch(/>\s*true\s*</);
+    expect(srcdoc).not.toMatch(/>\s*false\s*</);
+  });
+
+  test('buckets a date custom field by calendar month', async ({ page }) => {
+    await openBuilderOnSeededData(page);
+    await addGroupingLevel(page, new RegExp(`^${dueName} \\(Month\\) Custom$`));
+
+    // Two receipts fall in March and one in April, so grouping by the derived month
+    // yields three buckets — not the one-per-receipt the raw instant would give.
+    await expect(preview(page)).toHaveAttribute('srcdoc', /2024-03/, { timeout: 20_000 });
+    await expect(preview(page)).toHaveAttribute('srcdoc', /2024-04/);
+    await expect(preview(page)).toHaveAttribute('srcdoc', /\(None\)/);
+
+    // The raw timestamp never reaches the reader (see above on one-shot negatives).
+    const srcdoc = await preview(page).getAttribute('srcdoc');
+    expect(srcdoc).not.toContain('2024-03-15T');
+  });
+
+  test('aggregates a custom currency field as a measure', async ({ page }) => {
+    await openBuilderOnSeededData(page);
+
+    await page.getByTestId('report-add-column').click();
+    await page.getByTestId('picker-kind-aggregate').click();
+
+    // A currency custom field is offered as a measure, badged there too.
+    const measure = page.getByRole('combobox', { name: 'Measure' });
+    const tipOption = page.getByRole('option', { name: new RegExp(`^${tipName} Custom$`) });
+    await openComboboxAndPick(page, measure, tipOption);
+
+    await Promise.all([waitForPreview(page), page.getByTestId('picker-save').click()]);
+
+    // The column row carries the Custom badge because the measure it reads is custom.
+    const column = page.getByTestId('report-column-row').filter({ hasText: tipName });
+    await expect(column).toBeVisible();
+    await expect(column.getByTestId('report-column-custom')).toBeVisible();
+
+    // 1500.50 + 1500.50 + 2.00, with the fourth receipt contributing nothing.
+    await expect(preview(page)).toHaveAttribute('srcdoc', /3[,. ]003[.,]00/, { timeout: 20_000 });
+  });
+
+  test('a saved template names its custom fields and reopens badged', async ({ page }) => {
+    const templateName = uniqueName('cf-template');
+    await withAdminApi(async (api) => {
+      templateId = (
+        await apiCreateReportTemplate(api, {
+          name: templateName,
+          groupIds: [String(groupId)],
+          groupBy: [`custom_${dueId}_month`],
+          detail: { mode: 'aggregate', by: `custom_${reimbursedId}` },
+          columns: [
+            {
+              kind: 'dimension',
+              name: 'Reimbursed',
+              label: 'Reimbursed',
+              field: `custom_${reimbursedId}`,
+            },
+          ],
+        })
+      ).id;
+    });
+
+    await gotoReports(page);
+    const row = page.getByRole('row').filter({ hasText: templateName });
+
+    // The list resolves custom_<id> to the field's name; the raw key never shows.
+    await expect(row).toContainText(`${dueName} (Month)`);
+    await expect(row).toContainText(`Aggregate by ${reimbursedName}`);
+    await expect(row).not.toContainText(`custom_${dueId}`);
+
+    // Reopening rehydrates the grouping level, still marked custom.
+    await row.getByTestId('report-template-edit').click();
+    await page.waitForURL(/\/reports\/\d+\/edit/);
+    await expect(page.getByTestId('report-grouping-label')).toHaveText([`${dueName} (Month)`]);
+    await expect(page.getByTestId('report-grouping-custom')).toHaveCount(1);
+  });
+});

--- a/desktop/src/reports/dialogs/column-picker-dialog/column-picker-dialog.component.html
+++ b/desktop/src/reports/dialogs/column-picker-dialog/column-picker-dialog.component.html
@@ -32,7 +32,7 @@
     }
 
     @case ("dim") {
-      <app-select label="Field" optionValueKey="value" optionDisplayKey="displayValue"
+      <app-select label="Field" optionValueKey="value" optionDisplayKey="displayValue" optionBadgeKey="badge"
         [options]="dimensionOptions" [inputFormControl]="pickerForm | formGet: 'field'"></app-select>
       <app-input label="Column label" [inputFormControl]="pickerForm | formGet: 'label'"></app-input>
     }
@@ -46,7 +46,7 @@
         }
       </div>
       @if (aggregateNeedsMeasure) {
-        <app-select label="Measure" optionValueKey="value" optionDisplayKey="displayValue"
+        <app-select label="Measure" optionValueKey="value" optionDisplayKey="displayValue" optionBadgeKey="badge"
           [options]="measureOptions" [inputFormControl]="pickerForm | formGet: 'measure'"></app-select>
       }
       <app-input label="Column label" [inputFormControl]="pickerForm | formGet: 'label'"></app-input>

--- a/desktop/src/reports/dialogs/column-picker-dialog/column-picker-dialog.component.spec.ts
+++ b/desktop/src/reports/dialogs/column-picker-dialog/column-picker-dialog.component.spec.ts
@@ -42,8 +42,77 @@ const formulaData: ColumnPickerDialogData = {
   ],
 };
 
+// The same picker over a catalog that includes custom fields. A currency custom
+// field is both a dimension and a measure, so it appears in both lists.
+const customFieldData: ColumnPickerDialogData = {
+  dimensions: [
+    { key: "category", label: "Category" },
+    { key: "custom_7", label: "HST", isCustom: true },
+    { key: "custom_8", label: "Vendor", isCustom: true },
+  ],
+  measures: [
+    { key: "amount", label: "Amount" },
+    { key: "custom_7", label: "HST", isCustom: true },
+  ],
+  existingColumns: [],
+};
+
 describe("ColumnPickerDialogComponent", () => {
   afterEach(() => TestBed.resetTestingModule());
+
+  it("badges custom fields in the field and measure pickers", async () => {
+    const { fixture, component } = configure(customFieldData);
+    await fixture.whenStable();
+
+    const dimensions = new Map(component.dimensionOptions.map((o) => [o.value, o.badge]));
+    expect(dimensions.get("custom_7")).toBe("Custom");
+    expect(dimensions.get("custom_8")).toBe("Custom");
+    expect(dimensions.get("category")).toBe("");
+
+    const measures = new Map(component.measureOptions.map((o) => [o.value, o.badge]));
+    expect(measures.get("custom_7")).toBe("Custom");
+    expect(measures.get("amount")).toBe("");
+  });
+
+  it("saves an aggregate over a custom currency measure", async () => {
+    const { fixture, component, close } = configure(customFieldData);
+    await fixture.whenStable();
+
+    component.pickAggregate();
+    await fixture.whenStable();
+    component.selectFunction(ReportColumn.AggFuncEnum.Sum);
+    component.pickerForm.get("measure")!.setValue("custom_7");
+    await fixture.whenStable();
+
+    // The label is suggested from the custom field's name.
+    expect(component.pickerForm.get("label")!.value).toContain("HST");
+    component.save();
+
+    expect(close).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: ReportColumn.KindEnum.Aggregate,
+        aggFunc: ReportColumn.AggFuncEnum.Sum,
+        measure: "custom_7",
+      })
+    );
+  });
+
+  it("saves a dimension column over a custom field", async () => {
+    const { fixture, component, close } = configure(customFieldData);
+    await fixture.whenStable();
+
+    component.pickDimension();
+    await fixture.whenStable();
+    component.pickerForm.get("field")!.setValue("custom_8");
+    await fixture.whenStable();
+
+    expect(component.pickerForm.get("label")!.value).toBe("Vendor");
+    component.save();
+
+    expect(close).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: ReportColumn.KindEnum.Dimension, field: "custom_8" })
+    );
+  });
 
   it("opens on the kind step and cannot save yet", async () => {
     const { fixture, component } = configure(baseData);

--- a/desktop/src/reports/dialogs/column-picker-dialog/column-picker-dialog.component.ts
+++ b/desktop/src/reports/dialogs/column-picker-dialog/column-picker-dialog.component.ts
@@ -11,7 +11,12 @@ import { FormBuilder, FormGroup } from "@angular/forms";
 import { MAT_DIALOG_DATA, MatDialogRef } from "@angular/material/dialog";
 import { startWith } from "rxjs";
 import { ReportColumn } from "../../../open-api";
-import { aggregateNeedsMeasure, ReportField } from "../../models/report-catalog.constants";
+import {
+  aggregateNeedsMeasure,
+  ReportField,
+  ReportFieldOption,
+  toFieldOptions,
+} from "../../models/report-catalog.constants";
 import { ReportColumnValue } from "../../models/report-command.mapper";
 import { deriveColumnName, validateFormulaExpr } from "../../models/report-column.util";
 import { nextReportRowId } from "../../models/report-form.factory";
@@ -71,8 +76,8 @@ export class ColumnPickerDialogComponent {
 
   public readonly dimensions: ReportField[];
   public readonly measures: ReportField[];
-  public readonly dimensionOptions: { value: string; displayValue: string }[];
-  public readonly measureOptions: { value: string; displayValue: string }[];
+  public readonly dimensionOptions: ReportFieldOption[];
+  public readonly measureOptions: ReportFieldOption[];
   public readonly referenceableColumns: ReportColumnValue[];
 
   private readonly availableNames: string[];
@@ -120,8 +125,8 @@ export class ColumnPickerDialogComponent {
   constructor(@Inject(MAT_DIALOG_DATA) data: ColumnPickerDialogData) {
     this.dimensions = data.dimensions;
     this.measures = data.measures;
-    this.dimensionOptions = data.dimensions.map((field) => ({ value: field.key, displayValue: field.label }));
-    this.measureOptions = data.measures.map((field) => ({ value: field.key, displayValue: field.label }));
+    this.dimensionOptions = toFieldOptions(data.dimensions);
+    this.measureOptions = toFieldOptions(data.measures);
     this.referenceableColumns = data.existingColumns.filter(
       (column) => column.kind !== ReportColumn.KindEnum.Dimension
     );

--- a/desktop/src/reports/models/report-catalog.constants.ts
+++ b/desktop/src/reports/models/report-catalog.constants.ts
@@ -3,11 +3,36 @@ import { ReportColumn, ReportPeriod } from "../../open-api";
 /**
  * A selectable engine field: `key` is the reporting engine's field key (what the
  * backend `receiptsource` catalog exposes), `label` is what the builder shows.
- * Custom fields are added at runtime keyed `custom_<id>` (see ReportCatalogService).
+ * Custom fields are added at runtime keyed `custom_<id>` (see ReportCatalogService)
+ * and carry `isCustom`, which is what puts the "Custom" badge on them.
  */
 export interface ReportField {
   key: string;
   label: string;
+  isCustom?: boolean;
+}
+
+/** The badge text marking a custom field wherever the builder lists fields. */
+export const CUSTOM_FIELD_BADGE = "Custom";
+
+/** An app-select option built from a field: value/display plus an optional badge. */
+export interface ReportFieldOption {
+  value: string;
+  displayValue: string;
+  badge: string;
+}
+
+/**
+ * Maps fields onto the option shape every field dropdown binds to, so the
+ * grouping picker, the aggregate-by picker and the column picker's field/measure
+ * pickers cannot drift in how they present a custom field.
+ */
+export function toFieldOptions(fields: ReportField[]): ReportFieldOption[] {
+  return fields.map((field) => ({
+    value: field.key,
+    displayValue: field.label,
+    badge: field.isCustom ? CUSTOM_FIELD_BADGE : "",
+  }));
 }
 
 /**

--- a/desktop/src/reports/models/report-template-summary.spec.ts
+++ b/desktop/src/reports/models/report-template-summary.spec.ts
@@ -32,6 +32,16 @@ describe("report-template-summary", () => {
     expect(fieldLabel(undefined)).toBe("");
   });
 
+  it("resolves custom field keys through the caller's resolver", () => {
+    const resolve = (key: string) => (key === "custom_42" ? "Due Date" : undefined);
+
+    expect(fieldLabel("custom_42", resolve)).toBe("Due Date");
+    // A resolver that doesn't know the key still falls back to the raw key.
+    expect(fieldLabel("custom_99", resolve)).toBe("custom_99");
+    // A built-in never consults the resolver.
+    expect(fieldLabel("category", () => "Wrong")).toBe("Category");
+  });
+
   it("counts columns", () => {
     expect(columnCount(command({ columns: [] }))).toBe(0);
     expect(
@@ -49,6 +59,17 @@ describe("report-template-summary", () => {
   it("summarizes grouping levels or reports none", () => {
     expect(groupingSummary(command({ groupBy: [] }))).toBe("No grouping");
     expect(groupingSummary(command({ groupBy: ["group", "category"] }))).toBe("Group, Category");
+  });
+
+  it("names custom fields in the grouping and detail summaries", () => {
+    const resolve = (key: string) => ({ custom_42: "Due Date", custom_7: "HST" })[key];
+
+    expect(groupingSummary(command({ groupBy: ["group", "custom_42"] }), resolve)).toBe(
+      "Group, Due Date"
+    );
+    expect(
+      detailSummary(command({ detail: { mode: ReportDetail.ModeEnum.Aggregate, by: "custom_7" } }), resolve)
+    ).toBe("Aggregate by HST");
   });
 
   it("summarizes the detail mode", () => {

--- a/desktop/src/reports/models/report-template-summary.ts
+++ b/desktop/src/reports/models/report-template-summary.ts
@@ -2,15 +2,28 @@ import { ReportDetail, ReportRequestCommand } from "../../open-api";
 import { REPORT_BUILTIN_DIMENSIONS, REPORT_FORMATS } from "./report-catalog.constants";
 
 // Field-key -> label for the built-in dimensions the list renders. Custom-field
-// grouping keys (custom_<id>) aren't in this map and fall back to the raw key.
+// keys (custom_<id>) are only resolvable against the loaded custom-field pool, so
+// callers that have it pass a resolver.
 const DIMENSION_LABELS = new Map(REPORT_BUILTIN_DIMENSIONS.map((d) => [d.key, d.label]));
 
-/** The human label for an engine field key, or the raw key when it isn't a built-in. */
-export function fieldLabel(key: string | undefined): string {
+/**
+ * Resolves a field key the built-in map doesn't cover — a custom field's
+ * `custom_<id>`. Returning undefined means "I don't know it", which falls back to
+ * the raw key.
+ */
+export type FieldLabelResolver = (key: string) => string | undefined;
+
+/**
+ * The human label for an engine field key: a built-in's name, else whatever the
+ * caller's resolver knows, else the raw key. The raw-key fallback is what a
+ * caller without the custom-field pool (no resolver, or no permission to read it)
+ * gets, so a row still renders something rather than nothing.
+ */
+export function fieldLabel(key: string | undefined, resolve?: FieldLabelResolver): string {
   if (!key) {
     return "";
   }
-  return DIMENSION_LABELS.get(key) ?? key;
+  return DIMENSION_LABELS.get(key) ?? resolve?.(key) ?? key;
 }
 
 /** How many columns the stored report defines. */
@@ -19,18 +32,24 @@ export function columnCount(configuration: ReportRequestCommand): number {
 }
 
 /** The grouping levels as a readable label list, or a "no grouping" hint. */
-export function groupingSummary(configuration: ReportRequestCommand): string {
+export function groupingSummary(
+  configuration: ReportRequestCommand,
+  resolve?: FieldLabelResolver
+): string {
   const groupBy = configuration.groupBy ?? [];
   if (groupBy.length === 0) {
     return "No grouping";
   }
-  return groupBy.map(fieldLabel).join(", ");
+  return groupBy.map((key) => fieldLabel(key, resolve)).join(", ");
 }
 
 /** Whether the report aggregates (and by what) or lists individual receipts. */
-export function detailSummary(configuration: ReportRequestCommand): string {
+export function detailSummary(
+  configuration: ReportRequestCommand,
+  resolve?: FieldLabelResolver
+): string {
   if (configuration.detail?.mode === ReportDetail.ModeEnum.Aggregate) {
-    return `Aggregate by ${fieldLabel(configuration.detail.by)}`;
+    return `Aggregate by ${fieldLabel(configuration.detail.by, resolve)}`;
   }
   return "Record-level";
 }

--- a/desktop/src/reports/report-config-panel/report-config-panel.component.html
+++ b/desktop/src/reports/report-config-panel/report-config-panel.component.html
@@ -52,6 +52,10 @@
     <div class="report-config__list-row">
       <span class="report-config__pos">{{ level.index + 1 }}</span>
       <span class="report-config__list-label" data-testid="report-grouping-label">{{ level.label }}</span>
+      @if (level.isCustom) {
+        <span class="report-config__kind-badge report-config__custom-badge"
+          data-testid="report-grouping-custom">{{ customFieldBadge }}</span>
+      }
       <app-button matButtonType="iconButton" icon="arrow_upward" tooltip="Move up" [disabled]="level.isFirst"
         (clicked)="moveGroupBy(level.index, -1)" data-testid="report-grouping-up"></app-button>
       <app-button matButtonType="iconButton" icon="arrow_downward" tooltip="Move down" [disabled]="level.isLast"
@@ -62,8 +66,8 @@
   }
   @if (addableDimensions().length > 0) {
     <app-select class="report-config__add-select" label="Add grouping level…" [addEmptyOption]="true"
-      optionValueKey="key" optionDisplayKey="label"
-      [options]="addableDimensions()" [inputFormControl]="addGroupControl"
+      optionValueKey="value" optionDisplayKey="displayValue" optionBadgeKey="badge"
+      [options]="addableDimensionOptions()" [inputFormControl]="addGroupControl"
       data-testid="report-add-grouping"></app-select>
   }
 </app-report-section>
@@ -86,7 +90,7 @@
     <div class="report-config__row report-config__row--center">
       <span class="report-config__inline-label">aggregate by</span>
       <app-select class="report-config__grow"
-        optionValueKey="value" optionDisplayKey="displayValue"
+        optionValueKey="value" optionDisplayKey="displayValue" optionBadgeKey="badge"
         [options]="dimensionOptions()"
         [inputFormControl]="form() | formGet: 'detail.by'"
       ></app-select>
@@ -112,6 +116,10 @@
           <div class="report-config__col-label">{{ column.label }}</div>
           <div class="report-config__col-desc">{{ column.disabled ? column.disabledReason : column.description }}</div>
         </div>
+        @if (column.isCustom) {
+          <span class="report-config__kind-badge report-config__custom-badge"
+            data-testid="report-column-custom">{{ customFieldBadge }}</span>
+        }
         <span class="report-config__kind-badge" [ngClass]="column.kindClass">{{ column.kindLabel }}</span>
         <app-button matButtonType="iconButton" icon="arrow_upward" tooltip="Move up" [disabled]="column.isFirst"
           (clicked)="moveColumn(column.index, -1)" data-testid="report-column-up"></app-button>

--- a/desktop/src/reports/report-config-panel/report-config-panel.component.scss
+++ b/desktop/src/reports/report-config-panel/report-config-panel.component.scss
@@ -277,6 +277,13 @@
     flex: none;
   }
 
+  // Marks a grouping level or column that reads a custom field, so a custom field
+  // stays identifiable after it has been picked — not only in the dropdown.
+  &__custom-badge {
+    color: #7c5cd6;
+    background: rgba(124, 92, 214, 0.13);
+  }
+
   &__col-text {
     flex: 1;
     min-width: 0;

--- a/desktop/src/reports/report-config-panel/report-config-panel.component.scss
+++ b/desktop/src/reports/report-config-panel/report-config-panel.component.scss
@@ -279,8 +279,12 @@
 
   // Marks a grouping level or column that reads a custom field, so a custom field
   // stays identifiable after it has been picked — not only in the dropdown.
+  // #5b3fae rather than a lighter purple: the badge is 9.5px/700, which is small
+  // text under WCAG, so it needs 4.5:1 against its own COMPOSITED background —
+  // the translucent fill over the row (#f8fafc) resolves to #e4e2f2, where the
+  // lighter purple managed only 3.90:1. This pairing is 5.95:1.
   &__custom-badge {
-    color: #7c5cd6;
+    color: #5b3fae;
     background: rgba(124, 92, 214, 0.13);
   }
 

--- a/desktop/src/reports/report-config-panel/report-config-panel.component.spec.ts
+++ b/desktop/src/reports/report-config-panel/report-config-panel.component.spec.ts
@@ -4,8 +4,15 @@ import { FormArray, FormBuilder, FormGroup } from "@angular/forms";
 import { MatDialog } from "@angular/material/dialog";
 import { Store } from "@ngxs/store";
 import { of } from "rxjs";
-import { CustomFieldService, ReportColumn, ReportDetail, ReportPeriod } from "../../open-api";
+import {
+  CustomFieldService,
+  CustomFieldType,
+  ReportColumn,
+  ReportDetail,
+  ReportPeriod,
+} from "../../open-api";
 import { buildColumnGroup } from "../models/report-form.factory";
+import { ReportCatalogService } from "../services/report-catalog.service";
 import { ReportConfigPanelComponent } from "./report-config-panel.component";
 
 const GROUPS = [
@@ -39,9 +46,11 @@ describe("ReportConfigPanelComponent", () => {
   let form: FormGroup;
   let formBuilder: FormBuilder;
   let dialog: { open: jest.Mock };
+  let customFieldService: { getPagedCustomFields: jest.Mock };
 
   beforeEach(async () => {
     dialog = { open: jest.fn() };
+    customFieldService = { getPagedCustomFields: jest.fn(() => of({ data: [], totalCount: 0 })) };
 
     await TestBed.configureTestingModule({
       declarations: [ReportConfigPanelComponent],
@@ -50,7 +59,7 @@ describe("ReportConfigPanelComponent", () => {
         FormBuilder,
         { provide: Store, useValue: { selectSignal: () => signal(GROUPS) } },
         { provide: MatDialog, useValue: dialog },
-        { provide: CustomFieldService, useValue: { getPagedCustomFields: jest.fn(() => of({ data: [], totalCount: 0 })) } },
+        { provide: CustomFieldService, useValue: customFieldService },
       ],
       schemas: [NO_ERRORS_SCHEMA],
     })
@@ -138,6 +147,88 @@ describe("ReportConfigPanelComponent", () => {
   it("addGroupBy ignores an empty key", () => {
     component.addGroupBy("");
     expect(component.groupByLevels().length).toBe(0);
+  });
+
+  // ---- custom fields ------------------------------------------------------
+
+  /** Loads a custom-field pool into the catalog the component is already bound to. */
+  function loadCustomFields(): void {
+    customFieldService.getPagedCustomFields.mockReturnValue(
+      of({
+        data: [
+          { id: 7, name: "HST", type: CustomFieldType.Currency },
+          { id: 8, name: "Vendor", type: CustomFieldType.Text },
+        ],
+        totalCount: 2,
+      })
+    );
+    TestBed.inject(ReportCatalogService).load();
+  }
+
+  // A currency custom field is a measure, but measuring is the only thing its type
+  // restricts — it is groupable too.
+  it("offers a currency custom field as a grouping level and as a measure", () => {
+    loadCustomFields();
+
+    expect(component.addableDimensions().map((field) => field.key)).toContain("custom_7");
+    expect(component.measures().map((field) => field.key)).toContain("custom_7");
+
+    component.addGroupBy("custom_7");
+    expect(component.groupByLevels().map((level) => level.label)).toEqual(["HST"]);
+  });
+
+  it("flags grouping levels and columns that read a custom field", () => {
+    loadCustomFields();
+
+    component.addGroupBy("custom_8");
+    component.addGroupBy("paid_by");
+    expect(component.groupByLevels().map((level) => level.isCustom)).toEqual([true, false]);
+
+    columnsArray().push(
+      buildColumnGroup(formBuilder, {
+        kind: ReportColumn.KindEnum.Dimension,
+        name: "Vendor",
+        label: "Vendor",
+        field: "custom_8",
+      })
+    );
+    columnsArray().push(
+      buildColumnGroup(formBuilder, {
+        kind: ReportColumn.KindEnum.Aggregate,
+        name: "Hst",
+        label: "HST",
+        aggFunc: ReportColumn.AggFuncEnum.Sum,
+        measure: "custom_7",
+      })
+    );
+    columnsArray().push(
+      buildColumnGroup(formBuilder, {
+        kind: ReportColumn.KindEnum.Aggregate,
+        name: "Total",
+        label: "Total",
+        aggFunc: ReportColumn.AggFuncEnum.Sum,
+        measure: "amount",
+      })
+    );
+    form.get("detail.by")!.setValue("custom_8");
+
+    const byLabel = new Map(component.columnRows().map((row) => [row.label, row.isCustom]));
+    expect(byLabel.get("Vendor")).toBe(true);
+    expect(byLabel.get("HST")).toBe(true);
+    expect(byLabel.get("Total")).toBe(false);
+  });
+
+  it("badges custom fields in the dropdown options", () => {
+    loadCustomFields();
+
+    const options = new Map(
+      component.addableDimensionOptions().map((option) => [option.value, option.badge])
+    );
+    expect(options.get("custom_7")).toBe("Custom");
+    expect(options.get("category")).toBe("");
+    expect(
+      component.dimensionOptions().find((option) => option.value === "custom_8")?.badge
+    ).toBe("Custom");
   });
 
   // ---- detail mode -------------------------------------------------------

--- a/desktop/src/reports/report-config-panel/report-config-panel.component.ts
+++ b/desktop/src/reports/report-config-panel/report-config-panel.component.ts
@@ -17,9 +17,11 @@ import { DEFAULT_DIALOG_CONFIG } from "src/constants/dialog.constant";
 import { GroupState } from "src/store";
 import { ReportColumn, ReportDetail, ReportPeriod } from "../../open-api";
 import {
+  CUSTOM_FIELD_BADGE,
   REPORT_DOCUMENT_VARIABLES,
   REPORT_PERIOD_PRESETS,
   ReportField,
+  toFieldOptions,
 } from "../models/report-catalog.constants";
 import { CHIP_COLORS, groupInitials } from "../models/report-chip.util";
 import { isDimensionColumnDisabled, ReportColumnValue } from "../models/report-command.mapper";
@@ -45,6 +47,7 @@ interface ScopeChip {
 interface GroupByLevel {
   index: number;
   label: string;
+  isCustom: boolean;
   isFirst: boolean;
   isLast: boolean;
 }
@@ -57,6 +60,7 @@ interface ColumnRow {
   kindLabel: string;
   kindIcon: string;
   kindClass: string;
+  isCustom: boolean;
   isFirst: boolean;
   isLast: boolean;
   disabled: boolean;
@@ -104,6 +108,7 @@ export class ReportConfigPanelComponent implements OnInit {
     displayValue: preset.label,
   }));
   public readonly documentVariables = REPORT_DOCUMENT_VARIABLES;
+  public readonly customFieldBadge = CUSTOM_FIELD_BADGE;
   public readonly ReportPeriodPreset = ReportPeriod.PresetEnum;
   public readonly ReportDetailMode = ReportDetail.ModeEnum;
 
@@ -112,9 +117,9 @@ export class ReportConfigPanelComponent implements OnInit {
   // into addGroupBy and is reset to the blank option afterward.
   public readonly addGroupControl = new FormControl<string | null>(null);
 
-  public readonly dimensionOptions = computed(() =>
-    this.dimensions().map((field) => ({ value: field.key, displayValue: field.label }))
-  );
+  public readonly dimensionOptions = computed(() => toFieldOptions(this.dimensions()));
+
+  public readonly addableDimensionOptions = computed(() => toFieldOptions(this.addableDimensions()));
 
   public readonly scopeChips = computed<ScopeChip[]>(() => {
     this.revision();
@@ -133,6 +138,7 @@ export class ReportConfigPanelComponent implements OnInit {
     return controls.map((control, index) => ({
       index,
       label: this.labelForField(control.value as string),
+      isCustom: this.isCustomField(control.value as string),
       isFirst: index === 0,
       isLast: index === controls.length - 1,
     }));
@@ -162,6 +168,7 @@ export class ReportConfigPanelComponent implements OnInit {
         kindLabel: meta.label,
         kindIcon: meta.icon,
         kindClass: meta.cssClass,
+        isCustom: this.columnReadsACustomField(value),
         isFirst: index === 0,
         isLast: index === controls.length - 1,
         disabled,
@@ -329,6 +336,30 @@ export class ReportConfigPanelComponent implements OnInit {
 
   private labelForField(key: string): string {
     return this.dimensions().find((field) => field.key === key)?.label ?? key;
+  }
+
+  /**
+   * Whether a field key names a custom field. Resolved through the catalog rather
+   * than by matching the key's shape, so a user who cannot read the custom-field
+   * pool (the catalog swallows that 403) sees no badge instead of a badge on a
+   * field the builder cannot even name.
+   */
+  private isCustomField(key: string): boolean {
+    const field =
+      this.dimensions().find((candidate) => candidate.key === key) ??
+      this.measures().find((candidate) => candidate.key === key);
+    return field?.isCustom === true;
+  }
+
+  /** A column is custom when the field it reads is — a dimension's or an aggregate's measure. */
+  private columnReadsACustomField(column: ReportColumnValue): boolean {
+    if (column.kind === ReportColumn.KindEnum.Dimension) {
+      return this.isCustomField(column.field ?? "");
+    }
+    if (column.kind === ReportColumn.KindEnum.Aggregate) {
+      return this.isCustomField(column.measure ?? "");
+    }
+    return false;
   }
 
   private describeColumn(column: ReportColumnValue): string {

--- a/desktop/src/reports/report-template-list/report-template-list.component.spec.ts
+++ b/desktop/src/reports/report-template-list/report-template-list.component.spec.ts
@@ -6,6 +6,8 @@ import { Router } from "@angular/router";
 import { Store } from "@ngxs/store";
 import { of, Subject, throwError } from "rxjs";
 import {
+  CustomFieldService,
+  CustomFieldType,
   Permission,
   ReportColumn,
   ReportDetail,
@@ -103,6 +105,18 @@ describe("ReportTemplateListComponent", () => {
         { provide: Router, useValue: router },
         { provide: SnackbarService, useValue: snackbar },
         { provide: MatDialog, useValue: matDialog },
+        // The Grouping/Detail columns name custom fields out of this pool.
+        {
+          provide: CustomFieldService,
+          useValue: {
+            getPagedCustomFields: jest.fn(() =>
+              of({
+                data: [{ id: 7, name: "Due Date", type: CustomFieldType.Date }],
+                totalCount: 1,
+              })
+            ),
+          },
+        },
       ],
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
@@ -248,6 +262,31 @@ describe("ReportTemplateListComponent", () => {
     expect(component.formatChipsFor(templates[0])).toEqual(["CSV", "PDF"]);
     expect(component.detailSummaryFor(templates[0])).toBe("Record-level");
     expect(component.groupingSummaryFor(templates[0])).toBe("Group");
+  });
+
+  // A stored config references a custom field by key; the list resolves it to the
+  // field's name so a row does not read "custom_7".
+  it("names custom fields in the grouping and detail summaries", () => {
+    const custom: ReportTemplate = {
+      ...templates[0],
+      configuration: {
+        ...templates[0].configuration,
+        groupBy: ["group", "custom_7_month"],
+        detail: { mode: ReportDetail.ModeEnum.Aggregate, by: "custom_7" },
+      },
+    };
+
+    expect(component.groupingSummaryFor(custom)).toBe("Group, Due Date (Month)");
+    expect(component.detailSummaryFor(custom)).toBe("Aggregate by Due Date");
+  });
+
+  it("falls back to the raw key for a custom field the catalog cannot name", () => {
+    const missing: ReportTemplate = {
+      ...templates[0],
+      configuration: { ...templates[0].configuration, groupBy: ["custom_999"] },
+    };
+
+    expect(component.groupingSummaryFor(missing)).toBe("custom_999");
   });
 
   it("summarizes scope by group count (unresolved groups fall back to the raw id)", () => {

--- a/desktop/src/reports/report-template-list/report-template-list.component.ts
+++ b/desktop/src/reports/report-template-list/report-template-list.component.ts
@@ -28,6 +28,7 @@ import {
   groupingSummary,
   scopeNames,
 } from "../models/report-template-summary";
+import { ReportCatalogService } from "../services/report-catalog.service";
 import { ReportRunnerService } from "../services/report-runner.service";
 import { ReportTemplateTableService } from "./report-template-table.service";
 
@@ -52,6 +53,7 @@ export class ReportTemplateListComponent extends BaseTableComponent<ReportTempla
   private readonly matDialog = inject(MatDialog);
   private readonly snackbar = inject(SnackbarService);
   private readonly runner = inject(ReportRunnerService);
+  private readonly catalog = inject(ReportCatalogService);
   private readonly destroyRef = inject(DestroyRef);
 
   private readonly nameCell = viewChild.required<TemplateRef<any>>("nameCell");
@@ -91,6 +93,11 @@ export class ReportTemplateListComponent extends BaseTableComponent<ReportTempla
   }
 
   public ngAfterViewInit(): void {
+    // A stored config references custom fields by key (custom_<id>), so the pool has
+    // to be loaded for the Grouping/Detail columns to name them rather than print the
+    // raw key. The catalog loads once per session and swallows a 403, so a user
+    // without app.custom-fields.read simply keeps the raw key.
+    this.catalog.load();
     this.setColumns();
     this.getTableData();
   }
@@ -151,11 +158,23 @@ export class ReportTemplateListComponent extends BaseTableComponent<ReportTempla
   }
 
   public groupingSummaryFor(template: ReportTemplate): string {
-    return groupingSummary(template.configuration);
+    return groupingSummary(template.configuration, (key) => this.customFieldLabel(key));
   }
 
   public detailSummaryFor(template: ReportTemplate): string {
-    return detailSummary(template.configuration);
+    return detailSummary(template.configuration, (key) => this.customFieldLabel(key));
+  }
+
+  /**
+   * A custom field's name for its engine key. Both catalog lists are searched
+   * because a currency custom field is a measure as well as a dimension, and a
+   * stored `detail.by` may name either.
+   */
+  private customFieldLabel(key: string): string | undefined {
+    const field =
+      this.catalog.dimensions().find((candidate) => candidate.key === key) ??
+      this.catalog.measures().find((candidate) => candidate.key === key);
+    return field?.label;
   }
 
   public formatChipsFor(template: ReportTemplate): string[] {

--- a/desktop/src/reports/services/report-catalog.service.spec.ts
+++ b/desktop/src/reports/services/report-catalog.service.spec.ts
@@ -25,7 +25,62 @@ describe("ReportCatalogService", () => {
     expect(service.measures().map((field) => field.key)).toEqual(["amount"]);
   });
 
-  it("adds currency custom fields as measures and other kinds as dimensions", () => {
+  // Every custom field cuts, so a currency one is a dimension AND a measure; only
+  // measuring is type-restricted.
+  it("adds every custom field as a dimension and currency ones as measures too", () => {
+    customFieldService.getPagedCustomFields.mockReturnValue(
+      of({
+        data: [
+          { id: 7, name: "HST", type: CustomFieldType.Currency },
+          { id: 8, name: "Vendor", type: CustomFieldType.Text },
+          { id: 9, name: "Reimbursed", type: CustomFieldType.Boolean },
+        ],
+        totalCount: 3,
+      })
+    );
+
+    service.load();
+
+    expect(service.measures().find((field) => field.key === "custom_7")?.label).toBe("HST");
+    expect(service.dimensions().find((field) => field.key === "custom_7")?.label).toBe("HST");
+    expect(service.dimensions().find((field) => field.key === "custom_8")?.label).toBe("Vendor");
+    expect(service.dimensions().find((field) => field.key === "custom_9")?.label).toBe("Reimbursed");
+    expect(service.measures().some((field) => field.key === "custom_8")).toBe(false);
+  });
+
+  it("marks custom fields so the builder can badge them", () => {
+    customFieldService.getPagedCustomFields.mockReturnValue(
+      of({ data: [{ id: 7, name: "HST", type: CustomFieldType.Currency }], totalCount: 1 })
+    );
+
+    service.load();
+
+    expect(service.dimensions().find((field) => field.key === "custom_7")?.isCustom).toBe(true);
+    expect(service.measures().find((field) => field.key === "custom_7")?.isCustom).toBe(true);
+    expect(service.dimensions().find((field) => field.key === "category")?.isCustom).toBeUndefined();
+  });
+
+  // Grouping by a raw date buckets on the exact instant (one bucket per receipt), so
+  // a date custom field also offers the calendar-period fields the backend derives.
+  it("offers day/month/year dimensions for a date custom field", () => {
+    customFieldService.getPagedCustomFields.mockReturnValue(
+      of({ data: [{ id: 4, name: "Due Date", type: CustomFieldType.Date }], totalCount: 1 })
+    );
+
+    service.load();
+
+    const keys = service.dimensions().map((field) => field.key);
+    expect(keys).toEqual(
+      expect.arrayContaining(["custom_4", "custom_4_day", "custom_4_month", "custom_4_year"])
+    );
+    expect(service.dimensions().find((field) => field.key === "custom_4_month")?.label).toBe(
+      "Due Date (Month)"
+    );
+    // Period fields are dimensions only — there is nothing to sum in a calendar month.
+    expect(service.measures().some((field) => field.key.startsWith("custom_4"))).toBe(false);
+  });
+
+  it("derives period fields only for date custom fields", () => {
     customFieldService.getPagedCustomFields.mockReturnValue(
       of({
         data: [
@@ -38,9 +93,9 @@ describe("ReportCatalogService", () => {
 
     service.load();
 
-    expect(service.measures().find((field) => field.key === "custom_7")?.label).toBe("HST");
-    expect(service.dimensions().find((field) => field.key === "custom_8")?.label).toBe("Vendor");
-    expect(service.measures().some((field) => field.key === "custom_8")).toBe(false);
+    expect(service.dimensions().some((field) => field.key.endsWith("_month"))).toBe(true); // date_month, a built-in
+    expect(service.dimensions().some((field) => field.key === "custom_7_month")).toBe(false);
+    expect(service.dimensions().some((field) => field.key === "custom_8_month")).toBe(false);
   });
 
   it("keeps only the built-ins when the custom-field lookup fails", () => {

--- a/desktop/src/reports/services/report-catalog.service.ts
+++ b/desktop/src/reports/services/report-catalog.service.ts
@@ -9,10 +9,16 @@ import {
 
 /**
  * Supplies the dimension and measure catalog the builder's dropdowns bind to: the
- * built-in engine fields plus every custom field (currency custom fields become
- * measures, all other kinds become dimensions), keyed `custom_<id>` to match the
+ * built-in engine fields plus every custom field, keyed `custom_<id>` to match the
  * backend. The backend validates every field key, so this is the picker's option
  * source, not the authorization gate.
+ *
+ * Every custom field is a dimension, whatever its type — the engine restricts
+ * measuring, not cutting, so a currency field is groupable as well as summable and
+ * appears in *both* lists. A date field additionally contributes the three
+ * calendar-period fields the backend derives for it (`custom_<id>_month` and
+ * friends): grouping by the raw date buckets on the exact instant, which puts
+ * every receipt in its own group.
  */
 @Injectable({ providedIn: "root" })
 export class ReportCatalogService {
@@ -22,9 +28,7 @@ export class ReportCatalogService {
 
   public readonly dimensions = computed<ReportField[]>(() => [
     ...REPORT_BUILTIN_DIMENSIONS,
-    ...this.customFields()
-      .filter((field) => field.type !== CustomFieldType.Currency)
-      .map(customFieldToField),
+    ...this.customFields().flatMap(customFieldDimensions),
   ]);
 
   public readonly measures = computed<ReportField[]>(() => [
@@ -56,5 +60,24 @@ export class ReportCatalogService {
 }
 
 function customFieldToField(field: CustomField): ReportField {
-  return { key: "custom_" + field.id, label: field.name };
+  return { key: "custom_" + field.id, label: field.name, isCustom: true };
+}
+
+/**
+ * The dimensions one custom field offers: itself, plus — for a date field — the
+ * day/month/year fields the backend derives from it. The keys and labels mirror
+ * `receiptsource.CustomFieldPeriodKeys` / `dateFieldRefs`; a mismatch here is a
+ * 400 from the engine, not a silent fallback.
+ */
+function customFieldDimensions(field: CustomField): ReportField[] {
+  const self = customFieldToField(field);
+  if (field.type !== CustomFieldType.Date) {
+    return [self];
+  }
+  return [
+    self,
+    { key: self.key + "_day", label: field.name + " (Day)", isCustom: true },
+    { key: self.key + "_month", label: field.name + " (Month)", isCustom: true },
+    { key: self.key + "_year", label: field.name + " (Year)", isCustom: true },
+  ];
 }

--- a/desktop/src/select/select/select.component.html
+++ b/desktop/src/select/select/select.component.html
@@ -12,12 +12,34 @@
       (blur)="inputBlur.emit($event)"
       readonly
     >
+      <!--
+        A badged option's text content would otherwise leak into the closed
+        select, which renders the selected option's textContent, so a badged
+        select draws its own trigger. Without optionBadgeKey the trigger is
+        omitted and mat-select's default is used, unchanged.
+      -->
+      @if (optionBadgeKey()) {
+        <mat-select-trigger>
+          @let selected = selectedIndex();
+          @if (selected >= 0) {
+            {{ selected | optionDisplay : options()[selected] : optionDisplayKey() : optionsDisplayArray() }}
+            @let selectedBadge = badgeFor(options()[selected]);
+            @if (selectedBadge) {
+              <span class="select__badge">{{ selectedBadge }}</span>
+            }
+          }
+        </mat-select-trigger>
+      }
       <mat-option *ngIf="addEmptyOption()" [value]="null"></mat-option>
       <mat-option
         *ngFor="let option of options(); let i = index"
         [value]="optionValueKey ? option[optionValueKey] : option"
       >
         {{ i | optionDisplay : option : optionDisplayKey() : optionsDisplayArray() }}
+        @let badge = badgeFor(option);
+        @if (badge) {
+          <span class="select__badge">{{ badge }}</span>
+        }
       </mat-option>
     </mat-select>
   }

--- a/desktop/src/select/select/select.component.scss
+++ b/desktop/src/select/select/select.component.scss
@@ -11,6 +11,9 @@
   text-transform: uppercase;
   border-radius: 5px;
   padding: 2px 6px;
-  color: #64748b;
+  // Same WCAG reasoning as the report config panel's badge: 9.5px/700 is small
+  // text, so it needs 4.5:1 against the composited fill (#e2e4e7 over white).
+  // The lighter slate was 3.90:1; this is 5.95:1.
+  color: #475569;
   background: rgba(100, 116, 139, 0.16);
 }

--- a/desktop/src/select/select/select.component.scss
+++ b/desktop/src/select/select/select.component.scss
@@ -1,0 +1,16 @@
+// The optional per-option badge (app-select's optionBadgeKey). It marks what an
+// option is — a custom field in the report builder's field pickers — so it sits
+// beside the option text and in the trigger, never replacing either.
+.select__badge {
+  display: inline-block;
+  margin-left: 6px;
+  vertical-align: middle;
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  border-radius: 5px;
+  padding: 2px 6px;
+  color: #64748b;
+  background: rgba(100, 116, 139, 0.16);
+}

--- a/desktop/src/select/select/select.component.spec.ts
+++ b/desktop/src/select/select/select.component.spec.ts
@@ -62,6 +62,26 @@ describe('SelectComponent', () => {
     expect(component.selectedIndex()).toBe(-1);
   });
 
+  // Without an optionValueKey the control holds the option OBJECT itself, so the
+  // match is by reference — the other half of selectedIndex()'s branch.
+  it('resolves the selection by identity when there is no value key', () => {
+    component.inputFormControl = new FormControl(options[1]);
+    component.optionValueKey = '';
+    fixture.componentRef.setInput('options', options);
+    fixture.componentRef.setInput('optionDisplayKey', 'displayValue');
+    fixture.componentRef.setInput('optionBadgeKey', 'badge');
+
+    expect(component.selectedIndex()).toBe(1);
+
+    // An equal-looking copy is a different reference, so it does not match —
+    // which is the same rule mat-select itself applies without a compareWith.
+    component.inputFormControl.setValue({ ...options[1] });
+    expect(component.selectedIndex()).toBe(-1);
+
+    component.inputFormControl.setValue('nope');
+    expect(component.selectedIndex()).toBe(-1);
+  });
+
   // The closed select renders the selected option's text content, so a badged
   // option would otherwise read "HSTCustom". A badged select draws its own
   // trigger to keep the two apart.

--- a/desktop/src/select/select/select.component.spec.ts
+++ b/desktop/src/select/select/select.component.spec.ts
@@ -1,18 +1,26 @@
+import { CUSTOM_ELEMENTS_SCHEMA, provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
-import { ReactiveFormsModule } from '@angular/forms';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { MatSelectModule } from '@angular/material/select';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { OptionDisplayPipe } from '../pipes/option-display.pipe';
+import { ReadonlyValuePipe } from '../pipes/readonly-value.pipe';
 import { SelectComponent } from './select.component';
 
 describe('SelectComponent', () => {
   let component: SelectComponent;
   let fixture: ComponentFixture<SelectComponent>;
 
+  const options = [
+    { value: 'category', displayValue: 'Category', badge: '' },
+    { value: 'custom_7', displayValue: 'HST', badge: 'Custom' },
+  ];
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [SelectComponent],
+      declarations: [SelectComponent, OptionDisplayPipe, ReadonlyValuePipe],
       imports: [MatSelectModule, ReactiveFormsModule, NoopAnimationsModule],
+      providers: [provideZonelessChangeDetection()],
       schemas: [CUSTOM_ELEMENTS_SCHEMA],
     }).compileComponents();
 
@@ -23,5 +31,57 @@ describe('SelectComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  // --- optionBadgeKey -----------------------------------------------------
+
+  function configure(optionBadgeKey: string, value: string | null): void {
+    component.inputFormControl = new FormControl(value);
+    component.optionValueKey = 'value';
+    fixture.componentRef.setInput('options', options);
+    fixture.componentRef.setInput('optionDisplayKey', 'displayValue');
+    fixture.componentRef.setInput('optionBadgeKey', optionBadgeKey);
+  }
+
+  it('reads an option badge only when optionBadgeKey names one', () => {
+    fixture.componentRef.setInput('optionBadgeKey', 'badge');
+    expect(component.badgeFor(options[1])).toBe('Custom');
+    expect(component.badgeFor(options[0])).toBe('');
+    expect(component.badgeFor(undefined)).toBe('');
+
+    // Unset (every existing call site) means no badge at all.
+    fixture.componentRef.setInput('optionBadgeKey', '');
+    expect(component.badgeFor(options[1])).toBe('');
+  });
+
+  it('resolves the selected option by its value key, or -1 when absent', () => {
+    configure('badge', 'custom_7');
+    expect(component.selectedIndex()).toBe(1);
+
+    component.inputFormControl.setValue('nope');
+    expect(component.selectedIndex()).toBe(-1);
+  });
+
+  // The closed select renders the selected option's text content, so a badged
+  // option would otherwise read "HSTCustom". A badged select draws its own
+  // trigger to keep the two apart.
+  it('draws the badge in the trigger for a badged selection', async () => {
+    configure('badge', 'custom_7');
+    await fixture.whenStable();
+
+    const badges = fixture.nativeElement.querySelectorAll('.select__badge');
+    expect(badges.length).toBe(1);
+    expect(badges[0].textContent.trim()).toBe('Custom');
+    expect(fixture.nativeElement.textContent).toContain('HST');
+  });
+
+  it('draws no badge for an unbadged selection, or when badges are off', async () => {
+    configure('badge', 'category');
+    await fixture.whenStable();
+    expect(fixture.nativeElement.querySelectorAll('.select__badge').length).toBe(0);
+
+    configure('', 'custom_7');
+    await fixture.whenStable();
+    expect(fixture.nativeElement.querySelectorAll('.select__badge').length).toBe(0);
   });
 });

--- a/desktop/src/select/select/select.component.ts
+++ b/desktop/src/select/select/select.component.ts
@@ -18,11 +18,40 @@ export class SelectComponent extends BaseInputComponent implements OnInit {
 
   public readonly addEmptyOption = input<boolean>(false);
 
+  /**
+   * The property on an option holding a short badge to draw beside its text —
+   * e.g. "Custom" on the report builder's custom fields. Left unset (the
+   * default) nothing is drawn and the select behaves exactly as before, so
+   * existing call sites are unaffected.
+   */
+  public readonly optionBadgeKey = input<string>("");
+
   constructor() {
     super();
   }
 
   public override ngOnInit(): void {
     super.ngOnInit();
+  }
+
+  /** An option's badge text, or "" when it has none or badges are off. */
+  public badgeFor(option: any): string {
+    const key = this.optionBadgeKey();
+    if (!key || option === null || option === undefined) {
+      return "";
+    }
+    return option[key] ?? "";
+  }
+
+  /**
+   * The index of the selected option, or -1 when nothing matches. The custom
+   * trigger renders by index so it can reuse the same optionDisplay pipe the
+   * option list does, optionsDisplayArray included.
+   */
+  public selectedIndex(): number {
+    const value = this.inputFormControl.value;
+    return this.options().findIndex(
+      (option) => (this.optionValueKey ? option[this.optionValueKey] : option) === value
+    );
   }
 }


### PR DESCRIPTION
## Summary
Extends the report builder to support grouping by and aggregating custom fields of any type. Currency custom fields can be measured (summed, averaged, etc.), all custom fields can be grouped by, and date custom fields contribute derived calendar-period grouping levels (day/month/year).

## Key Changes

### Backend (api/)
- **Field catalog**: Custom fields are now exposed in the reporting field catalog with their declared data types (currency, date, boolean, text, select)
- **Date period derivation**: Date custom fields automatically generate `custom_<id>_day`, `custom_<id>_month`, and `custom_<id>_year` fields for calendar-period grouping, matching the behavior of built-in date fields
- **Validation**: Removed the restriction that prevented grouping by measures; now only measuring is type-restricted (a currency field can be grouped by and aggregated)
- **Rendering**: Added `formatLabelValue()` to present typed values correctly in reports:
  - Booleans render as "Yes"/"No" instead of "true"/"false"
  - Dates render as calendar days (YYYY-MM-DD) instead of RFC 3339 instants
  - Currency values render with proper formatting (thousands separators, decimal places) in label columns
- **CSV/XLSX/HTML rendering**: Updated to use the new typed value formatting for dimension and label columns

### Frontend (desktop/)
- **Report catalog service**: Every custom field is now a dimension; currency custom fields additionally appear as measures
- **UI badging**: Custom fields are marked with a "Custom" badge in all field pickers (grouping levels, columns, measures)
- **Select component**: Added optional `optionBadgeKey` input to display badges beside option text
- **Report config panel**: Displays custom field badges on selected grouping levels and columns
- **Column picker**: Supports custom fields in both dimension and measure selections
- **Template summary**: Resolves custom field keys through a provided resolver function

### E2E Tests
- Added comprehensive test suite (`report-custom-fields.spec.ts`) covering:
  - Custom fields appear in the grouping picker with badges
  - Currency custom fields group and format as money
  - Boolean custom fields render as Yes/No
  - Date custom fields offer calendar-period grouping levels
  - Duplicate values (e.g., 1500.50 and 1500.5) bucket together
  - Missing values land in the (None) bucket

### Test Updates
- Updated existing tests to account for new custom field support in catalogs and pickers
- Added test fixtures for typed dimensions (boolean, date, currency)
- Verified formatting behavior across CSV, XLSX, and HTML renderers

## Notable Implementation Details

- **Canonical decimals**: Currency values are keyed by their canonical decimal representation, so 1500.50 and 1500.5 land in the same bucket
- **Period field labels**: Date custom field periods are labeled off the field's own name (e.g., "Due Date (Month)") through shared helpers
- **Type-aware rendering**: Renderers check the declared data type and fall back to the value's own rendering if the payload disagrees, preventing type mismatches from breaking output
- **Backward compatibility**: The select component's badge feature is optional; existing call sites are unaffected

https://claude.ai/code/session_01PD4YZT5i1pnwKphx93auE5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Custom fields are available as report dimensions; currency fields can also be used as measures.
  * Date custom fields support day, month, and year grouping.
  * Custom fields display a “Custom” badge in report configuration.
  * Saved report summaries show custom field names when available.
  * Numeric fields can be used for grouping and detail buckets.

* **Improvements**
  * Reports consistently format dates, booleans, currencies, and empty values across exports.
  * Date groups use readable calendar-day labels instead of timestamps.
  * Numeric grouping provides consistent sorting and grouping for equivalent values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->