### PR TITLE
Make report columns section editable in both detail modes

### DIFF
--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -1130,8 +1130,10 @@ endpoint); the builder's own ad-hoc generate still gates on `app.reports.generat
     too: each record gets its own accumulator set (so `SUM(amount)` is that receipt's amount and
     `COUNT()` is 1), and they still roll up correctly across subtotal/grand-total rows. A Records-only
     hint (`report-columns-records-note`) explains this above the list; the aggregate-only "aggregate by"
-    select is the one control the mode still toggles. One shared column set spans both modes — switching
-    modes never rewrites it, it just re-derives which columns are disabled.
+    select (`report-detail-aggregate-by` — it has no `label`, so per the e2e locator rules it carries a
+    `data-testid` rather than being matched on its sibling span's copy) is the one control the mode still
+    toggles. One shared column set spans both modes — switching modes never rewrites it, it just
+    re-derives which columns are disabled.
   - **Aggregate dimension-column rule**: in aggregate mode the engine can only label an (aggregated) row
     by a field it's grouped/aggregated by, so a dimension column is valid only when its `field` is the
     `detail.by` dimension or one of the `groupBy` levels. Rather than error, such a column is **disabled**

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -1121,6 +1121,17 @@ endpoint); the builder's own ad-hoc generate still gates on `app.reports.generat
   derived identifier kept stable across label edits (`report-column.util.ts`); formula validation is
   lightweight inline feedback — the backend is the authoritative validator (a bad spec → 400, surfaced by
   the interceptor). Grouping levels and columns reorder via up/down (no drag-and-drop).
+  - **The section is editable in *both* detail modes.** It used to be replaced by a note in Records mode
+    ("columns are the receipt fields") — which was never true: the `columns` FormArray was still posted,
+    the user just could not see or change it. In Records mode a detail row *is* one receipt, so the
+    engine reads a dimension column straight off that record (`emitRecordRows` →
+    `record.Get(column.field)`) and the disabled-dimension rule below does not apply — a column may read
+    **any** catalog field with no grouping level for it. Aggregates and formulas are configurable there
+    too: each record gets its own accumulator set (so `SUM(amount)` is that receipt's amount and
+    `COUNT()` is 1), and they still roll up correctly across subtotal/grand-total rows. A Records-only
+    hint (`report-columns-records-note`) explains this above the list; the aggregate-only "aggregate by"
+    select is the one control the mode still toggles. One shared column set spans both modes — switching
+    modes never rewrites it, it just re-derives which columns are disabled.
   - **Aggregate dimension-column rule**: in aggregate mode the engine can only label an (aggregated) row
     by a field it's grouped/aggregated by, so a dimension column is valid only when its `field` is the
     `detail.by` dimension or one of the `groupBy` levels. Rather than error, such a column is **disabled**

--- a/desktop/e2e/report-config.spec.ts
+++ b/desktop/e2e/report-config.spec.ts
@@ -49,18 +49,39 @@ test.describe('Report Builder — configuration', () => {
     await expect(labels).toHaveText(['Tag', 'Paid By']);
   });
 
-  test('switching detail mode shows or hides the columns section', async ({ page }) => {
-    // Default is Aggregate: the custom-column UI is present.
+  test('the columns section stays configurable in both detail modes', async ({ page }) => {
+    const note = page.getByTestId('report-columns-records-note');
+    // The "aggregate by" picker is a bare span + unlabelled app-select, so it has
+    // no accessible name — locate it by its own text.
+    const aggregateBy = page.getByText('aggregate by', { exact: true });
+
+    // Default is Aggregate: columns are editable, and the records hint is absent.
     await expect(page.getByTestId('report-add-column')).toBeVisible();
+    await expect(aggregateBy).toBeVisible();
+    await expect(note).toHaveCount(0);
 
-    // Records mode: columns are the receipt fields, so the custom-column UI is gone.
+    // Records mode keeps the same columns UI, adding a hint about what a column
+    // means on a record row. The aggregate-only "aggregate by" select is what goes.
     await page.getByTestId('report-detail-records').click();
-    await expect(page.getByTestId('report-add-column')).toHaveCount(0);
-    await expect(page.getByText('Switch to Aggregate to define custom columns')).toBeVisible();
+    await expect(page.getByTestId('report-add-column')).toBeVisible();
+    await expect(note).toBeVisible();
+    await expect(aggregateBy).toHaveCount(0);
 
-    // Back to Aggregate: the Add column control returns.
+    // A record row reads the field off the receipt, so a dimension column over a
+    // field that is neither grouped nor summarized by is valid here. The picker
+    // presets the first dimension (Paid By); nothing groups by it.
+    await page.getByTestId('report-add-column').click();
+    await page.getByTestId('picker-kind-dimension').click();
+    await page.getByTestId('picker-save').click();
+    await expect(page.getByTestId('report-column-row').filter({ hasText: 'Paid By' })).toBeVisible();
+    await expect(page.getByTestId('report-column-disabled')).toHaveCount(0);
+
+    // Back in Aggregate mode that same column can no longer be resolved, so it
+    // greys out rather than disappearing — the existing self-healing behaviour.
     await page.getByTestId('report-detail-aggregate').click();
     await expect(page.getByTestId('report-add-column')).toBeVisible();
+    await expect(note).toHaveCount(0);
+    await expect(page.getByTestId('report-column-disabled').filter({ hasText: 'Paid By' })).toBeVisible();
   });
 
   test('the custom period range reveals date pickers', async ({ page }) => {

--- a/desktop/e2e/report-config.spec.ts
+++ b/desktop/e2e/report-config.spec.ts
@@ -51,9 +51,7 @@ test.describe('Report Builder — configuration', () => {
 
   test('the columns section stays configurable in both detail modes', async ({ page }) => {
     const note = page.getByTestId('report-columns-records-note');
-    // The "aggregate by" picker is a bare span + unlabelled app-select, so it has
-    // no accessible name — locate it by its own text.
-    const aggregateBy = page.getByText('aggregate by', { exact: true });
+    const aggregateBy = page.getByTestId('report-detail-aggregate-by');
 
     // Default is Aggregate: columns are editable, and the records hint is absent.
     await expect(page.getByTestId('report-add-column')).toBeVisible();

--- a/desktop/src/reports/report-config-panel/report-config-panel.component.html
+++ b/desktop/src/reports/report-config-panel/report-config-panel.component.html
@@ -101,40 +101,41 @@
 <!-- Columns -->
 <app-report-section icon="view_column" headerText="Columns" subtitle="Dimensions, aggregates & formulas">
   @if (detailMode === ReportDetailMode.Records) {
-    <div class="report-config__note">
+    <div class="report-config__note" data-testid="report-columns-records-note">
       <mat-icon>info</mat-icon>
-      In Records mode columns are the receipt fields. Switch to Aggregate to define custom columns.
+      Each row is one receipt, so a dimension column shows that receipt's own value — it doesn't have to be
+      something you group by. Aggregates and formulas read a single receipt per row, and still roll up across
+      the subtotal and grand total rows.
     </div>
-  } @else {
-    @for (column of columnRows(); track column.id) {
-      <div class="report-config__list-row" [class.report-config__list-row--disabled]="column.disabled"
-        [attr.data-testid]="column.disabled ? 'report-column-disabled' : 'report-column-row'">
-        <span class="report-config__kind" [ngClass]="column.kindClass">
-          <mat-icon>{{ column.kindIcon }}</mat-icon>
-        </span>
-        <div class="report-config__col-text">
-          <div class="report-config__col-label">{{ column.label }}</div>
-          <div class="report-config__col-desc">{{ column.disabled ? column.disabledReason : column.description }}</div>
-        </div>
-        @if (column.isCustom) {
-          <span class="report-config__kind-badge report-config__custom-badge"
-            data-testid="report-column-custom">{{ customFieldBadge }}</span>
-        }
-        <span class="report-config__kind-badge" [ngClass]="column.kindClass">{{ column.kindLabel }}</span>
-        <app-button matButtonType="iconButton" icon="arrow_upward" tooltip="Move up" [disabled]="column.isFirst"
-          (clicked)="moveColumn(column.index, -1)" data-testid="report-column-up"></app-button>
-        <app-button matButtonType="iconButton" icon="arrow_downward" tooltip="Move down" [disabled]="column.isLast"
-          (clicked)="moveColumn(column.index, 1)" data-testid="report-column-down"></app-button>
-        <app-button matButtonType="iconButton" icon="edit" tooltip="Edit"
-          (clicked)="openColumnPicker(column.index)" data-testid="report-column-edit"></app-button>
-        <app-button matButtonType="iconButton" icon="close" color="warn" tooltip="Remove"
-          (clicked)="removeColumn(column.index)" data-testid="report-column-remove"></app-button>
-      </div>
-    }
-    <button type="button" class="report-config__add-block" (click)="openColumnPicker()" data-testid="report-add-column">
-      <mat-icon>add</mat-icon>Add column
-    </button>
   }
+  @for (column of columnRows(); track column.id) {
+    <div class="report-config__list-row" [class.report-config__list-row--disabled]="column.disabled"
+      [attr.data-testid]="column.disabled ? 'report-column-disabled' : 'report-column-row'">
+      <span class="report-config__kind" [ngClass]="column.kindClass">
+        <mat-icon>{{ column.kindIcon }}</mat-icon>
+      </span>
+      <div class="report-config__col-text">
+        <div class="report-config__col-label">{{ column.label }}</div>
+        <div class="report-config__col-desc">{{ column.disabled ? column.disabledReason : column.description }}</div>
+      </div>
+      @if (column.isCustom) {
+        <span class="report-config__kind-badge report-config__custom-badge"
+          data-testid="report-column-custom">{{ customFieldBadge }}</span>
+      }
+      <span class="report-config__kind-badge" [ngClass]="column.kindClass">{{ column.kindLabel }}</span>
+      <app-button matButtonType="iconButton" icon="arrow_upward" tooltip="Move up" [disabled]="column.isFirst"
+        (clicked)="moveColumn(column.index, -1)" data-testid="report-column-up"></app-button>
+      <app-button matButtonType="iconButton" icon="arrow_downward" tooltip="Move down" [disabled]="column.isLast"
+        (clicked)="moveColumn(column.index, 1)" data-testid="report-column-down"></app-button>
+      <app-button matButtonType="iconButton" icon="edit" tooltip="Edit"
+        (clicked)="openColumnPicker(column.index)" data-testid="report-column-edit"></app-button>
+      <app-button matButtonType="iconButton" icon="close" color="warn" tooltip="Remove"
+        (clicked)="removeColumn(column.index)" data-testid="report-column-remove"></app-button>
+    </div>
+  }
+  <button type="button" class="report-config__add-block" (click)="openColumnPicker()" data-testid="report-add-column">
+    <mat-icon>add</mat-icon>Add column
+  </button>
 </app-report-section>
 
 <!-- Totals -->

--- a/desktop/src/reports/report-config-panel/report-config-panel.component.html
+++ b/desktop/src/reports/report-config-panel/report-config-panel.component.html
@@ -93,6 +93,7 @@
         optionValueKey="value" optionDisplayKey="displayValue" optionBadgeKey="badge"
         [options]="dimensionOptions()"
         [inputFormControl]="form() | formGet: 'detail.by'"
+        data-testid="report-detail-aggregate-by"
       ></app-select>
     </div>
   }

--- a/desktop/src/reports/report-config-panel/report-config-panel.component.spec.ts
+++ b/desktop/src/reports/report-config-panel/report-config-panel.component.spec.ts
@@ -281,6 +281,20 @@ describe("ReportConfigPanelComponent", () => {
     expect(total.disabled).toBe(false);
   });
 
+  it("columnRows leaves every dimension column enabled in records mode", () => {
+    columnsArray().push(buildColumnGroup(formBuilder, { kind: ReportColumn.KindEnum.Dimension, name: "Category", label: "Category", field: "category" }));
+
+    // The same config that disables the column in aggregate mode: summarizing by
+    // tag, no grouping. A record row reads the field off the receipt itself, so
+    // the column stays enabled and configurable.
+    form.get("detail.by")!.setValue("tag");
+    component.setDetailMode(ReportDetail.ModeEnum.Records);
+
+    const category = component.columnRows().find((row) => row.label === "Category")!;
+    expect(category.disabled).toBe(false);
+    expect(category.disabledReason).toBe("");
+  });
+
   // ---- parameters + document --------------------------------------------
 
   it("periodLabel resolves the preset, and reports a custom range with no dates", () => {


### PR DESCRIPTION
## Summary
The report builder's Columns section is now fully editable in both Records and Aggregate detail modes, rather than being replaced by a read-only note in Records mode. This aligns the UI with the actual backend behavior, which has always supported columns in both modes.

**This is a template-only change.** No production logic, backend, `swagger.yml`, generated-client or mobile code is touched — the engine, the service-side projection and the desktop mapper already handled Records mode correctly. The only reason columns were unavailable there was one `@if`/`@else` in the config panel template.

## Key Changes

- **Template restructuring**: Moved the column list and "Add column" button out of the `@else` block so they render in both detail modes. The informational note now only appears in Records mode, with accurate guidance.

- **Updated Records mode hint**: Replaced the misleading "Switch to Aggregate to define custom columns" message. That note was never true — the `columns` FormArray was still mapped and posted in Records mode, so users were stuck with whatever columns already existed (the three defaults, or whatever a loaded template stored) with no way to see or change them. The new hint explains that each row is one receipt, dimension columns read that receipt's own field value, and aggregates/formulas still roll up correctly across subtotal/grand-total rows.

- **Test coverage for the Records-mode dimension rule**: added a unit case asserting `columnRows()` reports `disabled: false` for a dimension column on a non-grouped field in Records mode. Note this is **coverage only** — no validation logic changed. `isDimensionColumnDisabled` (`report-command.mapper.ts`) and its Go twin `isDisabledDimensionColumn` (`report_service.go`) were already mode-aware and both short-circuit to `false` for Records on their first line.

- **Test updates**: Replaced the old test that expected columns to disappear in Records mode with `the columns section stays configurable in both detail modes`, verifying that columns stay editable in both modes, the Records hint appears/disappears appropriately, a dimension column over an ungrouped field is valid in Records mode but greys out in Aggregate mode, and the aggregate-only "aggregate by" select is the control that toggles with mode.

## Why the backend already supported this

- `emitRecordRows` reads a label column straight off the record (`record.Get(column.field)`), so in Records mode a dimension column may read **any** catalog field with no grouping level for it.
- `compileLabelColumn` guards its unresolvable-label rejection on `Detail.isAggregate()`, so it cannot fire in Records mode.
- Aggregate columns get a per-record accumulator set, so `SUM(amount)` is that receipt's own amount and `COUNT()` is 1 — and they still roll up correctly into subtotal and grand-total rows. Formulas recompute per row.

Verified end to end against a running API: a Records report with `Name`, `Status` and `Date` dimension columns — none of them grouped by — returns 200 and renders one row per receipt with each receipt's own values, aggregates summing to a correct grand total.

## Notes for reviewers

One shared column set spans both modes: switching modes never rewrites it, it just re-derives which columns are disabled. Save still persists every column, so a column that is disabled in Aggregate mode round-trips into a reopened template and re-enables when the config makes it valid again.

`desktop/e2e/report-config.spec.ts` has two **pre-existing** flaky tests (`adds and removes grouping levels`, `reorders grouping levels`) that intermittently fail on a chained `addGroupingLevel(…'Tag')` pick — the debounced preview re-renders the config panel and detaches the open mat-select panel. Measured at 3 failures/5 runs on the unmodified base vs 2/5 on this branch, so it is not caused by this change and is left out of scope.

https://claude.ai/code/session_0134CTjbcb94ohQQ1oN73zzg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reports column configuration is now editable in both Records and Aggregate detail modes.
  * Add and configure dimension, aggregate, and formula columns without leaving Records mode.
  * Records mode includes guidance on dimension values and aggregate behavior across subtotal and grand-total rows.
  * Aggregate mode retains mode-specific controls and automatically handles unresolved columns.

* **Tests**
  * Added coverage for column editing, mode-specific behavior, and dimension-column availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->