### PR TITLE
Allow renaming grouping level column headings in reports

### DIFF
--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -1319,6 +1319,21 @@ multi-value label has no numeric reading; aggregate columns are what carry nativ
 changed existing reports that group by the built-in `date` / `resolved_date` / `created_at`: their
 bucket text went from RFC 3339 to a plain calendar day.
 
+**Grouping-level column headings are overridable.** Because a grouping level renders as a *leading
+column*, the request may name that column itself: `ReportRequestCommand.GroupByLabels`
+(`map[string]string`, `omitempty`) overrides `render.Dimension.Label` per grouping field key, resolved
+in `buildDimensions` (`services/report_service.go`). It is **keyed by field key rather than
+index-aligned** with `GroupBy` — grouping keys are unique (`reporting.ErrDuplicateGroupBy`), so
+reordering the levels can't desynchronize it. A key that is absent, blank after trimming, or names no
+grouping level falls back to the catalog label; a stale entry is ignored rather than failing an
+otherwise valid report, so there is **no validation** for it (matching the unvalidated
+`ReportColumn.Label`). Only the heading changes — `DataType` is untouched, so buckets still format by
+type. It is purely additive and optional, so stored templates deserialize unchanged and
+`CurrentReportConfigurationVersion` stays `1`. The user-supplied text is already covered by the two
+escaping paths every column label goes through: `html/template` for HTML/PDF and `SanitizeCSVField` in
+`dimensionHeading` for CSV. Nothing in `internal/reporting/` is involved — this is a renderer concern.
+The desktop drives it from the pencil on each Grouping row (see `desktop/CLAUDE.md` → "Reports").
+
 **`services.ReportDataService`** (`internal/services/report_data.go`) is the first DB-backed caller of
 the engine — it follows the `pie_chart.go` pattern. `Rows(userId, groupId, filter)` fetches the group's
 receipts unpaged and applies the reporting access controls **in order**: narrow the request filter to

--- a/api/internal/commands/report_request_command.go
+++ b/api/internal/commands/report_request_command.go
@@ -74,17 +74,23 @@ var validAggFuncs = map[string]bool{"SUM": true, "COUNT": true, "AVG": true, "MI
 // submitting. The deep validity of the spec (that a field key exists, has the
 // right role, and that formulas form no cycle) is left to reporting.Run.
 type ReportRequestCommand struct {
-	Name        string                    `json:"name"`
-	GroupIds    []string                  `json:"groupIds"`
-	Period      ReportPeriod              `json:"period"`
-	Filter      ReceiptPagedRequestFilter `json:"filter"`
-	GroupBy     []string                  `json:"groupBy"`
-	Detail      ReportDetail              `json:"detail"`
-	Columns     []ReportColumn            `json:"columns"`
-	Subtotals   bool                      `json:"subtotals"`
-	GrandTotals bool                      `json:"grandTotals"`
-	Document    ReportDocument            `json:"document"`
-	Formats     []string                  `json:"formats"`
+	Name     string                    `json:"name"`
+	GroupIds []string                  `json:"groupIds"`
+	Period   ReportPeriod              `json:"period"`
+	Filter   ReceiptPagedRequestFilter `json:"filter"`
+	GroupBy  []string                  `json:"groupBy"`
+	// GroupByLabels overrides the column heading a grouping level renders with,
+	// keyed by its GroupBy field key. A level with no entry (or a blank one) uses
+	// the field catalog's own label. It is keyed rather than index-aligned because
+	// grouping keys are unique (reporting.ErrDuplicateGroupBy), so reordering the
+	// levels cannot desynchronize it; a key not in GroupBy is simply ignored.
+	GroupByLabels map[string]string `json:"groupByLabels,omitempty"`
+	Detail        ReportDetail      `json:"detail"`
+	Columns       []ReportColumn    `json:"columns"`
+	Subtotals     bool              `json:"subtotals"`
+	GrandTotals   bool              `json:"grandTotals"`
+	Document      ReportDocument    `json:"document"`
+	Formats       []string          `json:"formats"`
 }
 
 // ReportPeriod is the reporting window. Preset is one of the ReportPeriod*

--- a/api/internal/services/report_service.go
+++ b/api/internal/services/report_service.go
@@ -266,7 +266,7 @@ func (service ReportService) buildModel(
 
 	return reportBuild{
 		model:        model,
-		dimensions:   buildDimensions(spec.GroupBy, catalog),
+		dimensions:   buildDimensions(spec.GroupBy, catalog, command.GroupByLabels),
 		chrome:       chrome,
 		receiptCount: receiptCount,
 	}, nil
@@ -511,13 +511,20 @@ func aggregateSource(aggFunc string, measure string) string {
 // money per the report's currency configuration — instead of dumping the engine's
 // raw value. A key the catalog does not know falls back to the key as its own
 // heading and to plain text, which is what an unresolvable dimension can offer.
-func buildDimensions(groupBy []reporting.FieldKey, catalog reporting.FieldCatalog) []render.Dimension {
+func buildDimensions(groupBy []reporting.FieldKey, catalog reporting.FieldCatalog, labels map[string]string) []render.Dimension {
 	dimensions := make([]render.Dimension, len(groupBy))
 	for index, key := range groupBy {
 		dimension := render.Dimension{Key: key, Label: string(key)}
 		if field, ok := catalog.Get(key); ok {
 			dimension.Label = field.Label
 			dimension.DataType = field.DataType
+		}
+		// A grouping level renders as a leading column, and the request may name
+		// that column itself. A blank override means "use the catalog label", and
+		// a key naming no grouping level is simply never looked up — a stale
+		// entry must not fail an otherwise valid report.
+		if override := strings.TrimSpace(labels[string(key)]); len(override) > 0 {
+			dimension.Label = override
 		}
 		dimensions[index] = dimension
 	}

--- a/api/internal/services/report_service_test.go
+++ b/api/internal/services/report_service_test.go
@@ -262,6 +262,7 @@ func TestReportService_BuildDimensions(t *testing.T) {
 	got := buildDimensions(
 		[]reporting.FieldKey{"paid_by", "date", "custom_1", "custom_5", "gone"},
 		catalog,
+		nil,
 	)
 	want := []render.Dimension{
 		{Key: "paid_by", Label: "Paid By", DataType: reporting.TypeString},
@@ -269,6 +270,42 @@ func TestReportService_BuildDimensions(t *testing.T) {
 		{Key: "custom_1", Label: "HST", DataType: reporting.TypeCurrency},
 		{Key: "custom_5", Label: "Reimbursed", DataType: reporting.TypeBool},
 		{Key: "gone", Label: "gone", DataType: reporting.TypeString},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("buildDimensions() = %+v, want %+v", got, want)
+	}
+}
+
+// A grouping level renders as a leading column, so the request may name that
+// column itself. Only a non-blank override for a key that is actually grouped
+// takes effect: a blank one means "use the catalog label", and an entry naming
+// no grouping level is ignored rather than failing the report. The data type is
+// never affected — a renamed column still formats its buckets by type.
+func TestReportService_BuildDimensions_LabelOverrides(t *testing.T) {
+	catalog, err := reporting.NewFieldCatalog(
+		reporting.FieldRef{Key: "category", Label: "Category", DataType: reporting.TypeString},
+		reporting.FieldRef{Key: "date", Label: "Date", DataType: reporting.TypeDate},
+		reporting.FieldRef{Key: "paid_by", Label: "Paid By", DataType: reporting.TypeString},
+	)
+	if err != nil {
+		t.Fatalf("NewFieldCatalog() error = %v", err)
+	}
+
+	got := buildDimensions(
+		[]reporting.FieldKey{"category", "date", "paid_by", "gone"},
+		catalog,
+		map[string]string{
+			"category": "Expense Type", // renamed
+			"date":     "   ",          // blank after trimming -> catalog label
+			"gone":     "Renamed Key",  // unknown key still falls back to itself
+			"status":   "Never Used",   // not a grouping level at all
+		},
+	)
+	want := []render.Dimension{
+		{Key: "category", Label: "Expense Type", DataType: reporting.TypeString},
+		{Key: "date", Label: "Date", DataType: reporting.TypeDate},
+		{Key: "paid_by", Label: "Paid By", DataType: reporting.TypeString},
+		{Key: "gone", Label: "Renamed Key", DataType: reporting.TypeString},
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("buildDimensions() = %+v, want %+v", got, want)

--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -6316,6 +6316,14 @@ components:
           items:
             type: string
           description: Ordered engine field keys to nest the report by
+        groupByLabels:
+          type: object
+          additionalProperties:
+            type: string
+          description: >-
+            Column-heading overrides for the grouping levels, keyed by the
+            groupBy field key. A key that is absent, blank, or not present in
+            groupBy falls back to the field catalog's label.
         detail:
           $ref: "#/components/schemas/ReportDetail"
         columns:

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -1133,6 +1133,30 @@ endpoint); the builder's own ad-hoc generate still gates on `app.reports.generat
     instead of being silently dropped. The backend applies the same projection when a stored template is
     generated (see `api/CLAUDE.md` → "Report templates"), so a template holding a currently-disabled
     column still generates with it omitted.
+  - **Grouping levels are columns too, and can be renamed.** Every grouping level also renders as a
+    *leading* column in the report, headed server-side from the field catalog (`buildDimensions`) — it
+    is not in the `columns` FormArray and was previously unnameable. Each Grouping row therefore carries
+    an edit pencil (`data-testid="report-grouping-edit"`) beside move-up/down/remove that reuses the
+    **same** `ColumnPickerDialogComponent` in a locked-field mode: `ColumnPickerDialogData.lockField`
+    hides the Back button (the kind step is unreachable — the field is chosen by the grouping level, not
+    the dialog), binds the Field `app-select` `[readonly]`, disables the `field` control, and retitles the
+    dialog "Grouping column". The panel hands the level in as the dimension column it *is* — a synthetic
+    `ReportColumnValue` with an id — so the picker's existing edit path seeds the label and opens straight
+    on the dimension step; only `label` is read back.
+    - **The form's `groupBy` is a `FormArray<FormGroup>` of `{ field, label }`**, not bare field keys, so
+      a heading cannot outlive its level (removing a level drops its rename; reordering carries it along).
+      Read the keys with `readGroupByFields()` (`report-form.factory.ts`), never `readStringArray`.
+    - **A blank `label` means "use the field catalog's label"**, and that is how a user resets: entering
+      the field's own label stores nothing. The mapper emits `groupByLabels` (a `{ [fieldKey]: label }`
+      map on `ReportRequestCommand`) **only** when at least one level is renamed, so an untouched report
+      maps to byte-identical the command it always did and the round-trip spec still holds. Keyed by
+      field, not index-aligned, because grouping keys are unique — reordering can't desynchronize it.
+    - The templates list's Grouping summary (`report-template-summary.ts`) prefers the override, so the
+      list agrees with the report it describes. See `api/CLAUDE.md` → "Reporting Engine".
+    - **E2E:** `e2e/report-grouping-label.spec.ts` — the rename reaches the real rendered report (asserted
+      against the preview iframe's `srcdoc`, which is the engine's own HTML), the dialog is locked/Back-less,
+      retyping the default resets it, and a saved template round-trips the heading into both its list row
+      and a reopened builder. The first two were verified to **FAIL** with the backend override reverted.
 - **Save Template**: the generate bar's secondary button (left of Generate) persists the current
   configuration. Its gate and label follow the builder's mode, driven by two inputs from
   `report-builder` (`isEditMode` + `saveButtonPermission`): on the **new** route it **creates** a

--- a/desktop/e2e/custom-field-edit.spec.ts
+++ b/desktop/e2e/custom-field-edit.spec.ts
@@ -115,14 +115,19 @@ test.describe('Edit custom fields (app.custom-fields.update)', () => {
     await admin.close();
 
     await withAdminApi(async (api) => {
-      editableField = await apiCreateCustomField(api, uniqueName('editable-field'));
-      untouchedField = await apiCreateCustomField(api, uniqueName('leftover-field'));
-      selectField = await apiCreateCustomField(
-        api,
-        uniqueName('select-field'),
-        'SELECT',
-        ['Option 1', 'Option 2'],
-      );
+      editableField = await apiCreateCustomField(api, {
+        name: uniqueName('editable-field'),
+        type: 'TEXT',
+      });
+      untouchedField = await apiCreateCustomField(api, {
+        name: uniqueName('leftover-field'),
+        type: 'TEXT',
+      });
+      selectField = await apiCreateCustomField(api, {
+        name: uniqueName('select-field'),
+        type: 'SELECT',
+        options: ['Option 1', 'Option 2'],
+      });
     });
 
     await captureSession(

--- a/desktop/e2e/helpers/provisioning.ts
+++ b/desktop/e2e/helpers/provisioning.ts
@@ -666,60 +666,6 @@ export async function apiDeleteCategoryById(
   await warnOnFailedDelete(api, `/api/category/${id}`, `category ${id}`);
 }
 
-/**
- * Creates a custom field and returns its id + name. [options] are only meaningful
- * for a SELECT field; the server clears them for every other type.
- */
-export async function apiCreateCustomField(
-  api: APIRequestContext,
-  name: string,
-  type: 'TEXT' | 'DATE' | 'SELECT' | 'CURRENCY' | 'BOOLEAN' = 'TEXT',
-  options: string[] = [],
-): Promise<{ id: number; name: string }> {
-  const res = await api.post('/api/customField/', {
-    data: {
-      name,
-      type,
-      description: '',
-      options: options.map((value) => ({ value, customFieldId: 0 })),
-    },
-  });
-  if (!res.ok()) {
-    throw new Error(
-      `create custom field failed: HTTP ${res.status()} ${await res.text()}`,
-    );
-  }
-  const customField = (await res.json()) as { id: number; name: string };
-  return { id: customField.id, name: customField.name };
-}
-
-/** Reads one custom field back, so a spec can assert what an edit persisted. */
-export async function apiGetCustomFieldById(
-  api: APIRequestContext,
-  id: number,
-): Promise<{
-  id: number;
-  name: string;
-  type: string;
-  description?: string;
-  options?: { id: number; value: string }[];
-}> {
-  const res = await api.get(`/api/customField/${id}`);
-  if (!res.ok()) {
-    throw new Error(
-      `get custom field failed: HTTP ${res.status()} ${await res.text()}`,
-    );
-  }
-  return res.json();
-}
-
-export async function apiDeleteCustomFieldById(
-  api: APIRequestContext,
-  id: number,
-): Promise<void> {
-  await warnOnFailedDelete(api, `/api/customField/${id}`, `custom field ${id}`);
-}
-
 export async function apiDeleteTagById(
   api: APIRequestContext,
   id: number,
@@ -757,6 +703,26 @@ export async function apiCreateCustomField(
   }
   const customField = (await res.json()) as { id: number; name: string };
   return { id: customField.id, name: customField.name };
+}
+
+/** Reads one custom field back, so a spec can assert what an edit persisted. */
+export async function apiGetCustomFieldById(
+  api: APIRequestContext,
+  id: number,
+): Promise<{
+  id: number;
+  name: string;
+  type: string;
+  description?: string;
+  options?: { id: number; value: string }[];
+}> {
+  const res = await api.get(`/api/customField/${id}`);
+  if (!res.ok()) {
+    throw new Error(
+      `get custom field failed: HTTP ${res.status()} ${await res.text()}`,
+    );
+  }
+  return res.json();
 }
 
 /** Deletes a custom field. Requires app.custom-fields.delete (admin-only). */

--- a/desktop/e2e/report-grouping-label.spec.ts
+++ b/desktop/e2e/report-grouping-label.spec.ts
@@ -1,0 +1,150 @@
+import { expect, Page, test } from '@playwright/test';
+import { stubTokenRefresh } from './helpers/auth';
+import { apiDeleteReportTemplateById, uniqueName, withAdminApi } from './helpers/provisioning';
+import {
+  addFirstGroupToScope,
+  addGroupingLevel,
+  gotoReportBuilder,
+  gotoReports,
+  waitForPreview,
+} from './helpers/reports';
+
+// The Report Builder is gated by app.reports.read, carried only by Legacy Admin.
+test.use({ storageState: 'e2e/.auth/admin.json' });
+
+/** The preview is server-rendered HTML in an iframe; assert against its srcdoc. */
+function preview(page: Page) {
+  return page.getByTitle('Report preview');
+}
+
+/** Matches a heading rendered as its own cell, not a substring of some other text. */
+function asCell(text: string): RegExp {
+  return new RegExp(`>\\s*${text}\\s*<`);
+}
+
+/** Opens the rename dialog for the grouping level at `index` and returns its label input. */
+async function openGroupingRename(page: Page, index = 0) {
+  await page.getByTestId('report-grouping-edit').nth(index).click();
+  const label = page.getByLabel('Column label');
+  await expect(label).toBeVisible();
+  return label;
+}
+
+/** Renames the open dialog's column and waits for the preview to catch up. */
+async function saveRename(page: Page, heading: string) {
+  await page.getByLabel('Column label').fill(heading);
+  await Promise.all([waitForPreview(page), page.getByTestId('picker-save').click()]);
+}
+
+// A grouping level adds a leading column to the rendered report whose heading the
+// backend derives from the field catalog. These cover the pencil that overrides it:
+// the heading reaches the real rendered report (the preview is the engine's own
+// output), resets when the default is retyped, and survives a save/reopen.
+test.describe('Report Builder — grouping column headings', () => {
+  // The template created by the running test, torn down afterwards so runs don't
+  // accumulate saved templates.
+  let createdTemplateId: number | undefined;
+
+  test.beforeEach(async ({ page }) => {
+    await stubTokenRefresh(page);
+    await gotoReportBuilder(page);
+    await addFirstGroupToScope(page);
+    // Settle the initial preview so the grouping picks start from a stable panel.
+    await expect(page.getByTestId('report-receipt-count')).toBeVisible({ timeout: 20_000 });
+  });
+
+  test.afterEach(async () => {
+    if (createdTemplateId === undefined) {
+      return;
+    }
+    try {
+      await withAdminApi((api) => apiDeleteReportTemplateById(api, createdTemplateId!));
+    } catch {
+      // Best-effort cleanup — don't mask a test failure with a teardown error.
+    }
+    createdTemplateId = undefined;
+  });
+
+  test('renames the column a grouping level adds to the report', async ({ page }) => {
+    const heading = uniqueName('Payer');
+
+    await addGroupingLevel(page, 'Paid By');
+    // The grouping level's column is rendered by the backend, headed by the field
+    // catalog's own label until it is overridden.
+    await expect(preview(page)).toHaveAttribute('srcdoc', asCell('Paid By'), { timeout: 20_000 });
+
+    await openGroupingRename(page);
+
+    // The dialog names the grouping column rather than claiming to add one, and the
+    // field is locked: it is chosen by the grouping level, not here.
+    await expect(page.getByText('Grouping column')).toBeVisible();
+    await expect(page.getByTestId('picker-back')).toHaveCount(0);
+    const field = page.getByLabel('Field');
+    await expect(field).toHaveJSProperty('readOnly', true);
+    await expect(field).toHaveValue('Paid By');
+    // The label is seeded with the heading the column currently carries.
+    await expect(page.getByLabel('Column label')).toHaveValue('Paid By');
+
+    await saveRename(page, heading);
+
+    // The grouping row shows the heading its column will carry...
+    await expect(page.getByTestId('report-grouping-label')).toHaveText(heading);
+    // ...and so does the rendered report, in place of the catalog label.
+    await expect(preview(page)).toHaveAttribute('srcdoc', asCell(heading), { timeout: 20_000 });
+    expect(await preview(page).getAttribute('srcdoc')).not.toMatch(asCell('Paid By'));
+  });
+
+  test('resets to the field label when the default is retyped', async ({ page }) => {
+    await addGroupingLevel(page, 'Paid By');
+    await expect(preview(page)).toHaveAttribute('srcdoc', asCell('Paid By'), { timeout: 20_000 });
+
+    const heading = uniqueName('Payer');
+    await openGroupingRename(page);
+    await saveRename(page, heading);
+    await expect(page.getByTestId('report-grouping-label')).toHaveText(heading);
+    await expect(preview(page)).toHaveAttribute('srcdoc', asCell(heading), { timeout: 20_000 });
+
+    // Retyping the field's own label is how a user resets: no override is stored, so
+    // the report goes back to the catalog heading.
+    await openGroupingRename(page);
+    await saveRename(page, 'Paid By');
+
+    await expect(page.getByTestId('report-grouping-label')).toHaveText('Paid By');
+    await expect(preview(page)).toHaveAttribute('srcdoc', asCell('Paid By'), { timeout: 20_000 });
+    expect(await preview(page).getAttribute('srcdoc')).not.toMatch(asCell(heading));
+  });
+
+  test('persists the heading into a saved template and its list row', async ({ page }) => {
+    const heading = uniqueName('Payer');
+    const templateName = uniqueName('grouping-heading');
+
+    await addGroupingLevel(page, 'Paid By');
+    await openGroupingRename(page);
+    await saveRename(page, heading);
+
+    await page.getByLabel('Report name').fill(templateName);
+
+    const save = page.getByTestId('report-save-template');
+    await expect(save.locator('button')).toBeEnabled();
+    const [response] = await Promise.all([
+      page.waitForResponse(
+        (r) => r.url().includes('/api/report/template') && r.request().method() === 'POST',
+      ),
+      save.click(),
+    ]);
+    expect(response.status()).toBe(200);
+    createdTemplateId = ((await response.json()) as { id: number }).id;
+
+    // The list summarizes the grouping with the heading the report renders, not the
+    // underlying field's name.
+    await gotoReports(page);
+    const row = page.getByRole('row').filter({ hasText: templateName });
+    await expect(row).toContainText(heading);
+    await expect(row).not.toContainText('Paid By');
+
+    // Reopening rehydrates the override, so it is not lost on the next edit.
+    await row.getByTestId('report-template-name').click();
+    await expect(page).toHaveURL(/\/reports\/\d+\/edit$/);
+    await expect(page.getByTestId('report-grouping-label')).toHaveText(heading);
+  });
+});

--- a/desktop/src/open-api/model/reportRequestCommand.ts
+++ b/desktop/src/open-api/model/reportRequestCommand.ts
@@ -32,6 +32,10 @@ export interface ReportRequestCommand {
      * Ordered engine field keys to nest the report by
      */
     groupBy?: Array<string>;
+    /**
+     * Column-heading overrides for the grouping levels, keyed by the groupBy field key. A key that is absent, blank, or not present in groupBy falls back to the field catalog\'s label.
+     */
+    groupByLabels?: { [key: string]: string; };
     detail: ReportDetail;
     columns: Array<ReportColumn>;
     /**

--- a/desktop/src/reports/dialogs/column-picker-dialog/column-picker-dialog.component.html
+++ b/desktop/src/reports/dialogs/column-picker-dialog/column-picker-dialog.component.html
@@ -33,6 +33,7 @@
 
     @case ("dim") {
       <app-select label="Field" optionValueKey="value" optionDisplayKey="displayValue" optionBadgeKey="badge"
+        [readonly]="lockField"
         [options]="dimensionOptions" [inputFormControl]="pickerForm | formGet: 'field'"></app-select>
       <app-input label="Column label" [inputFormControl]="pickerForm | formGet: 'label'"></app-input>
     }
@@ -94,8 +95,9 @@
   }
 
   <div class="picker__footer">
-    @if (step() !== "kind") {
-      <app-button matButtonType="basic" buttonText="Back" icon="arrow_back" (clicked)="back()"></app-button>
+    @if (step() !== "kind" && !lockField) {
+      <app-button matButtonType="basic" buttonText="Back" icon="arrow_back" (clicked)="back()"
+        data-testid="picker-back"></app-button>
     }
     <span class="picker__footer-spacer"></span>
     <app-button matButtonType="basic" buttonText="Cancel" (clicked)="cancel()"></app-button>

--- a/desktop/src/reports/dialogs/column-picker-dialog/column-picker-dialog.component.spec.ts
+++ b/desktop/src/reports/dialogs/column-picker-dialog/column-picker-dialog.component.spec.ts
@@ -229,6 +229,80 @@ describe("ColumnPickerDialogComponent", () => {
     expect(component.canSave()).toBe(false);
   });
 
+  // ---- locked-field mode (renaming a grouping level's column) --------------
+
+  // The grouping section hands the level in as the dimension column it is, so the
+  // picker opens on the dimension step in edit mode with only the label editable.
+  const lockedData: ColumnPickerDialogData = {
+    ...baseData,
+    column: {
+      id: "g1",
+      kind: ReportColumn.KindEnum.Dimension,
+      name: "category",
+      label: "Category",
+      field: "category",
+    },
+    lockField: true,
+  };
+
+  it("opens on the dimension step with the field locked and no way back", async () => {
+    const { fixture, component } = configure(lockedData);
+    await fixture.whenStable();
+
+    expect(component.step()).toBe("dim");
+    expect(component.lockField).toBe(true);
+    // Disabled as well as presented read-only, so the field cannot be changed
+    // through the control either.
+    expect(component.pickerForm.get("field")!.disabled).toBe(true);
+    // It still names the grouping column rather than claiming to add one.
+    expect(component.title()).toBe("Grouping column");
+  });
+
+  it("saves the edited label while keeping the locked field and name", async () => {
+    const { fixture, component, close } = configure(lockedData);
+    await fixture.whenStable();
+
+    component.pickerForm.get("label")!.setValue("Expense Type");
+    await fixture.whenStable();
+    expect(component.canSave()).toBe(true);
+
+    component.save();
+    expect(close).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "g1",
+        kind: ReportColumn.KindEnum.Dimension,
+        // A disabled control is omitted from form.value, so save() must read
+        // getRawValue() or the field would ride out empty and fail canSave().
+        field: "category",
+        name: "category",
+        label: "Expense Type",
+      })
+    );
+  });
+
+  it("still requires a non-empty label", async () => {
+    const { fixture, component } = configure(lockedData);
+    await fixture.whenStable();
+
+    component.pickerForm.get("label")!.setValue("   ");
+    await fixture.whenStable();
+
+    expect(component.canSave()).toBe(false);
+  });
+
+  it("leaves the field editable and the kind step reachable for a normal column", async () => {
+    const { fixture, component } = configure(baseData);
+    await fixture.whenStable();
+    component.pickDimension();
+    await fixture.whenStable();
+
+    expect(component.lockField).toBe(false);
+    expect(component.pickerForm.get("field")!.disabled).toBe(false);
+    expect(component.title()).toBe("Dimension column");
+    component.back();
+    expect(component.step()).toBe("kind");
+  });
+
   it("keeps an edited column's existing name", async () => {
     const { fixture, component, close } = configure({
       ...baseData,

--- a/desktop/src/reports/dialogs/column-picker-dialog/column-picker-dialog.component.ts
+++ b/desktop/src/reports/dialogs/column-picker-dialog/column-picker-dialog.component.ts
@@ -26,6 +26,13 @@ export interface ColumnPickerDialogData {
   measures: ReportField[];
   existingColumns: ReportColumnValue[];
   column?: ReportColumnValue;
+  /**
+   * Opens the dialog with its field fixed: the kind step is unreachable (no Back)
+   * and the Field picker is read-only, so only the label can be changed. Used to
+   * rename the column a grouping level renders as — the level's field is chosen
+   * in the Grouping section, not here.
+   */
+  lockField?: boolean;
 }
 
 type PickerStep = "kind" | "dim" | "agg" | "formula";
@@ -43,6 +50,11 @@ const STEP_SUBTITLES: Record<PickerStep, string> = {
   agg: "A number summed across rows",
   formula: "Computed from other columns",
 };
+
+// A locked-field dialog is always on the dimension step, but it is not adding a
+// dimension column — it renames the column a grouping level already produces.
+const LOCKED_TITLE = "Grouping column";
+const LOCKED_SUBTITLE = "The column this grouping level adds to the report";
 
 /**
  * The column builder: pick a kind (dimension / aggregate / formula), then configure
@@ -101,8 +113,15 @@ export class ColumnPickerDialogComponent {
     validateFormulaExpr(this.exprValue() ?? "", this.availableNames)
   );
 
-  public readonly title = computed(() => STEP_TITLES[this.step()]);
-  public readonly subtitle = computed(() => STEP_SUBTITLES[this.step()]);
+  /** True when the dialog only edits the label (see ColumnPickerDialogData.lockField). */
+  public readonly lockField: boolean;
+
+  public readonly title = computed(() =>
+    this.lockField ? LOCKED_TITLE : STEP_TITLES[this.step()]
+  );
+  public readonly subtitle = computed(() =>
+    this.lockField ? LOCKED_SUBTITLE : STEP_SUBTITLES[this.step()]
+  );
 
   public readonly canSave = computed<boolean>(() => {
     this.formTick();
@@ -132,9 +151,16 @@ export class ColumnPickerDialogComponent {
     );
     this.availableNames = data.existingColumns.map((column) => column.name);
     this.editingId = data.column?.id ?? null;
+    this.lockField = data.lockField === true;
 
     if (data.column) {
       this.seedFromColumn(data.column);
+    }
+    if (this.lockField) {
+      // Disabled rather than merely presented read-only, so the field cannot be
+      // changed through the control either. save() reads getRawValue(), so the
+      // fixed field still rides the result.
+      this.pickerForm.get("field")!.disable({ emitEvent: false });
     }
 
     // Auto-suggest the label on user-driven field/measure/function changes (seeds

--- a/desktop/src/reports/models/report-command.mapper.spec.ts
+++ b/desktop/src/reports/models/report-command.mapper.spec.ts
@@ -13,7 +13,10 @@ function baseValue(): ReportBuilderValue {
     scope: ["1", "2"],
     period: { preset: ReportPeriod.PresetEnum.ThisMonth, startDate: null, endDate: null },
     filter: {},
-    groupBy: ["group", "category"],
+    groupBy: [
+      { field: "group", label: "" },
+      { field: "category", label: "" },
+    ],
     detail: { mode: ReportDetail.ModeEnum.Aggregate, by: "category" },
     columns: [
       { id: "a", kind: ReportColumn.KindEnum.Dimension, name: "Category", label: "Category", field: "category" },
@@ -36,6 +39,33 @@ describe("toReportRequestCommand", () => {
     expect(command.groupBy).toEqual(["group", "category"]);
     expect(command.subtotals).toBe(true);
     expect(command.grandTotals).toBe(false);
+  });
+
+  it("omits groupByLabels when no grouping level is renamed", () => {
+    // An untouched report must map to exactly the command it always did, so the
+    // key is absent rather than an empty object.
+    const command = toReportRequestCommand(baseValue());
+    expect(command.groupByLabels).toBeUndefined();
+    expect("groupByLabels" in command).toBe(false);
+  });
+
+  it("emits groupByLabels for the renamed levels only, keyed by field", () => {
+    const value = baseValue();
+    value.groupBy = [
+      { field: "group", label: "" },
+      { field: "category", label: "  Expense Type  " },
+    ];
+    const command = toReportRequestCommand(value);
+    // Trimmed, and the untouched level contributes nothing.
+    expect(command.groupByLabels).toEqual({ category: "Expense Type" });
+    // The grouping order is still the plain field keys.
+    expect(command.groupBy).toEqual(["group", "category"]);
+  });
+
+  it("treats a whitespace-only label as no override", () => {
+    const value = baseValue();
+    value.groupBy = [{ field: "group", label: "   " }];
+    expect(toReportRequestCommand(value).groupByLabels).toBeUndefined();
   });
 
   it("emits a preset period without dates", () => {
@@ -94,7 +124,7 @@ describe("toReportRequestCommand", () => {
     // The reported failing config: aggregate by tag, group by paid_by, but a
     // Category dimension column that reads neither -> it is left out of the spec.
     const value = baseValue();
-    value.groupBy = ["paid_by"];
+    value.groupBy = [{ field: "paid_by", label: "" }];
     value.detail = { mode: ReportDetail.ModeEnum.Aggregate, by: "tag" };
     value.columns = [
       { id: "cat", kind: ReportColumn.KindEnum.Dimension, name: "Category", label: "Category", field: "category" },
@@ -112,7 +142,7 @@ describe("toReportRequestCommandForSave", () => {
     // paid_by, plus a Category dimension that reads neither. The save mapper keeps
     // it (so it round-trips and self-heals) where the generate mapper drops it.
     const value = baseValue();
-    value.groupBy = ["paid_by"];
+    value.groupBy = [{ field: "paid_by", label: "" }];
     value.detail = { mode: ReportDetail.ModeEnum.Aggregate, by: "tag" };
     value.columns = [
       { id: "cat", kind: ReportColumn.KindEnum.Dimension, name: "Category", label: "Category", field: "category" },
@@ -160,7 +190,7 @@ describe("isDimensionColumnDisabled", () => {
   it("enabledReportColumns drops only the disabled dimension columns", () => {
     const value = {
       detail: { mode: Aggregate, by: "tag" },
-      groupBy: ["paid_by"],
+      groupBy: [{ field: "paid_by", label: "" }],
       columns: [dim("category"), dim("tag"), agg()],
     } as any as ReportBuilderValue;
     expect(enabledReportColumns(value).map((c) => c.field ?? c.name)).toEqual(["tag", "Y"]);

--- a/desktop/src/reports/models/report-command.mapper.ts
+++ b/desktop/src/reports/models/report-command.mapper.ts
@@ -22,6 +22,16 @@ export interface ReportColumnValue {
   expr?: string;
 }
 
+/**
+ * One grouping level. `field` is the engine field key the report nests by;
+ * `label` is a heading override for the leading column that level renders as,
+ * blank when the field catalog's own label should be used.
+ */
+export interface ReportGroupByValue {
+  field: string;
+  label: string;
+}
+
 /** The builder form's resolved value, shaped for mapping to a request command. */
 export interface ReportBuilderValue {
   name: string;
@@ -32,7 +42,7 @@ export interface ReportBuilderValue {
     endDate: Date | null;
   };
   filter: ReceiptPagedRequestFilter;
-  groupBy: string[];
+  groupBy: ReportGroupByValue[];
   detail: { mode: ReportDetail.ModeEnum; by: string };
   columns: ReportColumnValue[];
   subtotals: boolean;
@@ -64,8 +74,9 @@ export function isDimensionColumnDisabled(
 
 /** The columns actually sent to the engine — every column minus the disabled ones. */
 export function enabledReportColumns(value: ReportBuilderValue): ReportColumnValue[] {
+  const groupByFields = value.groupBy.map((level) => level.field);
   return value.columns.filter(
-    (column) => !isDimensionColumnDisabled(column, value.detail.mode, value.detail.by, value.groupBy)
+    (column) => !isDimensionColumnDisabled(column, value.detail.mode, value.detail.by, groupByFields)
   );
 }
 
@@ -134,7 +145,7 @@ function mapReportCommand(value: ReportBuilderValue, columns: ReportColumnValue[
     groupIds: value.scope,
     period: toPeriod(value.period),
     filter: value.filter,
-    groupBy: value.groupBy,
+    groupBy: value.groupBy.map((level) => level.field),
     detail,
     columns: columns.map(toColumn),
     subtotals: value.subtotals,
@@ -142,12 +153,35 @@ function mapReportCommand(value: ReportBuilderValue, columns: ReportColumnValue[
     formats: toFormats(value.formats),
   };
 
+  const groupByLabels = toGroupByLabels(value.groupBy);
+  if (groupByLabels) {
+    command.groupByLabels = groupByLabels;
+  }
+
   const { title, intro, footer } = value.document;
   if (title || intro || footer) {
     command.document = { title, intro, footer };
   }
 
   return command;
+}
+
+/**
+ * The heading overrides for the grouping levels, keyed by field key, or
+ * undefined when no level is renamed — an untouched report must map to exactly
+ * the command it always did, so the key is omitted rather than sent empty.
+ */
+function toGroupByLabels(
+  levels: ReportGroupByValue[]
+): { [key: string]: string } | undefined {
+  const labels: { [key: string]: string } = {};
+  levels.forEach((level) => {
+    const label = (level.label ?? "").trim();
+    if (label) {
+      labels[level.field] = label;
+    }
+  });
+  return Object.keys(labels).length > 0 ? labels : undefined;
 }
 
 /**

--- a/desktop/src/reports/models/report-form.factory.spec.ts
+++ b/desktop/src/reports/models/report-form.factory.spec.ts
@@ -5,7 +5,11 @@ import { UntilDestroy } from "@ngneat/until-destroy";
 import { FilterOperation, ReportColumn, ReportDetail, ReportPeriod, ReportRequestCommand } from "../../open-api";
 import { buildReceiptFilterForm } from "../../utils/receipt-filter";
 import { ReportBuilderValue, toReportRequestCommand, toReportRequestCommandForSave } from "./report-command.mapper";
-import { buildReportFormFromCommand, readStringArray } from "./report-form.factory";
+import {
+  buildReportFormFromCommand,
+  readGroupByFields,
+  readStringArray,
+} from "./report-form.factory";
 
 // buildReceiptFilterForm wires untilDestroyed subscriptions, so it needs an
 // @UntilDestroy()-decorated context — a throwaway host, exactly as the receipt
@@ -166,7 +170,7 @@ describe("buildReportFormFromCommand", () => {
     const form = buildReportFormFromCommand(fb, host, command);
     // Assert the array CONTENTS carried over, not just the lengths.
     expect(readStringArray(form.get("scope") as FormArray)).toEqual(["3", "4", "9"]);
-    expect(readStringArray(form.get("groupBy") as FormArray)).toEqual(["group", "status"]);
+    expect(readGroupByFields(form.get("groupBy") as FormArray)).toEqual(["group", "status"]);
 
     const columns = form.get("columns") as FormArray;
     expect(columns.length).toBe(2);
@@ -186,6 +190,50 @@ describe("buildReportFormFromCommand", () => {
     expect(form.get("columns.0.id")!.value).toBeTruthy();
     expect(form.get("columns.1.id")!.value).toBeTruthy();
     expect(form.get("columns.0.id")!.value).not.toBe(form.get("columns.1.id")!.value);
+  });
+
+  it("hydrates a grouping level's column-heading override, and leaves the rest blank", () => {
+    const command: ReportRequestCommand = {
+      name: "Renamed",
+      groupIds: ["1"],
+      period: { preset: ReportPeriod.PresetEnum.ThisMonth },
+      filter: canonicalFilter({}),
+      groupBy: ["group", "category"],
+      groupByLabels: { category: "Expense Type" },
+      detail: { mode: ReportDetail.ModeEnum.Aggregate, by: "category" },
+      columns: [{ kind: ReportColumn.KindEnum.Aggregate, name: "Count", label: "Count", aggFunc: ReportColumn.AggFuncEnum.Count }],
+      subtotals: false,
+      grandTotals: false,
+      formats: [ReportRequestCommand.FormatsEnum.Csv],
+    };
+
+    const form = buildReportFormFromCommand(fb, host, command);
+    expect(readGroupByFields(form.get("groupBy") as FormArray)).toEqual(["group", "category"]);
+    // A level the stored config does not rename holds a blank label, which maps
+    // back to no override at all.
+    expect(form.get("groupBy.0.label")!.value).toBe("");
+    expect(form.get("groupBy.1.label")!.value).toBe("Expense Type");
+
+    expect(roundTrip(command)).toEqual(command);
+  });
+
+  it("round-trips a command with no groupByLabels without inventing the key", () => {
+    const command: ReportRequestCommand = {
+      name: "Untouched",
+      groupIds: ["1"],
+      period: { preset: ReportPeriod.PresetEnum.ThisMonth },
+      filter: canonicalFilter({}),
+      groupBy: ["group"],
+      detail: { mode: ReportDetail.ModeEnum.Aggregate, by: "group" },
+      columns: [{ kind: ReportColumn.KindEnum.Aggregate, name: "Count", label: "Count", aggFunc: ReportColumn.AggFuncEnum.Count }],
+      subtotals: false,
+      grandTotals: false,
+      formats: [ReportRequestCommand.FormatsEnum.Csv],
+    };
+
+    const mapped = roundTrip(command);
+    expect(mapped).toEqual(command);
+    expect("groupByLabels" in mapped).toBe(false);
   });
 
   // A saved filter can touch any receipt-filter field, over every editor type: text

--- a/desktop/src/reports/models/report-form.factory.ts
+++ b/desktop/src/reports/models/report-form.factory.ts
@@ -28,7 +28,7 @@ export function buildReportForm(formBuilder: FormBuilder, thisContext: any): For
       endDate: formBuilder.control<Date | null>(null),
     }),
     filter: buildReceiptFilterForm({}, thisContext),
-    groupBy: formBuilder.array<FormControl<string>>([]),
+    groupBy: formBuilder.array<FormGroup>([]),
     detail: formBuilder.group({
       mode: formBuilder.control<ReportDetail.ModeEnum>(ReportDetail.ModeEnum.Aggregate),
       by: formBuilder.control("category"),
@@ -87,8 +87,10 @@ export function buildReportFormFromCommand(
       ),
     }),
     filter: buildReceiptFilterForm(command.filter ?? {}, thisContext),
-    groupBy: formBuilder.array<FormControl<string>>(
-      (command.groupBy ?? []).map((key) => formBuilder.control(key, { nonNullable: true }))
+    groupBy: formBuilder.array<FormGroup>(
+      (command.groupBy ?? []).map((key) =>
+        buildGroupByGroup(formBuilder, key, command.groupByLabels?.[key] ?? "")
+      )
     ),
     detail: formBuilder.group({
       mode: formBuilder.control<ReportDetail.ModeEnum>(
@@ -133,6 +135,23 @@ const DEFAULT_COLUMNS: Omit<ReportColumnValue, "id">[] = [
   { kind: ReportColumn.KindEnum.Aggregate, name: "Total", label: "Total", aggFunc: ReportColumn.AggFuncEnum.Sum, measure: "amount" },
 ];
 
+/**
+ * Builds a grouping-level FormGroup. A level is `{ field, label }` rather than a
+ * bare field key because each level also renders as a leading column in the
+ * report, whose heading the user may rename. A blank label means "use the field
+ * catalog's own label", which is what the mapper omits from the request.
+ */
+export function buildGroupByGroup(
+  formBuilder: FormBuilder,
+  field: string,
+  label: string = ""
+): FormGroup {
+  return formBuilder.group({
+    field: formBuilder.control(field),
+    label: formBuilder.control(label),
+  });
+}
+
 /** Builds a column FormGroup from a column value (used by defaults and the picker). */
 export function buildColumnGroup(formBuilder: FormBuilder, column: Omit<ReportColumnValue, "id">): FormGroup {
   return formBuilder.group({
@@ -147,7 +166,12 @@ export function buildColumnGroup(formBuilder: FormBuilder, column: Omit<ReportCo
   });
 }
 
-/** Reads the scope/group-by FormArray as a plain string[] of ids/keys. */
+/** Reads the scope FormArray as a plain string[] of group ids. */
 export function readStringArray(array: FormArray): string[] {
   return array.controls.map((control) => control.value as string);
+}
+
+/** Reads the group-by FormArray as the ordered engine field keys it groups on. */
+export function readGroupByFields(array: FormArray): string[] {
+  return array.controls.map((control) => control.get("field")!.value as string);
 }

--- a/desktop/src/reports/models/report-template-summary.spec.ts
+++ b/desktop/src/reports/models/report-template-summary.spec.ts
@@ -61,6 +61,33 @@ describe("report-template-summary", () => {
     expect(groupingSummary(command({ groupBy: ["group", "category"] }))).toBe("Group, Category");
   });
 
+  it("shows a grouping level's renamed column heading", () => {
+    // The list must agree with the report it describes: a level whose column the
+    // report renames shows that name, not the underlying field's.
+    expect(
+      groupingSummary(
+        command({ groupBy: ["group", "category"], groupByLabels: { category: "Expense Type" } })
+      )
+    ).toBe("Group, Expense Type");
+
+    // A blank or unrelated entry changes nothing.
+    expect(
+      groupingSummary(
+        command({ groupBy: ["group"], groupByLabels: { group: "  ", status: "Ignored" } })
+      )
+    ).toBe("Group");
+  });
+
+  it("prefers a renamed heading over a resolved custom-field name", () => {
+    const resolve = (key: string) => ({ custom_42: "Due Date" })[key];
+    expect(
+      groupingSummary(
+        command({ groupBy: ["custom_42"], groupByLabels: { custom_42: "Deadline" } }),
+        resolve
+      )
+    ).toBe("Deadline");
+  });
+
   it("names custom fields in the grouping and detail summaries", () => {
     const resolve = (key: string) => ({ custom_42: "Due Date", custom_7: "HST" })[key];
 

--- a/desktop/src/reports/models/report-template-summary.ts
+++ b/desktop/src/reports/models/report-template-summary.ts
@@ -31,7 +31,11 @@ export function columnCount(configuration: ReportRequestCommand): number {
   return configuration.columns?.length ?? 0;
 }
 
-/** The grouping levels as a readable label list, or a "no grouping" hint. */
+/**
+ * The grouping levels as a readable label list, or a "no grouping" hint. A level
+ * whose column heading the report renames shows that name, so the list agrees
+ * with the report it describes.
+ */
 export function groupingSummary(
   configuration: ReportRequestCommand,
   resolve?: FieldLabelResolver
@@ -40,7 +44,9 @@ export function groupingSummary(
   if (groupBy.length === 0) {
     return "No grouping";
   }
-  return groupBy.map((key) => fieldLabel(key, resolve)).join(", ");
+  return groupBy
+    .map((key) => (configuration.groupByLabels?.[key] ?? "").trim() || fieldLabel(key, resolve))
+    .join(", ");
 }
 
 /** Whether the report aggregates (and by what) or lists individual receipts. */

--- a/desktop/src/reports/report-builder/report-builder.component.spec.ts
+++ b/desktop/src/reports/report-builder/report-builder.component.spec.ts
@@ -20,7 +20,11 @@ import { AuthState } from "../../store";
 import { SetPermissions } from "../../store/auth.state.actions";
 import { buildReceiptFilterForm } from "../../utils/receipt-filter";
 import { ReportBuilderValue, toReportRequestCommand } from "../models/report-command.mapper";
-import { buildColumnGroup, readStringArray } from "../models/report-form.factory";
+import {
+  buildColumnGroup,
+  readGroupByFields,
+  readStringArray,
+} from "../models/report-form.factory";
 import { ReportRunnerService } from "../services/report-runner.service";
 import { ReportBuilderComponent } from "./report-builder.component";
 
@@ -486,7 +490,7 @@ describe("ReportBuilderComponent", () => {
     expect(form.get("filter.status.value")!.value).toEqual(["OPEN"]);
 
     // Group-by (values), detail mode + by.
-    expect(readStringArray(form.get("groupBy") as FormArray)).toEqual(["group", "category"]);
+    expect(readGroupByFields(form.get("groupBy") as FormArray)).toEqual(["group", "category"]);
     expect(form.get("detail.mode")!.value).toBe(ReportDetail.ModeEnum.Aggregate);
     expect(form.get("detail.by")!.value).toBe("category");
 

--- a/desktop/src/reports/report-config-panel/report-config-panel.component.html
+++ b/desktop/src/reports/report-config-panel/report-config-panel.component.html
@@ -60,6 +60,8 @@
         (clicked)="moveGroupBy(level.index, -1)" data-testid="report-grouping-up"></app-button>
       <app-button matButtonType="iconButton" icon="arrow_downward" tooltip="Move down" [disabled]="level.isLast"
         (clicked)="moveGroupBy(level.index, 1)" data-testid="report-grouping-down"></app-button>
+      <app-button matButtonType="iconButton" icon="edit" tooltip="Edit"
+        (clicked)="openGroupingLabelPicker(level.index)" data-testid="report-grouping-edit"></app-button>
       <app-button matButtonType="iconButton" icon="close" color="warn" tooltip="Remove"
         (clicked)="removeGroupBy(level.index)" data-testid="report-grouping-remove"></app-button>
     </div>

--- a/desktop/src/reports/report-config-panel/report-config-panel.component.spec.ts
+++ b/desktop/src/reports/report-config-panel/report-config-panel.component.spec.ts
@@ -89,7 +89,7 @@ describe("ReportConfigPanelComponent", () => {
     component.addGroupControl.setValue("paid_by");
 
     expect(groupBy.length).toBe(1);
-    expect(groupBy.at(0).value).toBe("paid_by");
+    expect(groupBy.at(0).value).toEqual({ field: "paid_by", label: "" });
     expect(component.addGroupControl.value).toBeNull();
   });
 
@@ -147,6 +147,106 @@ describe("ReportConfigPanelComponent", () => {
   it("addGroupBy ignores an empty key", () => {
     component.addGroupBy("");
     expect(component.groupByLevels().length).toBe(0);
+  });
+
+  // ---- grouping column headings ------------------------------------------
+
+  function groupByArray(): FormArray {
+    return form.get("groupBy") as FormArray;
+  }
+
+  it("opens the column picker for a grouping level with its field locked and seeded", () => {
+    component.addGroupBy("paid_by");
+    dialog.open.mockReturnValue({ afterClosed: () => of(undefined) });
+
+    component.openGroupingLabelPicker(0);
+
+    const data = dialog.open.mock.calls[0][1].data;
+    expect(data.lockField).toBe(true);
+    // Handed to the picker as the dimension column it is, seeded with the heading
+    // the level currently renders with, so the picker opens straight on the
+    // dimension step in edit mode.
+    expect(data.column).toEqual(
+      expect.objectContaining({
+        kind: ReportColumn.KindEnum.Dimension,
+        field: "paid_by",
+        label: "Paid By",
+      })
+    );
+    expect(data.column.id).toBeTruthy();
+  });
+
+  it("stores a renamed heading on the level and shows it in the grouping list", () => {
+    component.addGroupBy("paid_by");
+    dialog.open.mockReturnValue({
+      afterClosed: () =>
+        of({ id: "x", kind: ReportColumn.KindEnum.Dimension, name: "paid_by", label: "  Payer  ", field: "paid_by" }),
+    });
+
+    component.openGroupingLabelPicker(0);
+
+    expect(groupByArray().at(0).get("label")!.value).toBe("Payer");
+    expect(component.groupByLevels().map((level) => level.label)).toEqual(["Payer"]);
+  });
+
+  it("clears the override when the entered heading is the field's own label", () => {
+    component.addGroupBy("paid_by");
+    dialog.open.mockReturnValue({
+      afterClosed: () =>
+        of({ id: "x", kind: ReportColumn.KindEnum.Dimension, name: "paid_by", label: "Payer", field: "paid_by" }),
+    });
+    component.openGroupingLabelPicker(0);
+    expect(groupByArray().at(0).get("label")!.value).toBe("Payer");
+
+    // Retyping the catalog label is how a user resets to the default — nothing is
+    // stored, so the report falls back to the field's own heading.
+    dialog.open.mockReturnValue({
+      afterClosed: () =>
+        of({ id: "x", kind: ReportColumn.KindEnum.Dimension, name: "paid_by", label: "Paid By", field: "paid_by" }),
+    });
+    component.openGroupingLabelPicker(0);
+
+    expect(groupByArray().at(0).get("label")!.value).toBe("");
+    expect(component.groupByLevels().map((level) => level.label)).toEqual(["Paid By"]);
+  });
+
+  it("is a no-op when the picker is cancelled", () => {
+    component.addGroupBy("paid_by");
+    dialog.open.mockReturnValue({ afterClosed: () => of(undefined) });
+
+    component.openGroupingLabelPicker(0);
+
+    expect(groupByArray().at(0).get("label")!.value).toBe("");
+  });
+
+  it("keeps a heading with its level when the levels are reordered", () => {
+    component.addGroupBy("paid_by");
+    component.addGroupBy("tag");
+    dialog.open.mockReturnValue({
+      afterClosed: () =>
+        of({ id: "x", kind: ReportColumn.KindEnum.Dimension, name: "tag", label: "Label", field: "tag" }),
+    });
+    component.openGroupingLabelPicker(1);
+
+    component.moveGroupBy(1, -1);
+
+    expect(component.groupByLevels().map((level) => level.label)).toEqual(["Label", "Paid By"]);
+  });
+
+  it("drops the heading with the level it belongs to", () => {
+    component.addGroupBy("paid_by");
+    dialog.open.mockReturnValue({
+      afterClosed: () =>
+        of({ id: "x", kind: ReportColumn.KindEnum.Dimension, name: "paid_by", label: "Payer", field: "paid_by" }),
+    });
+    component.openGroupingLabelPicker(0);
+
+    // Removing then re-adding the field must not resurrect the old rename.
+    component.removeGroupBy(0);
+    component.addGroupBy("paid_by");
+
+    expect(groupByArray().at(0).get("label")!.value).toBe("");
+    expect(component.groupByLevels().map((level) => level.label)).toEqual(["Paid By"]);
   });
 
   // ---- custom fields ------------------------------------------------------

--- a/desktop/src/reports/report-config-panel/report-config-panel.component.ts
+++ b/desktop/src/reports/report-config-panel/report-config-panel.component.ts
@@ -25,7 +25,11 @@ import {
 } from "../models/report-catalog.constants";
 import { CHIP_COLORS, groupInitials } from "../models/report-chip.util";
 import { isDimensionColumnDisabled, ReportColumnValue } from "../models/report-command.mapper";
-import { buildColumnGroup } from "../models/report-form.factory";
+import {
+  buildColumnGroup,
+  buildGroupByGroup,
+  readGroupByFields,
+} from "../models/report-form.factory";
 import { formatPeriodRange, resolvePeriodRange } from "../models/report-period.util";
 import { ReportCatalogService } from "../services/report-catalog.service";
 import {
@@ -66,6 +70,11 @@ interface ColumnRow {
   disabled: boolean;
   disabledReason: string;
 }
+
+// The id the grouping level's synthetic column carries into the picker. The
+// picker only reads it as "this is an edit, not a new column" (and hands it back
+// untouched), so it is a constant rather than a real row id.
+const GROUPING_LEVEL_COLUMN_ID = "grouping-level";
 
 const KIND_META: Record<ReportColumn.KindEnum, { label: string; icon: string; cssClass: string }> = {
   dimension: { label: "Dim", icon: "sell", cssClass: "kind-dimension" },
@@ -135,10 +144,12 @@ export class ReportConfigPanelComponent implements OnInit {
   public readonly groupByLevels = computed<GroupByLevel[]>(() => {
     this.revision();
     const controls = this.groupByArray.controls;
-    return controls.map((control, index) => ({
+    return controls.map((_, index) => ({
       index,
-      label: this.labelForField(control.value as string),
-      isCustom: this.isCustomField(control.value as string),
+      // A level renders as a leading column in the report, so it shows the
+      // heading that column will carry: the user's override when set.
+      label: this.headingForLevel(index),
+      isCustom: this.isCustomField(this.fieldForLevel(index)),
       isFirst: index === 0,
       isLast: index === controls.length - 1,
     }));
@@ -146,7 +157,7 @@ export class ReportConfigPanelComponent implements OnInit {
 
   public readonly addableDimensions = computed<ReportField[]>(() => {
     this.revision();
-    const used = new Set(this.groupByArray.controls.map((control) => control.value as string));
+    const used = new Set(readGroupByFields(this.groupByArray));
     return this.dimensions().filter((field) => !used.has(field.key));
   });
 
@@ -154,7 +165,7 @@ export class ReportConfigPanelComponent implements OnInit {
     this.revision();
     const mode = this.detailMode;
     const detailBy = this.form().get("detail.by")!.value as string;
-    const groupBy = this.groupByArray.controls.map((control) => control.value as string);
+    const groupBy = readGroupByFields(this.groupByArray);
     const controls = this.columnsArray.controls;
     return controls.map((control, index) => {
       const value = control.value as ReportColumnValue;
@@ -266,8 +277,48 @@ export class ReportConfigPanelComponent implements OnInit {
     if (!key) {
       return;
     }
-    this.groupByArray.push(this.formBuilder.control(key));
+    this.groupByArray.push(buildGroupByGroup(this.formBuilder, key));
     this.bump();
+  }
+
+  /**
+   * Renames the column this grouping level renders as, through the same picker a
+   * regular dimension column uses — with its field locked, since the field is
+   * chosen by the grouping level itself. The override is dropped when the entered
+   * label is the field's own catalog label, so retyping the default resets it.
+   */
+  public openGroupingLabelPicker(index: number): void {
+    const level = this.groupByArray.at(index);
+    const field = this.fieldForLevel(index);
+    const data: ColumnPickerDialogData = {
+      dimensions: this.dimensions(),
+      measures: this.measures(),
+      existingColumns: this.columnsArray.controls.map(
+        (control) => control.value as ReportColumnValue
+      ),
+      // A grouping level *is* a dimension column, so it is handed to the picker as
+      // one: an id makes the picker treat it as an edit (seeding the label and
+      // opening straight on the dimension step) rather than a new column.
+      column: {
+        id: GROUPING_LEVEL_COLUMN_ID,
+        kind: ReportColumn.KindEnum.Dimension,
+        name: field,
+        label: this.headingForLevel(index),
+        field,
+      },
+      lockField: true,
+    };
+    this.dialog
+      .open(ColumnPickerDialogComponent, { ...DEFAULT_DIALOG_CONFIG, data })
+      .afterClosed()
+      .subscribe((result?: ReportColumnValue) => {
+        if (!result) {
+          return;
+        }
+        const label = result.label.trim();
+        level.get("label")!.setValue(label === this.labelForField(field) ? "" : label);
+        this.bump();
+      });
   }
 
   public moveGroupBy(index: number, delta: number): void {
@@ -336,6 +387,21 @@ export class ReportConfigPanelComponent implements OnInit {
 
   private labelForField(key: string): string {
     return this.dimensions().find((field) => field.key === key)?.label ?? key;
+  }
+
+  /** The engine field key the grouping level at [index] nests by. */
+  private fieldForLevel(index: number): string {
+    return this.groupByArray.at(index).get("field")!.value as string;
+  }
+
+  /**
+   * The heading the grouping level's column carries: the user's override when
+   * set, otherwise the field catalog's label. Mirrors the backend's
+   * buildDimensions, which resolves the same way when rendering the report.
+   */
+  private headingForLevel(index: number): string {
+    const override = ((this.groupByArray.at(index).get("label")!.value as string) ?? "").trim();
+    return override || this.labelForField(this.fieldForLevel(index));
   }
 
   /**

--- a/mobile/api/doc/ReportRequestCommand.md
+++ b/mobile/api/doc/ReportRequestCommand.md
@@ -13,6 +13,7 @@ Name | Type | Description | Notes
 **period** | [**ReportPeriod**](ReportPeriod.md) |  | 
 **filter** | [**ReceiptPagedRequestFilter**](ReceiptPagedRequestFilter.md) | Which receipts go into the report | [optional] 
 **groupBy** | **BuiltList&lt;String&gt;** | Ordered engine field keys to nest the report by | [optional] 
+**groupByLabels** | **BuiltMap&lt;String, String&gt;** | Column-heading overrides for the grouping levels, keyed by the groupBy field key. A key that is absent, blank, or not present in groupBy falls back to the field catalog's label. | [optional] 
 **detail** | [**ReportDetail**](ReportDetail.md) |  | 
 **columns** | [**BuiltList&lt;ReportColumn&gt;**](ReportColumn.md) |  | 
 **subtotals** | **bool** | Emit a subtotal row at each grouping level | [optional] 

--- a/mobile/api/lib/src/model/report_request_command.dart
+++ b/mobile/api/lib/src/model/report_request_command.dart
@@ -22,6 +22,7 @@ part 'report_request_command.g.dart';
 /// * [period] 
 /// * [filter] - Which receipts go into the report
 /// * [groupBy] - Ordered engine field keys to nest the report by
+/// * [groupByLabels] - Column-heading overrides for the grouping levels, keyed by the groupBy field key. A key that is absent, blank, or not present in groupBy falls back to the field catalog's label.
 /// * [detail] 
 /// * [columns] 
 /// * [subtotals] - Emit a subtotal row at each grouping level
@@ -48,6 +49,10 @@ abstract class ReportRequestCommand implements Built<ReportRequestCommand, Repor
   /// Ordered engine field keys to nest the report by
   @BuiltValueField(wireName: r'groupBy')
   BuiltList<String>? get groupBy;
+
+  /// Column-heading overrides for the grouping levels, keyed by the groupBy field key. A key that is absent, blank, or not present in groupBy falls back to the field catalog's label.
+  @BuiltValueField(wireName: r'groupByLabels')
+  BuiltMap<String, String>? get groupByLabels;
 
   @BuiltValueField(wireName: r'detail')
   ReportDetail get detail;
@@ -123,6 +128,13 @@ class _$ReportRequestCommandSerializer implements PrimitiveSerializer<ReportRequ
       yield serializers.serialize(
         object.groupBy,
         specifiedType: const FullType(BuiltList, [FullType(String)]),
+      );
+    }
+    if (object.groupByLabels != null) {
+      yield r'groupByLabels';
+      yield serializers.serialize(
+        object.groupByLabels,
+        specifiedType: const FullType(BuiltMap, [FullType(String), FullType(String)]),
       );
     }
     yield r'detail';
@@ -218,6 +230,13 @@ class _$ReportRequestCommandSerializer implements PrimitiveSerializer<ReportRequ
             specifiedType: const FullType(BuiltList, [FullType(String)]),
           ) as BuiltList<String>;
           result.groupBy.replace(valueDes);
+          break;
+        case r'groupByLabels':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType(BuiltMap, [FullType(String), FullType(String)]),
+          ) as BuiltMap<String, String>;
+          result.groupByLabels.replace(valueDes);
           break;
         case r'detail':
           final valueDes = serializers.deserialize(

--- a/mobile/api/lib/src/model/report_request_command.g.dart
+++ b/mobile/api/lib/src/model/report_request_command.g.dart
@@ -83,6 +83,8 @@ class _$ReportRequestCommand extends ReportRequestCommand {
   @override
   final BuiltList<String>? groupBy;
   @override
+  final BuiltMap<String, String>? groupByLabels;
+  @override
   final ReportDetail detail;
   @override
   final BuiltList<ReportColumn> columns;
@@ -105,6 +107,7 @@ class _$ReportRequestCommand extends ReportRequestCommand {
       required this.period,
       this.filter,
       this.groupBy,
+      this.groupByLabels,
       required this.detail,
       required this.columns,
       this.subtotals,
@@ -130,6 +133,7 @@ class _$ReportRequestCommand extends ReportRequestCommand {
         period == other.period &&
         filter == other.filter &&
         groupBy == other.groupBy &&
+        groupByLabels == other.groupByLabels &&
         detail == other.detail &&
         columns == other.columns &&
         subtotals == other.subtotals &&
@@ -146,6 +150,7 @@ class _$ReportRequestCommand extends ReportRequestCommand {
     _$hash = $jc(_$hash, period.hashCode);
     _$hash = $jc(_$hash, filter.hashCode);
     _$hash = $jc(_$hash, groupBy.hashCode);
+    _$hash = $jc(_$hash, groupByLabels.hashCode);
     _$hash = $jc(_$hash, detail.hashCode);
     _$hash = $jc(_$hash, columns.hashCode);
     _$hash = $jc(_$hash, subtotals.hashCode);
@@ -164,6 +169,7 @@ class _$ReportRequestCommand extends ReportRequestCommand {
           ..add('period', period)
           ..add('filter', filter)
           ..add('groupBy', groupBy)
+          ..add('groupByLabels', groupByLabels)
           ..add('detail', detail)
           ..add('columns', columns)
           ..add('subtotals', subtotals)
@@ -200,6 +206,12 @@ class ReportRequestCommandBuilder
   ListBuilder<String>? _groupBy;
   ListBuilder<String> get groupBy => _$this._groupBy ??= ListBuilder<String>();
   set groupBy(ListBuilder<String>? groupBy) => _$this._groupBy = groupBy;
+
+  MapBuilder<String, String>? _groupByLabels;
+  MapBuilder<String, String> get groupByLabels =>
+      _$this._groupByLabels ??= MapBuilder<String, String>();
+  set groupByLabels(MapBuilder<String, String>? groupByLabels) =>
+      _$this._groupByLabels = groupByLabels;
 
   ReportDetailBuilder? _detail;
   ReportDetailBuilder get detail => _$this._detail ??= ReportDetailBuilder();
@@ -241,6 +253,7 @@ class ReportRequestCommandBuilder
       _period = $v.period.toBuilder();
       _filter = $v.filter?.toBuilder();
       _groupBy = $v.groupBy?.toBuilder();
+      _groupByLabels = $v.groupByLabels?.toBuilder();
       _detail = $v.detail.toBuilder();
       _columns = $v.columns.toBuilder();
       _subtotals = $v.subtotals;
@@ -275,6 +288,7 @@ class ReportRequestCommandBuilder
             period: period.build(),
             filter: _filter?.build(),
             groupBy: _groupBy?.build(),
+            groupByLabels: _groupByLabels?.build(),
             detail: detail.build(),
             columns: columns.build(),
             subtotals: subtotals,
@@ -293,6 +307,8 @@ class ReportRequestCommandBuilder
         _filter?.build();
         _$failedField = 'groupBy';
         _groupBy?.build();
+        _$failedField = 'groupByLabels';
+        _groupByLabels?.build();
         _$failedField = 'detail';
         detail.build();
         _$failedField = 'columns';

--- a/mobile/api/lib/src/serializers.g.dart
+++ b/mobile/api/lib/src/serializers.g.dart
@@ -268,6 +268,10 @@ Serializers _$serializers = (Serializers().toBuilder()
           const FullType(BuiltList, const [const FullType(String)]),
           () => ListBuilder<String>())
       ..addBuilderFactory(
+          const FullType(
+              BuiltMap, const [const FullType(String), const FullType(String)]),
+          () => MapBuilder<String, String>())
+      ..addBuilderFactory(
           const FullType(BuiltList, const [const FullType(ReportColumn)]),
           () => ListBuilder<ReportColumn>())
       ..addBuilderFactory(


### PR DESCRIPTION
## Summary
Adds the ability to rename the column headings that grouping levels render as in reports. Each grouping level now carries an editable label that overrides the field catalog's default heading, with the ability to reset to the default by retyping the original field name.

## Key Changes

**Frontend (Desktop)**
- Modified `ReportGroupByValue` interface to include a `label` field alongside `field` for storing heading overrides
- Updated `ReportConfigPanelComponent` to:
  - Store grouping levels as `{ field, label }` objects instead of bare field keys
  - Add `openGroupingLabelPicker()` method that reuses `ColumnPickerDialogComponent` in a new locked-field mode
  - Display the heading override in the grouping list via `headingForLevel()`
  - Persist heading overrides when saving templates
- Enhanced `ColumnPickerDialogComponent` with `lockField` mode:
  - Hides the Back button (kind step unreachable)
  - Disables the Field picker (read-only)
  - Retitles dialog to "Grouping column"
  - Allows only the label to be edited
- Updated form factory to build grouping levels as FormGroups with field and label controls
- Modified `toReportRequestCommand()` to emit `groupByLabels` map (keyed by field) when levels are renamed
- Updated `groupingSummary()` to show renamed headings in the template list

**Backend (API)**
- Added `GroupByLabels` field to `ReportRequestCommand` (map of field key → heading override)
- Updated `buildDimensions()` to accept and apply label overrides from `GroupByLabels`
- Blank or missing overrides fall back to the field catalog's label
- Overrides for non-grouped fields are safely ignored

**API Contract**
- Updated OpenAPI spec to include `groupByLabels` in `ReportRequestCommand`
- Regenerated TypeScript and Dart clients

**Tests**
- Added comprehensive e2e test (`report-grouping-label.spec.ts`) covering:
  - Renaming a grouping column heading
  - Resetting to default by retyping the field label
  - Persisting headings in saved templates
- Added unit tests for component and mapper logic
- Updated existing tests to work with new `{ field, label }` structure

## Implementation Details

- Heading overrides are **keyed by field key** (not index-aligned) so reordering levels doesn't lose renames
- A blank label means "use the catalog default" — this is how users reset to the original heading
- The grouping level's synthetic column is handed to the picker with a constant id (`"grouping-level"`) to signal edit mode
- Whitespace-only labels are treated as blank (no override stored)
- The override is dropped when the level is removed, preventing resurrection on re-add

https://claude.ai/code/session_0116Lyvt7dEou1g4kudBCo1P

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for renaming report grouping-column headings.
  * Grouping labels can be edited, reset to their defaults, and preserved in saved report templates.
  * Custom headings appear in report previews and generated reports.
  * Added API support for optional grouping-label overrides across desktop and mobile clients.

* **Bug Fixes**
  * Blank, invalid, or unrelated label overrides now correctly fall back to default field labels.
  * Grouping data types, formatting, ordering, and field selections remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->