### PR TITLE
Add configurable refresh token lifetime settings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,6 +210,13 @@ dev libs must be installed by hand.
 - Desktop stores tokens via NGXS persistent storage
 - Mobile uses `flutter_secure_storage` for secure token storage
 - All API endpoints except `/api/auth/login` and `/api/auth/signup` require authentication
+- **The refresh-token lifetime is a System Setting** (`refreshTokenValidForHours`, plus a separate
+  `mcpRefreshTokenValidForHours` for connector tokens) so each install can pick its own security
+  posture. Because refresh tokens rotate on every use, it is an **inactivity timeout, not an
+  absolute session cap**. The **access token is deliberately fixed at 20 minutes** — both clients
+  size their 15-minute proactive refresh timer against it, and neither client needed any change for
+  this. See `api/CLAUDE.md` → "Session lifetime" and `desktop/CLAUDE.md` → "Session lifetime
+  settings".
 
 ### Authorization (Roles & Permissions)
 - A configurable role system layers on top of auth: administrators define **app-level** and

--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -1108,6 +1108,63 @@ Claude can read a user's data. It is **off by default** and Go-native (no separa
 - **Production**: `docker/default.conf` proxies the new root paths to the backend; the `/mcp`
   location disables buffering and raises the read timeout for SSE streams.
 
+## Session lifetime (configurable refresh-token expiry)
+
+How long a signed-in user stays signed in is an admin setting rather than a compile-time constant.
+Two System Settings drive it (`models.SystemSettings`, edited via the System Settings UI, validated
+in `commands.UpsertSystemSettingsCommand.Validate`):
+
+- `refreshTokenValidForHours` (int, default 24) — the REST/app refresh-token lifetime.
+- `mcpRefreshTokenValidForHours` (int, default 24) — the same for MCP/OAuth connector tokens, kept
+  **separate on purpose** so a long window chosen for human convenience does not silently extend
+  tokens held by third-party clients.
+
+Both are **whole hours**, bounded to **1-720 (30 days)**, and `0` means "unset, use the default"
+(the `pdfDpi` convention) so a client that omits the field is tolerated rather than 400'd.
+
+**It is an inactivity timeout, not an absolute session cap.** Refresh tokens rotate on every use and
+both clients proactively refresh on a 15-minute timer, so an actively-used session re-mints itself
+indefinitely; the window only bites once a client has been away longer than it. There is no
+absolute cap — adding one would need a session-start timestamp threaded through every rotation.
+A useful corollary: **lowering** the setting takes effect for active sessions at their next refresh
+(~15 min), so only genuinely idle sessions coast on their original expiry. Nothing is bulk-revoked.
+
+**The access token is deliberately NOT configurable** and stays at 20 minutes
+(`utils.GetAccessTokenExpiryDate`). It is stateless and unrevocable, and both clients size their
+15-minute refresh timer against that fixed window — making it configurable would break them and
+widen the blast radius of a leaked token. This is also why `oauth.accessTokenExpiresIn` (the OAuth
+`expires_in`, RFC 6749 — which describes the access token only) still mirrors 20 minutes correctly.
+
+**Where the value is resolved.** `internal/utils` imports nothing from `internal/`, so it cannot
+read System Settings without an import cycle; `utils.GetRefreshTokenExpiryDate(lifetime)` therefore
+takes the duration as a parameter. `services.GetRefreshTokenLifetime()` /
+`GetMcpRefreshTokenLifetime()` do the live read and hand it to `generateTokenPair`, falling back to
+24h on error/unset/out-of-range via `clampRefreshTokenLifetime` — the same clamp-with-fallback shape
+as `repositories.pdfRasterizationDpi`. **The clamp, not the validator, is the real safety net**: it
+stops a bad stored value from ever producing a token regardless of how it got there. The bounds
+themselves live in `commands` (`Min`/`MaxRefreshTokenValidForHours`) and are imported by `services`,
+so validation and the clamp cannot drift. `BuildTokenCookies` resolves the app lifetime itself for
+the refresh cookie's `Expires` — both its call sites (login, token refresh) are REST-only, never
+MCP.
+
+The `@every 24h` refresh-token cleanup cron is unaffected: it deletes on `is_used = true` as well as
+expiry, and rotation marks the previous token used immediately, so the table stays small at any TTL.
+
+**Refresh-token consumption is atomic.** `middleware.RevokeRefreshToken` marks the token used with a
+single `UPDATE ... WHERE token = ? AND is_used = false` and checks `RowsAffected`, mirroring
+`oauth.rotateRefreshToken`. It used to read then update separately, which let two concurrent
+refreshes both observe `is_used = false` and rotate — defeating replay detection, and logging the
+loser out of every tab once the rotation it lost landed. Unknown and already-used tokens are
+deliberately indistinguishable (both already returned the same response). Guarded by
+`TestRevokeRefreshToken_ConcurrentRefreshesOnlyOneSucceeds`.
+
+Tests: `services/refresh_token_lifetime_test.go` (clamp table, per-field isolation, expiry stamped
+on both the JWT claim and the persisted row, MCP using its own setting, access token unchanged),
+`commands/upsert_system_settings_command_test.go` (bounds + the `0` escape hatch),
+`middleware/refresh_token_test.go` (the concurrency guard), `utils/auth_test.go` (the helper honors
+whatever lifetime it is handed), and `desktop/e2e/session-lifetime.spec.ts` (the only end-to-end
+proof that the setting reaches the `Set-Cookie` header).
+
 ## Login QR & mobile deep link
 
 The desktop login page can show a self-contained QR that sets up the mobile app. Two System Settings

--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -1123,13 +1123,27 @@ Both are **whole hours**, bounded to **1-720 (30 days)**. There are two distinct
 and the difference matters:
 
 - **Key omitted from the PUT body** (`nil` on the command) — the stored value is left alone. The
-  command fields are `*int` and `ApplyOmittedLifetimes` carries the existing value onto the update,
-  because `UpdateSystemSettings` writes every column with `Select("*")`: a plain `int` would persist
-  as `0` and silently reset a configured lifetime whenever any client PUT a partial body. Same
-  hazard and same fix as the pointer fields on `UpdateGroupReceiptSettingsCommand` (see the root
-  `CLAUDE.md` → "Group Default Custom Fields"). Guarded by
-  `TestUpdateSystemSettingsPreservesOmittedRefreshTokenLifetimes`, which drives a **raw JSON body**
-  through the handler — a typed command literal cannot express an absent key.
+  command fields are `*int`, because `UpdateSystemSettings` writes every column with `Select("*")`:
+  a plain `int` would persist as `0` and silently reset a configured lifetime whenever any client
+  PUT a partial body. Same hazard and same fix as the pointer fields on
+  `UpdateGroupReceiptSettingsCommand` (see the root `CLAUDE.md` → "Group Default Custom Fields").
+
+  **An omitted lifetime is dropped from the UPDATE entirely**, via
+  `OmittedLifetimeColumns()` feeding the existing `Omit(...)` on that statement — *not* by copying
+  the stored value onto the row. The distinction matters under concurrency: `existingSettings` is
+  read before the transaction, so two admins each setting one lifetime and omitting the other would
+  both write a full row and clobber each other's explicit value. A column that is never written
+  cannot be clobbered. This is deliberately **not** a `SELECT ... FOR UPDATE` row lock — SQLite is a
+  supported engine and rejects that syntax, there is no locking precedent anywhere in the codebase,
+  and a lock would only protect these two fields while every other column on this full-object upsert
+  stays last-write-wins. `ApplyOmittedLifetimes` still runs, but only so the response body echoes the
+  stored value instead of a misleading `0`.
+
+  Guarded by `TestUpdateSystemSettingsPreservesOmittedRefreshTokenLifetimes` (a **raw JSON body**
+  through the handler — a typed command literal cannot express an absent key),
+  `TestUpdateSystemSettingsOmitsUnsentLifetimeColumns` (the generated SQL), and
+  `TestUpdateSystemSettingsConcurrentLifetimeUpdatesBothSurvive` (two concurrent updates; fails on
+  the first attempt without the column skip).
 - **Explicit `0`** — means "unset, use the built-in default" (the `pdfDpi` convention). Valid, and
   resolved by the clamp on read.
 
@@ -1174,7 +1188,8 @@ on both the JWT claim and the persisted row, MCP using its own setting, access t
 `commands/upsert_system_settings_command_test.go` (bounds + the `0` escape hatch),
 `middleware/refresh_token_test.go` (the concurrency guard), `utils/auth_test.go` (the helper honors
 whatever lifetime it is handed), `handlers/system_settings_handler_test.go` (the omitted-key and
-explicit-value endpoint round trips), and `desktop/e2e/session-lifetime.spec.ts` (the only
+explicit-value endpoint round trips), `repositories/system_settings_test.go` (the omitted-column SQL
+shape and the concurrent-update guard), and `desktop/e2e/session-lifetime.spec.ts` (the only
 end-to-end proof that the setting reaches the `Set-Cookie` header).
 
 ## Login QR & mobile deep link

--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -1119,8 +1119,19 @@ in `commands.UpsertSystemSettingsCommand.Validate`):
   **separate on purpose** so a long window chosen for human convenience does not silently extend
   tokens held by third-party clients.
 
-Both are **whole hours**, bounded to **1-720 (30 days)**, and `0` means "unset, use the default"
-(the `pdfDpi` convention) so a client that omits the field is tolerated rather than 400'd.
+Both are **whole hours**, bounded to **1-720 (30 days)**. There are two distinct "no value" cases,
+and the difference matters:
+
+- **Key omitted from the PUT body** (`nil` on the command) — the stored value is left alone. The
+  command fields are `*int` and `ApplyOmittedLifetimes` carries the existing value onto the update,
+  because `UpdateSystemSettings` writes every column with `Select("*")`: a plain `int` would persist
+  as `0` and silently reset a configured lifetime whenever any client PUT a partial body. Same
+  hazard and same fix as the pointer fields on `UpdateGroupReceiptSettingsCommand` (see the root
+  `CLAUDE.md` → "Group Default Custom Fields"). Guarded by
+  `TestUpdateSystemSettingsPreservesOmittedRefreshTokenLifetimes`, which drives a **raw JSON body**
+  through the handler — a typed command literal cannot express an absent key.
+- **Explicit `0`** — means "unset, use the built-in default" (the `pdfDpi` convention). Valid, and
+  resolved by the clamp on read.
 
 **It is an inactivity timeout, not an absolute session cap.** Refresh tokens rotate on every use and
 both clients proactively refresh on a 15-minute timer, so an actively-used session re-mints itself
@@ -1162,8 +1173,9 @@ Tests: `services/refresh_token_lifetime_test.go` (clamp table, per-field isolati
 on both the JWT claim and the persisted row, MCP using its own setting, access token unchanged),
 `commands/upsert_system_settings_command_test.go` (bounds + the `0` escape hatch),
 `middleware/refresh_token_test.go` (the concurrency guard), `utils/auth_test.go` (the helper honors
-whatever lifetime it is handed), and `desktop/e2e/session-lifetime.spec.ts` (the only end-to-end
-proof that the setting reaches the `Set-Cookie` header).
+whatever lifetime it is handed), `handlers/system_settings_handler_test.go` (the omitted-key and
+explicit-value endpoint round trips), and `desktop/e2e/session-lifetime.spec.ts` (the only
+end-to-end proof that the setting reaches the `Set-Cookie` header).
 
 ## Login QR & mobile deep link
 

--- a/api/internal/commands/upsert_system_settings_command.go
+++ b/api/internal/commands/upsert_system_settings_command.go
@@ -194,13 +194,36 @@ func (command *UpsertSystemSettingsCommand) ToSystemSettings(id uint) (models.Sy
 	return systemSettings, nil
 }
 
+// OmittedLifetimeColumns names the refresh-token lifetime fields the request did
+// not send, so the repository can leave those columns out of the UPDATE entirely.
+//
+// Skipping the column is what makes a concurrent update safe. Copying the stored
+// value onto the row instead (see ApplyOmittedLifetimes) would still write it,
+// so two requests that each set one lifetime and omit the other would clobber
+// each other with the values they read before the write. A column that is never
+// written cannot be clobbered, and unlike a row lock this works identically on
+// SQLite, MySQL and Postgres.
+func (command *UpsertSystemSettingsCommand) OmittedLifetimeColumns() []string {
+	columns := make([]string, 0, 2)
+
+	if command.RefreshTokenValidForHours == nil {
+		columns = append(columns, "RefreshTokenValidForHours")
+	}
+
+	if command.McpRefreshTokenValidForHours == nil {
+		columns = append(columns, "McpRefreshTokenValidForHours")
+	}
+
+	return columns
+}
+
 // ApplyOmittedLifetimes carries the stored refresh-token lifetimes onto the
 // settings a PUT is about to write for any key the request omitted.
 //
 // ToSystemSettings round-trips the command through JSON, so a nil pointer lands
-// as 0 on the model; the repository then writes every column with Select("*").
-// Without this, a client that PUTs a body lacking these keys would silently
-// reset an admin's configured session length to the default.
+// as 0 on the model. The columns themselves are excluded from the UPDATE by
+// OmittedLifetimeColumns, so this exists purely so the object echoed back in the
+// response carries the stored value rather than a misleading 0.
 func (command *UpsertSystemSettingsCommand) ApplyOmittedLifetimes(existing models.SystemSettings, updated *models.SystemSettings) {
 	if command.RefreshTokenValidForHours == nil {
 		updated.RefreshTokenValidForHours = existing.RefreshTokenValidForHours

--- a/api/internal/commands/upsert_system_settings_command.go
+++ b/api/internal/commands/upsert_system_settings_command.go
@@ -10,6 +10,14 @@ import (
 	"strings"
 )
 
+// Bounds on the configurable refresh-token lifetimes. They live here rather than
+// alongside the resolver in services/ because internal/commands cannot import
+// internal/services, and the validation and the read-side clamp must agree.
+const (
+	MinRefreshTokenValidForHours = 1
+	MaxRefreshTokenValidForHours = 720 // 30 days
+)
+
 type UpsertSystemSettingsCommand struct {
 	EnableLocalSignUp                   bool                                  `json:"enableLocalSignUp"`
 	DebugOcr                            bool                                  `json:"debugOcr"`
@@ -29,6 +37,8 @@ type UpsertSystemSettingsCommand struct {
 	McpPublicUrl                        string                                `json:"mcpPublicUrl"`
 	ShowLoginQr                         bool                                  `json:"showLoginQr"`
 	MobileServerUrl                     string                                `json:"mobileServerUrl"`
+	RefreshTokenValidForHours           int                                   `json:"refreshTokenValidForHours"`
+	McpRefreshTokenValidForHours        int                                   `json:"mcpRefreshTokenValidForHours"`
 }
 
 func (command *UpsertSystemSettingsCommand) LoadDataFromRequest(w http.ResponseWriter, r *http.Request) error {
@@ -112,7 +122,32 @@ func (command *UpsertSystemSettingsCommand) Validate() structs.ValidatorError {
 		errorMap["mobileServerUrl"] = "Mobile server URL must be an absolute URL like https://receipts.example.com/api"
 	}
 
+	if msg := validateRefreshTokenValidForHours(command.RefreshTokenValidForHours); len(msg) > 0 {
+		errorMap["refreshTokenValidForHours"] = msg
+	}
+
+	if msg := validateRefreshTokenValidForHours(command.McpRefreshTokenValidForHours); len(msg) > 0 {
+		errorMap["mcpRefreshTokenValidForHours"] = msg
+	}
+
 	return vErr
+}
+
+// validateRefreshTokenValidForHours bounds a refresh-token lifetime, returning an
+// empty string when the value is acceptable. Zero is deliberately allowed and
+// means "unset": the read side falls back to the built-in default, so a client
+// that omits the field (an older desktop build, say) is tolerated rather than
+// rejected. Shared by the app and MCP settings so the two cannot drift.
+func validateRefreshTokenValidForHours(hours int) string {
+	if hours == 0 {
+		return ""
+	}
+
+	if hours < MinRefreshTokenValidForHours || hours > MaxRefreshTokenValidForHours {
+		return "Refresh token lifetime must be between 1 and 720 hours (30 days)"
+	}
+
+	return ""
 }
 
 // isValidAbsoluteUrl reports whether the value is an absolute http(s) URL.

--- a/api/internal/commands/upsert_system_settings_command.go
+++ b/api/internal/commands/upsert_system_settings_command.go
@@ -37,8 +37,13 @@ type UpsertSystemSettingsCommand struct {
 	McpPublicUrl                        string                                `json:"mcpPublicUrl"`
 	ShowLoginQr                         bool                                  `json:"showLoginQr"`
 	MobileServerUrl                     string                                `json:"mobileServerUrl"`
-	RefreshTokenValidForHours           int                                   `json:"refreshTokenValidForHours"`
-	McpRefreshTokenValidForHours        int                                   `json:"mcpRefreshTokenValidForHours"`
+	// Pointers so an omitted key is distinguishable from an explicit 0. The
+	// repository writes every column (Select("*")), so a plain int would persist
+	// as 0 and silently reset a configured lifetime to the default whenever a
+	// client PUTs a body without these keys. Same reasoning as the pointer
+	// fields on UpdateGroupReceiptSettingsCommand.
+	RefreshTokenValidForHours    *int `json:"refreshTokenValidForHours"`
+	McpRefreshTokenValidForHours *int `json:"mcpRefreshTokenValidForHours"`
 }
 
 func (command *UpsertSystemSettingsCommand) LoadDataFromRequest(w http.ResponseWriter, r *http.Request) error {
@@ -134,16 +139,18 @@ func (command *UpsertSystemSettingsCommand) Validate() structs.ValidatorError {
 }
 
 // validateRefreshTokenValidForHours bounds a refresh-token lifetime, returning an
-// empty string when the value is acceptable. Zero is deliberately allowed and
-// means "unset": the read side falls back to the built-in default, so a client
-// that omits the field (an older desktop build, say) is tolerated rather than
-// rejected. Shared by the app and MCP settings so the two cannot drift.
-func validateRefreshTokenValidForHours(hours int) string {
-	if hours == 0 {
+// empty string when the value is acceptable.
+//
+// A nil pointer means the key was omitted, which leaves the stored value alone
+// (see ApplyOmittedLifetimes) and is always valid. An explicit 0 means "unset":
+// the read side falls back to the built-in default. Shared by the app and MCP
+// settings so the two cannot drift.
+func validateRefreshTokenValidForHours(hours *int) string {
+	if hours == nil || *hours == 0 {
 		return ""
 	}
 
-	if hours < MinRefreshTokenValidForHours || hours > MaxRefreshTokenValidForHours {
+	if *hours < MinRefreshTokenValidForHours || *hours > MaxRefreshTokenValidForHours {
 		return "Refresh token lifetime must be between 1 and 720 hours (30 days)"
 	}
 
@@ -185,4 +192,21 @@ func (command *UpsertSystemSettingsCommand) ToSystemSettings(id uint) (models.Sy
 	}
 
 	return systemSettings, nil
+}
+
+// ApplyOmittedLifetimes carries the stored refresh-token lifetimes onto the
+// settings a PUT is about to write for any key the request omitted.
+//
+// ToSystemSettings round-trips the command through JSON, so a nil pointer lands
+// as 0 on the model; the repository then writes every column with Select("*").
+// Without this, a client that PUTs a body lacking these keys would silently
+// reset an admin's configured session length to the default.
+func (command *UpsertSystemSettingsCommand) ApplyOmittedLifetimes(existing models.SystemSettings, updated *models.SystemSettings) {
+	if command.RefreshTokenValidForHours == nil {
+		updated.RefreshTokenValidForHours = existing.RefreshTokenValidForHours
+	}
+
+	if command.McpRefreshTokenValidForHours == nil {
+		updated.McpRefreshTokenValidForHours = existing.McpRefreshTokenValidForHours
+	}
 }

--- a/api/internal/commands/upsert_system_settings_command_test.go
+++ b/api/internal/commands/upsert_system_settings_command_test.go
@@ -84,6 +84,32 @@ func TestUpsertSystemSettingsCommand_Validate_ValidInputs(t *testing.T) {
 				return cmd
 			}(),
 		},
+		// Zero means "unset": a client that omits the field must not be rejected,
+		// the read side falls back to the default instead.
+		"valid with unset refresh token lifetimes": {
+			command: func() UpsertSystemSettingsCommand {
+				cmd := validSystemSettingsCommand()
+				cmd.RefreshTokenValidForHours = 0
+				cmd.McpRefreshTokenValidForHours = 0
+				return cmd
+			}(),
+		},
+		"valid with the minimum refresh token lifetimes": {
+			command: func() UpsertSystemSettingsCommand {
+				cmd := validSystemSettingsCommand()
+				cmd.RefreshTokenValidForHours = 1
+				cmd.McpRefreshTokenValidForHours = 1
+				return cmd
+			}(),
+		},
+		"valid with the maximum refresh token lifetimes": {
+			command: func() UpsertSystemSettingsCommand {
+				cmd := validSystemSettingsCommand()
+				cmd.RefreshTokenValidForHours = 720
+				cmd.McpRefreshTokenValidForHours = 720
+				return cmd
+			}(),
+		},
 	}
 
 	for testName, test := range tests {
@@ -153,7 +179,9 @@ func TestUpsertSystemSettingsCommand_Validate_InvalidInputs(t *testing.T) {
 			expectedError: "taskConcurrency",
 		},
 		"wrong queue config count": {
-			modify:        func(cmd *UpsertSystemSettingsCommand) { cmd.TaskQueueConfigurations = []UpsertTaskQueueConfigurationCommand{} },
+			modify: func(cmd *UpsertSystemSettingsCommand) {
+				cmd.TaskQueueConfigurations = []UpsertTaskQueueConfigurationCommand{}
+			},
 			expectedError: "taskQueueConfigurations",
 		},
 		"mcp enabled without a public url": {
@@ -187,12 +215,30 @@ func TestUpsertSystemSettingsCommand_Validate_InvalidInputs(t *testing.T) {
 		// The login QR is served to unauthenticated clients, so credentials in
 		// the URL would be published as a scannable code.
 		"mobile server url with embedded credentials": {
-			modify:        func(cmd *UpsertSystemSettingsCommand) { cmd.MobileServerUrl = "https://user:token@receipts.example.com/api" },
+			modify: func(cmd *UpsertSystemSettingsCommand) {
+				cmd.MobileServerUrl = "https://user:token@receipts.example.com/api"
+			},
 			expectedError: "mobileServerUrl",
 		},
 		"mobile server url with an embedded username only": {
 			modify:        func(cmd *UpsertSystemSettingsCommand) { cmd.MobileServerUrl = "https://user@receipts.example.com/api" },
 			expectedError: "mobileServerUrl",
+		},
+		"negative refresh token lifetime": {
+			modify:        func(cmd *UpsertSystemSettingsCommand) { cmd.RefreshTokenValidForHours = -1 },
+			expectedError: "refreshTokenValidForHours",
+		},
+		"refresh token lifetime above the maximum": {
+			modify:        func(cmd *UpsertSystemSettingsCommand) { cmd.RefreshTokenValidForHours = 721 },
+			expectedError: "refreshTokenValidForHours",
+		},
+		"negative mcp refresh token lifetime": {
+			modify:        func(cmd *UpsertSystemSettingsCommand) { cmd.McpRefreshTokenValidForHours = -1 },
+			expectedError: "mcpRefreshTokenValidForHours",
+		},
+		"mcp refresh token lifetime above the maximum": {
+			modify:        func(cmd *UpsertSystemSettingsCommand) { cmd.McpRefreshTokenValidForHours = 721 },
+			expectedError: "mcpRefreshTokenValidForHours",
 		},
 	}
 
@@ -247,6 +293,53 @@ func TestUpsertSystemSettingsCommand_Validate_PdfDpi(t *testing.T) {
 		vErr := cmd.Validate()
 		if _, ok := vErr.Errors["pdfDpi"]; !ok {
 			utils.PrintTestError(t, "no pdfDpi error for invalid value "+utils.UintToString(uint(v)), "pdfDpi error")
+		}
+	}
+}
+
+func TestUpsertSystemSettingsCommand_Validate_RefreshTokenLifetimes(t *testing.T) {
+	// 0 means "unset / use default" and must be allowed; 1-720 pass; anything
+	// else is rejected. Both fields share one helper, so both are exercised to
+	// prove the two error keys are wired to the right field.
+	fields := map[string]struct {
+		set      func(cmd *UpsertSystemSettingsCommand, hours int)
+		errorKey string
+	}{
+		"refreshTokenValidForHours": {
+			set:      func(cmd *UpsertSystemSettingsCommand, hours int) { cmd.RefreshTokenValidForHours = hours },
+			errorKey: "refreshTokenValidForHours",
+		},
+		"mcpRefreshTokenValidForHours": {
+			set:      func(cmd *UpsertSystemSettingsCommand, hours int) { cmd.McpRefreshTokenValidForHours = hours },
+			errorKey: "mcpRefreshTokenValidForHours",
+		},
+	}
+
+	validValues := []int{0, 1, 24, 168, 720}
+	invalidValues := []int{-100, -1, 721, 100000}
+
+	for fieldName, field := range fields {
+		for _, hours := range validValues {
+			t.Run(fieldName+" accepts "+utils.UintToString(uint(hours)), func(t *testing.T) {
+				cmd := validSystemSettingsCommand()
+				field.set(&cmd, hours)
+
+				if vErr := cmd.Validate(); len(vErr.Errors) > 0 {
+					utils.PrintTestError(t, vErr.Errors, "no errors")
+				}
+			})
+		}
+
+		for _, hours := range invalidValues {
+			t.Run(fieldName+" rejects out of range value", func(t *testing.T) {
+				cmd := validSystemSettingsCommand()
+				field.set(&cmd, hours)
+
+				vErr := cmd.Validate()
+				if _, exists := vErr.Errors[field.errorKey]; !exists {
+					utils.PrintTestError(t, vErr.Errors, "an error for "+field.errorKey)
+				}
+			})
 		}
 	}
 }

--- a/api/internal/commands/upsert_system_settings_command_test.go
+++ b/api/internal/commands/upsert_system_settings_command_test.go
@@ -84,29 +84,39 @@ func TestUpsertSystemSettingsCommand_Validate_ValidInputs(t *testing.T) {
 				return cmd
 			}(),
 		},
-		// Zero means "unset": a client that omits the field must not be rejected,
-		// the read side falls back to the default instead.
+		// A nil pointer means the key was absent from the request body. It must
+		// validate, because omission leaves the stored value alone.
+		"valid with omitted refresh token lifetimes": {
+			command: func() UpsertSystemSettingsCommand {
+				cmd := validSystemSettingsCommand()
+				cmd.RefreshTokenValidForHours = nil
+				cmd.McpRefreshTokenValidForHours = nil
+				return cmd
+			}(),
+		},
+		// An explicit zero means "unset": the read side falls back to the
+		// default instead.
 		"valid with unset refresh token lifetimes": {
 			command: func() UpsertSystemSettingsCommand {
 				cmd := validSystemSettingsCommand()
-				cmd.RefreshTokenValidForHours = 0
-				cmd.McpRefreshTokenValidForHours = 0
+				cmd.RefreshTokenValidForHours = intPtr(0)
+				cmd.McpRefreshTokenValidForHours = intPtr(0)
 				return cmd
 			}(),
 		},
 		"valid with the minimum refresh token lifetimes": {
 			command: func() UpsertSystemSettingsCommand {
 				cmd := validSystemSettingsCommand()
-				cmd.RefreshTokenValidForHours = 1
-				cmd.McpRefreshTokenValidForHours = 1
+				cmd.RefreshTokenValidForHours = intPtr(1)
+				cmd.McpRefreshTokenValidForHours = intPtr(1)
 				return cmd
 			}(),
 		},
 		"valid with the maximum refresh token lifetimes": {
 			command: func() UpsertSystemSettingsCommand {
 				cmd := validSystemSettingsCommand()
-				cmd.RefreshTokenValidForHours = 720
-				cmd.McpRefreshTokenValidForHours = 720
+				cmd.RefreshTokenValidForHours = intPtr(720)
+				cmd.McpRefreshTokenValidForHours = intPtr(720)
 				return cmd
 			}(),
 		},
@@ -225,19 +235,19 @@ func TestUpsertSystemSettingsCommand_Validate_InvalidInputs(t *testing.T) {
 			expectedError: "mobileServerUrl",
 		},
 		"negative refresh token lifetime": {
-			modify:        func(cmd *UpsertSystemSettingsCommand) { cmd.RefreshTokenValidForHours = -1 },
+			modify:        func(cmd *UpsertSystemSettingsCommand) { cmd.RefreshTokenValidForHours = intPtr(-1) },
 			expectedError: "refreshTokenValidForHours",
 		},
 		"refresh token lifetime above the maximum": {
-			modify:        func(cmd *UpsertSystemSettingsCommand) { cmd.RefreshTokenValidForHours = 721 },
+			modify:        func(cmd *UpsertSystemSettingsCommand) { cmd.RefreshTokenValidForHours = intPtr(721) },
 			expectedError: "refreshTokenValidForHours",
 		},
 		"negative mcp refresh token lifetime": {
-			modify:        func(cmd *UpsertSystemSettingsCommand) { cmd.McpRefreshTokenValidForHours = -1 },
+			modify:        func(cmd *UpsertSystemSettingsCommand) { cmd.McpRefreshTokenValidForHours = intPtr(-1) },
 			expectedError: "mcpRefreshTokenValidForHours",
 		},
 		"mcp refresh token lifetime above the maximum": {
-			modify:        func(cmd *UpsertSystemSettingsCommand) { cmd.McpRefreshTokenValidForHours = 721 },
+			modify:        func(cmd *UpsertSystemSettingsCommand) { cmd.McpRefreshTokenValidForHours = intPtr(721) },
 			expectedError: "mcpRefreshTokenValidForHours",
 		},
 	}
@@ -306,11 +316,11 @@ func TestUpsertSystemSettingsCommand_Validate_RefreshTokenLifetimes(t *testing.T
 		errorKey string
 	}{
 		"refreshTokenValidForHours": {
-			set:      func(cmd *UpsertSystemSettingsCommand, hours int) { cmd.RefreshTokenValidForHours = hours },
+			set:      func(cmd *UpsertSystemSettingsCommand, hours int) { cmd.RefreshTokenValidForHours = &hours },
 			errorKey: "refreshTokenValidForHours",
 		},
 		"mcpRefreshTokenValidForHours": {
-			set:      func(cmd *UpsertSystemSettingsCommand, hours int) { cmd.McpRefreshTokenValidForHours = hours },
+			set:      func(cmd *UpsertSystemSettingsCommand, hours int) { cmd.McpRefreshTokenValidForHours = &hours },
 			errorKey: "mcpRefreshTokenValidForHours",
 		},
 	}
@@ -342,4 +352,8 @@ func TestUpsertSystemSettingsCommand_Validate_RefreshTokenLifetimes(t *testing.T
 			})
 		}
 	}
+}
+
+func intPtr(value int) *int {
+	return &value
 }

--- a/api/internal/handlers/system_settings_handler_test.go
+++ b/api/internal/handlers/system_settings_handler_test.go
@@ -240,3 +240,135 @@ func TestShouldValidateUpsertSystemSettingsCommand(t *testing.T) {
 		}
 	}
 }
+
+// Regression: the update writes every column via Select("*"), so a PUT body that
+// omits a configured lifetime used to persist 0 and silently reset an admin's
+// session length to the default. Driven through the handler with a RAW JSON body
+// rather than a typed command, because the whole point is which keys are absent
+// from the wire -- a struct literal cannot express that.
+func TestUpdateSystemSettingsPreservesOmittedRefreshTokenLifetimes(t *testing.T) {
+	defer tearDownSystemSettingsTest()
+
+	db := repositories.GetDB()
+	db.Create(&models.SystemSettings{})
+	grantAllAppPerms(t, 1)
+
+	// An admin has configured both lifetimes away from the defaults.
+	err := db.Model(&models.SystemSettings{}).
+		Where("id = ?", 1).
+		Updates(map[string]interface{}{
+			"refresh_token_valid_for_hours":     720,
+			"mcp_refresh_token_valid_for_hours": 6,
+		}).Error
+	if err != nil {
+		t.Fatalf("failed to seed configured lifetimes: %v", err)
+	}
+
+	queueConfigs := make([]map[string]interface{}, 0)
+	for _, config := range models.GetAllDefaultQueueConfigurations() {
+		queueConfigs = append(queueConfigs, map[string]interface{}{
+			"name":     config.Name,
+			"priority": 1,
+		})
+	}
+
+	// A valid body that simply does not mention either lifetime key.
+	body := map[string]interface{}{
+		"currencyDisplay":              "$",
+		"currencySymbolPosition":       models.START,
+		"currencyThousandthsSeparator": models.COMMA,
+		"currencyDecimalSeparator":     models.DOT,
+		"currencyHideDecimalPlaces":    false,
+		"taskConcurrency":              1,
+		"emailPollingInterval":         60,
+		"taskQueueConfigurations":      queueConfigs,
+	}
+	bodyBytes, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("failed to marshal body: %v", err)
+	}
+
+	r := httptest.NewRequest("PUT", "/api", strings.NewReader(string(bodyBytes)))
+	newContext := context.WithValue(r.Context(), jwtmiddleware.ContextKey{}, &validator.ValidatedClaims{CustomClaims: &structs.Claims{UserId: 1}})
+	r = r.WithContext(newContext)
+	w := httptest.NewRecorder()
+
+	UpdateSystemSettings(w, r)
+
+	if w.Result().StatusCode != http.StatusOK {
+		utils.PrintTestError(t, w.Result().StatusCode, http.StatusOK)
+	}
+
+	updated, err := repositories.NewSystemSettingsRepository(nil).GetSystemSettings()
+	if err != nil {
+		t.Fatalf("failed to read back system settings: %v", err)
+	}
+
+	if updated.RefreshTokenValidForHours != 720 {
+		utils.PrintTestError(t, updated.RefreshTokenValidForHours, 720)
+	}
+
+	if updated.McpRefreshTokenValidForHours != 6 {
+		utils.PrintTestError(t, updated.McpRefreshTokenValidForHours, 6)
+	}
+}
+
+// The flip side: an explicitly sent value must still be written, so the merge
+// above cannot be mistaken for "these fields are read-only".
+func TestUpdateSystemSettingsPersistsExplicitRefreshTokenLifetimes(t *testing.T) {
+	defer tearDownSystemSettingsTest()
+
+	db := repositories.GetDB()
+	db.Create(&models.SystemSettings{})
+	grantAllAppPerms(t, 1)
+
+	queueConfigs := make([]commands.UpsertTaskQueueConfigurationCommand, 0)
+	for _, config := range models.GetAllDefaultQueueConfigurations() {
+		queueConfigs = append(queueConfigs, commands.UpsertTaskQueueConfigurationCommand{
+			Name:     config.Name,
+			Priority: 1,
+		})
+	}
+
+	appHours := 168
+	mcpHours := 12
+	command := commands.UpsertSystemSettingsCommand{
+		CurrencyDisplay:              "$",
+		CurrencySymbolPosition:       models.START,
+		CurrencyThousandthsSeparator: models.COMMA,
+		CurrencyDecimalSeparator:     models.DOT,
+		TaskConcurrency:              1,
+		EmailPollingInterval:         60,
+		TaskQueueConfigurations:      queueConfigs,
+		RefreshTokenValidForHours:    &appHours,
+		McpRefreshTokenValidForHours: &mcpHours,
+	}
+	bodyBytes, err := json.Marshal(command)
+	if err != nil {
+		t.Fatalf("failed to marshal command: %v", err)
+	}
+
+	r := httptest.NewRequest("PUT", "/api", strings.NewReader(string(bodyBytes)))
+	newContext := context.WithValue(r.Context(), jwtmiddleware.ContextKey{}, &validator.ValidatedClaims{CustomClaims: &structs.Claims{UserId: 1}})
+	r = r.WithContext(newContext)
+	w := httptest.NewRecorder()
+
+	UpdateSystemSettings(w, r)
+
+	if w.Result().StatusCode != http.StatusOK {
+		utils.PrintTestError(t, w.Result().StatusCode, http.StatusOK)
+	}
+
+	updated, err := repositories.NewSystemSettingsRepository(nil).GetSystemSettings()
+	if err != nil {
+		t.Fatalf("failed to read back system settings: %v", err)
+	}
+
+	if updated.RefreshTokenValidForHours != appHours {
+		utils.PrintTestError(t, updated.RefreshTokenValidForHours, appHours)
+	}
+
+	if updated.McpRefreshTokenValidForHours != mcpHours {
+		utils.PrintTestError(t, updated.McpRefreshTokenValidForHours, mcpHours)
+	}
+}

--- a/api/internal/middleware/refresh_token.go
+++ b/api/internal/middleware/refresh_token.go
@@ -2,7 +2,6 @@ package middleware
 
 import (
 	"context"
-	"errors"
 	"net/http"
 	"receipt-wrangler/api/internal/commands"
 	"receipt-wrangler/api/internal/logging"
@@ -10,8 +9,6 @@ import (
 	"receipt-wrangler/api/internal/repositories"
 	"receipt-wrangler/api/internal/services"
 	"receipt-wrangler/api/internal/utils"
-
-	"gorm.io/gorm"
 )
 
 func ValidateRefreshToken(next http.Handler) http.Handler {
@@ -47,7 +44,6 @@ func ValidateRefreshToken(next http.Handler) http.Handler {
 func RevokeRefreshToken(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		db := repositories.GetDB()
-		dbToken := models.RefreshToken{}
 		err := error(nil)
 		errMessage := "Error refreshing token"
 
@@ -62,25 +58,25 @@ func RevokeRefreshToken(next http.Handler) http.Handler {
 		}
 
 		hashTokenString := utils.Sha256Hash([]byte(refreshTokenString.(string)))
-		err = db.Model(&models.RefreshToken{}).Where("token = ?", hashTokenString).First(&dbToken).Error
-		if err != nil {
-			if errors.Is(err, gorm.ErrRecordNotFound) {
-				emptyAccessTokenCookie := services.GetEmptyAccessTokenCookie()
-				emptyRefreshTokenCookie := services.GetEmptyRefreshTokenCookie()
 
-				http.SetCookie(w, &emptyAccessTokenCookie)
-				http.SetCookie(w, &emptyRefreshTokenCookie)
-
-				utils.WriteCustomErrorResponse(w, errMessage, http.StatusInternalServerError)
-				logging.LogStd(logging.LOG_LEVEL_ERROR, "Refresh token not found")
-				return
-			}
+		// Atomically mark the stored token used via the WHERE clause so two
+		// concurrent refreshes of the same token cannot both succeed. A read
+		// followed by a separate update lets both racers observe is_used = false
+		// and rotate, which defeats replay detection; it also logs the loser out
+		// of every tab once the rotation it lost lands. Mirrors the same fix in
+		// oauth.rotateRefreshToken. A zero row count means the token is unknown
+		// or already used — indistinguishable on purpose, and both already
+		// produced this identical response.
+		result := db.Model(&models.RefreshToken{}).
+			Where("token = ? AND is_used = ?", hashTokenString, false).
+			Update("is_used", true)
+		if result.Error != nil {
 			utils.WriteCustomErrorResponse(w, errMessage, http.StatusInternalServerError)
-			logging.LogStd(logging.LOG_LEVEL_ERROR, err.Error())
+			logging.LogStd(logging.LOG_LEVEL_ERROR, result.Error.Error())
 			return
 		}
 
-		if dbToken.IsUsed {
+		if result.RowsAffected == 0 {
 			emptyAccessTokenCookie := services.GetEmptyAccessTokenCookie()
 			emptyRefreshTokenCookie := services.GetEmptyRefreshTokenCookie()
 
@@ -88,16 +84,9 @@ func RevokeRefreshToken(next http.Handler) http.Handler {
 			http.SetCookie(w, &emptyRefreshTokenCookie)
 
 			utils.WriteCustomErrorResponse(w, errMessage, http.StatusInternalServerError)
-			logging.LogStd(logging.LOG_LEVEL_ERROR, "Refresh token has been used already.")
+			logging.LogStd(logging.LOG_LEVEL_ERROR, "Refresh token is invalid or has already been used.")
 
 			return
-		} else {
-			err = db.Model(&dbToken).Update("is_used", true).Error
-			if err != nil {
-				utils.WriteCustomErrorResponse(w, errMessage, http.StatusInternalServerError)
-				logging.LogStd(logging.LOG_LEVEL_ERROR, err.Error())
-				return
-			}
 		}
 
 		next.ServeHTTP(w, r)

--- a/api/internal/middleware/refresh_token_test.go
+++ b/api/internal/middleware/refresh_token_test.go
@@ -13,6 +13,8 @@ import (
 	"receipt-wrangler/api/internal/services"
 	"receipt-wrangler/api/internal/utils"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -343,5 +345,57 @@ func TestRevokeRefreshToken_UsesContextValue(t *testing.T) {
 	}
 	if w.Result().StatusCode != http.StatusOK {
 		utils.PrintTestError(t, w.Result().StatusCode, http.StatusOK)
+	}
+}
+
+// Refresh tokens are single-use. Consumption used to be a read followed by a
+// separate update, so two concurrent refreshes of the same token could both see
+// is_used = false and rotate — defeating replay detection, and logging the loser
+// out of every tab once the rotation it lost landed. Exactly one racer must win.
+func TestRevokeRefreshToken_ConcurrentRefreshesOnlyOneSucceeds(t *testing.T) {
+	defer teardownAuthTest()
+	setupAuthTest()
+
+	user := newRefreshUser(t)
+	raw := seedRefreshToken(t, user.ID, false)
+
+	const racers = 8
+	var passed atomic.Int32
+	var start sync.WaitGroup
+	var done sync.WaitGroup
+	start.Add(1)
+
+	for i := 0; i < racers; i++ {
+		done.Add(1)
+		go func() {
+			defer done.Done()
+
+			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				passed.Add(1)
+				w.WriteHeader(http.StatusOK)
+			})
+
+			r := httptest.NewRequest(http.MethodPost, "/api/refresh", nil)
+			r.AddCookie(&http.Cookie{Name: constants.RefreshTokenKey, Value: raw})
+			w := httptest.NewRecorder()
+
+			start.Wait()
+			RevokeRefreshToken(next).ServeHTTP(w, r)
+		}()
+	}
+
+	start.Done()
+	done.Wait()
+
+	if got := passed.Load(); got != 1 {
+		utils.PrintTestError(t, got, "exactly 1 racer to pass through")
+	}
+
+	var dbToken models.RefreshToken
+	if err := repositories.GetDB().Where("token = ?", utils.Sha256Hash([]byte(raw))).First(&dbToken).Error; err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	if !dbToken.IsUsed {
+		utils.PrintTestError(t, dbToken.IsUsed, true)
 	}
 }

--- a/api/internal/models/system_settings.go
+++ b/api/internal/models/system_settings.go
@@ -29,4 +29,14 @@ type SystemSettings struct {
 	// MobileServerUrl is the server/API URL mobile clients connect to. It is
 	// encoded (in the login QR's deep link) so scanning it sets up the app.
 	MobileServerUrl string `json:"mobileServerUrl"`
+	// RefreshTokenValidForHours is how long a refresh token stays valid, i.e. how
+	// long a user can be away and still return signed in. Refresh tokens rotate on
+	// every use, so this is an inactivity window rather than an absolute session
+	// cap. Zero means "unset" and falls back to the built-in default.
+	RefreshTokenValidForHours int `json:"refreshTokenValidForHours" gorm:"default:24"`
+	// McpRefreshTokenValidForHours is the same for MCP/OAuth connector tokens. It
+	// is kept separate from RefreshTokenValidForHours so a long window chosen for
+	// human convenience does not silently extend tokens held by third-party
+	// clients. Zero means "unset" and falls back to the built-in default.
+	McpRefreshTokenValidForHours int `json:"mcpRefreshTokenValidForHours" gorm:"default:24"`
 }

--- a/api/internal/repositories/system_settings.go
+++ b/api/internal/repositories/system_settings.go
@@ -91,6 +91,11 @@ func (repository SystemSettingsRepository) UpdateSystemSettings(command commands
 		return models.SystemSettings{}, err
 	}
 
+	// Select("*") below writes every column, so any field the request omitted
+	// would be persisted as its zero value. Carry the stored lifetimes forward
+	// for keys the caller did not send.
+	command.ApplyOmittedLifetimes(existingSettings, &updatedSettings)
+
 	err = db.Transaction(func(tx *gorm.DB) error {
 		txErr := tx.Model(&updatedSettings).Select("*").Omit("TaskQueueConfigurations").Where("id = ?", existingSettings.ID).Updates(&updatedSettings).Error
 		if txErr != nil {

--- a/api/internal/repositories/system_settings.go
+++ b/api/internal/repositories/system_settings.go
@@ -92,12 +92,16 @@ func (repository SystemSettingsRepository) UpdateSystemSettings(command commands
 	}
 
 	// Select("*") below writes every column, so any field the request omitted
-	// would be persisted as its zero value. Carry the stored lifetimes forward
-	// for keys the caller did not send.
+	// would be persisted as its zero value. Two things guard the lifetimes:
+	// the columns the caller did not send are dropped from the UPDATE entirely
+	// (so a concurrent update that DID set one is never clobbered by a value we
+	// read before the write), and the in-memory copy is back-filled so the
+	// response echoes the stored value rather than a 0.
+	omittedColumns := append([]string{"TaskQueueConfigurations"}, command.OmittedLifetimeColumns()...)
 	command.ApplyOmittedLifetimes(existingSettings, &updatedSettings)
 
 	err = db.Transaction(func(tx *gorm.DB) error {
-		txErr := tx.Model(&updatedSettings).Select("*").Omit("TaskQueueConfigurations").Where("id = ?", existingSettings.ID).Updates(&updatedSettings).Error
+		txErr := tx.Model(&updatedSettings).Select("*").Omit(omittedColumns...).Where("id = ?", existingSettings.ID).Updates(&updatedSettings).Error
 		if txErr != nil {
 			return txErr
 		}

--- a/api/internal/repositories/system_settings_test.go
+++ b/api/internal/repositories/system_settings_test.go
@@ -1,0 +1,179 @@
+package repositories
+
+import (
+	"strings"
+	"sync"
+	"testing"
+
+	"receipt-wrangler/api/internal/commands"
+	"receipt-wrangler/api/internal/models"
+
+	"gorm.io/gorm"
+)
+
+func intPtr(value int) *int {
+	return &value
+}
+
+// buildSettingsCommand returns a command that passes validation, with both
+// lifetimes omitted by default so callers can set only the one under test.
+func buildSettingsCommand() commands.UpsertSystemSettingsCommand {
+	queueConfigs := make([]commands.UpsertTaskQueueConfigurationCommand, 0)
+	for _, config := range models.GetAllDefaultQueueConfigurations() {
+		queueConfigs = append(queueConfigs, commands.UpsertTaskQueueConfigurationCommand{
+			Name:     config.Name,
+			Priority: 1,
+		})
+	}
+
+	return commands.UpsertSystemSettingsCommand{
+		CurrencyDisplay:              "$",
+		CurrencySymbolPosition:       models.START,
+		CurrencyThousandthsSeparator: models.COMMA,
+		CurrencyDecimalSeparator:     models.DOT,
+		TaskConcurrency:              1,
+		EmailPollingInterval:         60,
+		TaskQueueConfigurations:      queueConfigs,
+	}
+}
+
+func seedLifetimes(t *testing.T, appHours int, mcpHours int) {
+	t.Helper()
+
+	if err := GetDB().Create(&models.SystemSettings{}).Error; err != nil {
+		t.Fatalf("failed to create system settings: %v", err)
+	}
+
+	err := GetDB().Model(&models.SystemSettings{}).
+		Where("id = ?", 1).
+		Updates(map[string]interface{}{
+			"refresh_token_valid_for_hours":     appHours,
+			"mcp_refresh_token_valid_for_hours": mcpHours,
+		}).Error
+	if err != nil {
+		t.Fatalf("failed to seed lifetimes: %v", err)
+	}
+}
+
+// A lifetime the request omitted must be left out of the UPDATE statement
+// altogether. Copying the stored value onto the row instead would still write
+// the column, which is what lets a concurrent update clobber it. Asserted on the
+// generated SQL because that is the precise property the concurrency safety
+// rests on.
+func TestUpdateSystemSettingsOmitsUnsentLifetimeColumns(t *testing.T) {
+	defer TruncateTestDb()
+	seedLifetimes(t, 24, 24)
+
+	settings := models.SystemSettings{}
+	settings.ID = 1
+
+	tests := map[string]struct {
+		command       commands.UpsertSystemSettingsCommand
+		expectWritten []string
+		expectSkipped []string
+	}{
+		"both omitted": {
+			command:       buildSettingsCommand(),
+			expectSkipped: []string{"`refresh_token_valid_for_hours`", "`mcp_refresh_token_valid_for_hours`"},
+		},
+		"app sent, mcp omitted": {
+			command: func() commands.UpsertSystemSettingsCommand {
+				cmd := buildSettingsCommand()
+				cmd.RefreshTokenValidForHours = intPtr(720)
+				return cmd
+			}(),
+			expectWritten: []string{"`refresh_token_valid_for_hours`"},
+			expectSkipped: []string{"`mcp_refresh_token_valid_for_hours`"},
+		},
+		"mcp sent, app omitted": {
+			command: func() commands.UpsertSystemSettingsCommand {
+				cmd := buildSettingsCommand()
+				cmd.McpRefreshTokenValidForHours = intPtr(6)
+				return cmd
+			}(),
+			expectWritten: []string{"`mcp_refresh_token_valid_for_hours`"},
+			expectSkipped: []string{"`refresh_token_valid_for_hours`"},
+		},
+		"both sent": {
+			command: func() commands.UpsertSystemSettingsCommand {
+				cmd := buildSettingsCommand()
+				cmd.RefreshTokenValidForHours = intPtr(720)
+				cmd.McpRefreshTokenValidForHours = intPtr(6)
+				return cmd
+			}(),
+			expectWritten: []string{"`refresh_token_valid_for_hours`", "`mcp_refresh_token_valid_for_hours`"},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			omitted := append([]string{"TaskQueueConfigurations"}, test.command.OmittedLifetimeColumns()...)
+			sql := GetDB().Session(&gorm.Session{DryRun: true}).
+				Model(&settings).Select("*").Omit(omitted...).
+				Where("id = ?", 1).Updates(&settings).Statement.SQL.String()
+
+			for _, column := range test.expectWritten {
+				if !strings.Contains(sql, column+"=") {
+					t.Errorf("expected %s to be written, SQL: %s", column, sql)
+				}
+			}
+
+			for _, column := range test.expectSkipped {
+				if strings.Contains(sql, column+"=") {
+					t.Errorf("expected %s to be skipped, SQL: %s", column, sql)
+				}
+			}
+		})
+	}
+}
+
+// Two admins saving at once, each setting one lifetime and omitting the other.
+// Both explicit values must survive: with the columns skipped there is nothing
+// for either write to clobber. Repeated because the losing interleaving is
+// timing dependent -- a single pass could pass by luck against a broken
+// implementation.
+func TestUpdateSystemSettingsConcurrentLifetimeUpdatesBothSurvive(t *testing.T) {
+	defer TruncateTestDb()
+
+	const attempts = 15
+
+	for attempt := 0; attempt < attempts; attempt++ {
+		TruncateTestDb()
+		seedLifetimes(t, 24, 24)
+
+		appCommand := buildSettingsCommand()
+		appCommand.RefreshTokenValidForHours = intPtr(720)
+
+		mcpCommand := buildSettingsCommand()
+		mcpCommand.McpRefreshTokenValidForHours = intPtr(6)
+
+		var start sync.WaitGroup
+		var done sync.WaitGroup
+		start.Add(1)
+
+		for _, command := range []commands.UpsertSystemSettingsCommand{appCommand, mcpCommand} {
+			done.Add(1)
+			go func(c commands.UpsertSystemSettingsCommand) {
+				defer done.Done()
+				start.Wait()
+				NewSystemSettingsRepository(nil).UpdateSystemSettings(c)
+			}(command)
+		}
+
+		start.Done()
+		done.Wait()
+
+		settings, err := NewSystemSettingsRepository(nil).GetSystemSettings()
+		if err != nil {
+			t.Fatalf("failed to read system settings: %v", err)
+		}
+
+		if settings.RefreshTokenValidForHours != 720 {
+			t.Fatalf("attempt %d: app lifetime = %d, expected 720 (clobbered by the concurrent MCP update)", attempt, settings.RefreshTokenValidForHours)
+		}
+
+		if settings.McpRefreshTokenValidForHours != 6 {
+			t.Fatalf("attempt %d: mcp lifetime = %d, expected 6 (clobbered by the concurrent app update)", attempt, settings.McpRefreshTokenValidForHours)
+		}
+	}
+}

--- a/api/internal/services/auth.go
+++ b/api/internal/services/auth.go
@@ -6,6 +6,7 @@ import (
 	"receipt-wrangler/api/internal/commands"
 	"receipt-wrangler/api/internal/constants"
 	config "receipt-wrangler/api/internal/env"
+	"receipt-wrangler/api/internal/logging"
 	"receipt-wrangler/api/internal/models"
 	"receipt-wrangler/api/internal/permissions"
 	"receipt-wrangler/api/internal/repositories"
@@ -29,6 +30,52 @@ const jwtIssuer = "https://receiptWrangler.io"
 // distinct, runtime-derived audience instead (see GenerateMcpJWT) so an MCP
 // token is rejected everywhere except the MCP endpoints.
 const defaultAudience = "https://receiptWrangler.io"
+
+// defaultRefreshTokenLifetime is the fallback refresh-token lifetime, used when
+// the System Settings value is unset (0), out of range, or unreadable.
+const defaultRefreshTokenLifetime = 24 * time.Hour
+
+// GetRefreshTokenLifetime returns how long a REST refresh token stays valid.
+//
+// Refresh tokens rotate on every use, so this is an inactivity window rather
+// than an absolute session cap: an actively refreshing client is never logged
+// out, while an idle one must re-authenticate once it exceeds the window.
+func GetRefreshTokenLifetime() time.Duration {
+	systemSettings, err := repositories.NewSystemSettingsRepository(nil).GetSystemSettings()
+	if err != nil {
+		logging.LogStd(logging.LOG_LEVEL_ERROR, "Could not read refresh token lifetime, using default: "+err.Error())
+		return defaultRefreshTokenLifetime
+	}
+
+	return clampRefreshTokenLifetime(systemSettings.RefreshTokenValidForHours)
+}
+
+// GetMcpRefreshTokenLifetime returns how long an MCP/OAuth connector refresh
+// token stays valid. It is a separate setting from GetRefreshTokenLifetime so a
+// long window chosen for human convenience does not silently extend tokens held
+// by third-party clients.
+func GetMcpRefreshTokenLifetime() time.Duration {
+	systemSettings, err := repositories.NewSystemSettingsRepository(nil).GetSystemSettings()
+	if err != nil {
+		logging.LogStd(logging.LOG_LEVEL_ERROR, "Could not read MCP refresh token lifetime, using default: "+err.Error())
+		return defaultRefreshTokenLifetime
+	}
+
+	return clampRefreshTokenLifetime(systemSettings.McpRefreshTokenValidForHours)
+}
+
+// clampRefreshTokenLifetime converts a configured hour count into a duration,
+// falling back to the default for anything outside the supported range. This is
+// the real safety net — it stops a bad stored value (0, negative, absurd) from
+// ever producing a token, independent of whether the value passed command
+// validation on the way in.
+func clampRefreshTokenLifetime(hours int) time.Duration {
+	if hours < commands.MinRefreshTokenValidForHours || hours > commands.MaxRefreshTokenValidForHours {
+		return defaultRefreshTokenLifetime
+	}
+
+	return time.Duration(hours) * time.Hour
+}
 
 func InitTokenValidator() (*validator.Validator, error) {
 	return initTokenValidator(defaultAudience)
@@ -111,7 +158,10 @@ func BuildTokenCookies(jwt string, refreshToken string) (http.Cookie, http.Cooki
 	}
 
 	accessTokenCookie := http.Cookie{Name: constants.JwtKey, Value: jwt, HttpOnly: true, Path: "/", Expires: utils.GetAccessTokenExpiryDate().Time, SameSite: sameSite, Secure: secure}
-	refreshTokenCookie := http.Cookie{Name: constants.RefreshTokenKey, Value: refreshToken, HttpOnly: true, Path: "/", Expires: utils.GetRefreshTokenExpiryDate().Time, SameSite: sameSite, Secure: secure}
+	// Resolved here rather than threaded in from the caller: both call sites
+	// (login and token refresh) are REST-only, never MCP, so the app setting is
+	// always the right one. Costs one extra System Settings read per login.
+	refreshTokenCookie := http.Cookie{Name: constants.RefreshTokenKey, Value: refreshToken, HttpOnly: true, Path: "/", Expires: utils.GetRefreshTokenExpiryDate(GetRefreshTokenLifetime()).Time, SameSite: sameSite, Secure: secure}
 
 	return accessTokenCookie, refreshTokenCookie
 }
@@ -130,7 +180,7 @@ func GetEmptyRefreshTokenCookie() http.Cookie {
 }
 
 func GenerateJWT(userId uint) (string, string, structs.Claims, error) {
-	return generateTokenPair(userId, defaultAudience)
+	return generateTokenPair(userId, defaultAudience, GetRefreshTokenLifetime())
 }
 
 // GenerateMcpJWT mints an access + refresh token pair bound to the given MCP
@@ -140,10 +190,10 @@ func GenerateJWT(userId uint) (string, string, structs.Claims, error) {
 // Replacing (not appending) the audience ensures the resulting tokens are
 // accepted only by the MCP endpoints, which verify this exact audience.
 func GenerateMcpJWT(userId uint, audience string) (string, string, structs.Claims, error) {
-	return generateTokenPair(userId, audience)
+	return generateTokenPair(userId, audience, GetMcpRefreshTokenLifetime())
 }
 
-func generateTokenPair(userId uint, audience string) (string, string, structs.Claims, error) {
+func generateTokenPair(userId uint, audience string, refreshLifetime time.Duration) (string, string, structs.Claims, error) {
 	db := repositories.GetDB()
 	var user models.User
 
@@ -184,7 +234,7 @@ func generateTokenPair(userId uint, audience string) (string, string, structs.Cl
 		RegisteredClaims: jwt.RegisteredClaims{
 			Issuer:    jwtIssuer,
 			Audience:  []string{audience},
-			ExpiresAt: utils.GetRefreshTokenExpiryDate(),
+			ExpiresAt: utils.GetRefreshTokenExpiryDate(refreshLifetime),
 			ID:        refreshTokenId,
 		},
 	}

--- a/api/internal/services/refresh_token_lifetime_test.go
+++ b/api/internal/services/refresh_token_lifetime_test.go
@@ -1,0 +1,193 @@
+package services
+
+import (
+	"context"
+	"receipt-wrangler/api/internal/models"
+	"receipt-wrangler/api/internal/repositories"
+	"receipt-wrangler/api/internal/structs"
+	"testing"
+	"time"
+
+	"github.com/auth0/go-jwt-middleware/v2/validator"
+)
+
+// setRefreshTokenLifetimeSettings writes the two configurable lifetimes straight
+// to their columns, mirroring setLoginQrSettings in system_settings_test.go.
+// Raw column names are used deliberately so a value the command validator would
+// reject can still be stored — that is exactly what the read-side clamp exists
+// to survive.
+func setRefreshTokenLifetimeSettings(t *testing.T, appHours int, mcpHours int) {
+	t.Helper()
+
+	settings, err := repositories.NewSystemSettingsRepository(nil).GetSystemSettings()
+	if err != nil {
+		t.Fatalf("failed to load system settings: %v", err)
+	}
+
+	err = repositories.GetDB().
+		Model(&models.SystemSettings{}).
+		Where("id = ?", settings.ID).
+		Updates(map[string]interface{}{
+			"refresh_token_valid_for_hours":     appHours,
+			"mcp_refresh_token_valid_for_hours": mcpHours,
+		}).Error
+	if err != nil {
+		t.Fatalf("failed to set refresh token lifetime settings: %v", err)
+	}
+}
+
+func TestClampRefreshTokenLifetime(t *testing.T) {
+	tests := []struct {
+		name     string
+		hours    int
+		expected time.Duration
+	}{
+		{"unset falls back to the default", 0, 24 * time.Hour},
+		{"negative falls back to the default", -5, 24 * time.Hour},
+		{"above the maximum falls back to the default", 721, 24 * time.Hour},
+		{"absurd value falls back to the default", 1000000, 24 * time.Hour},
+		{"the minimum is honored", 1, time.Hour},
+		{"an in-range value is honored", 168, 168 * time.Hour},
+		{"the maximum is honored", 720, 720 * time.Hour},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := clampRefreshTokenLifetime(test.hours); got != test.expected {
+				t.Errorf("clampRefreshTokenLifetime(%d) = %v, expected %v", test.hours, got, test.expected)
+			}
+		})
+	}
+}
+
+func TestGetRefreshTokenLifetimeReadsTheConfiguredValue(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	setRefreshTokenLifetimeSettings(t, 168, 24)
+
+	if got := GetRefreshTokenLifetime(); got != 168*time.Hour {
+		t.Errorf("GetRefreshTokenLifetime() = %v, expected %v", got, 168*time.Hour)
+	}
+}
+
+// The whole point of the MCP setting being separate is that a long app window
+// must not extend third-party connector tokens. Assert both directions so a
+// future refactor cannot quietly collapse them onto one field.
+func TestRefreshTokenLifetimesAreIndependent(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	setRefreshTokenLifetimeSettings(t, 720, 2)
+
+	if got := GetRefreshTokenLifetime(); got != 720*time.Hour {
+		t.Errorf("GetRefreshTokenLifetime() = %v, expected %v", got, 720*time.Hour)
+	}
+
+	if got := GetMcpRefreshTokenLifetime(); got != 2*time.Hour {
+		t.Errorf("GetMcpRefreshTokenLifetime() = %v, expected %v", got, 2*time.Hour)
+	}
+
+	setRefreshTokenLifetimeSettings(t, 3, 500)
+
+	if got := GetRefreshTokenLifetime(); got != 3*time.Hour {
+		t.Errorf("GetRefreshTokenLifetime() = %v, expected %v", got, 3*time.Hour)
+	}
+
+	if got := GetMcpRefreshTokenLifetime(); got != 500*time.Hour {
+		t.Errorf("GetMcpRefreshTokenLifetime() = %v, expected %v", got, 500*time.Hour)
+	}
+}
+
+func TestGenerateJWTStampsTheConfiguredRefreshLifetime(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	setRefreshTokenLifetimeSettings(t, 168, 24)
+
+	db := repositories.GetDB()
+	user := models.User{Username: "refresh-lifetime-user", Password: "password", DisplayName: "Refresh Lifetime User"}
+	if err := db.Create(&user).Error; err != nil {
+		t.Fatalf("failed to create user: %v", err)
+	}
+
+	before := time.Now()
+	_, refreshToken, accessTokenClaims, err := GenerateJWT(user.ID)
+	if err != nil {
+		t.Fatalf("failed to generate jwt: %v", err)
+	}
+	after := time.Now()
+
+	// The access token is deliberately NOT configurable — both clients size
+	// their 15-minute refresh timer against this fixed 20-minute window.
+	assertWithinWindow(t, "access token claim", accessTokenClaims.ExpiresAt.Time, before, after, 20*time.Minute)
+
+	restValidator, err := InitTokenValidator()
+	if err != nil {
+		t.Fatalf("failed to build validator: %v", err)
+	}
+	refreshClaims := validateClaims(t, restValidator, refreshToken)
+	assertWithinWindow(t, "refresh token claim", refreshClaims.ExpiresAt.Time, before, after, 168*time.Hour)
+
+	// The persisted row must agree with the signed claim, or the cleanup job and
+	// the token itself would disagree about when the session ends.
+	var stored models.RefreshToken
+	if err := db.Where("user_id = ?", user.ID).First(&stored).Error; err != nil {
+		t.Fatalf("failed to load stored refresh token: %v", err)
+	}
+	assertWithinWindow(t, "stored refresh token row", stored.ExpiresAt, before, after, 168*time.Hour)
+}
+
+func TestGenerateMcpJWTUsesTheMcpRefreshLifetime(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	// App window far longer than the MCP one, so a token minted on the app
+	// setting would be unmistakable.
+	setRefreshTokenLifetimeSettings(t, 720, 6)
+
+	db := repositories.GetDB()
+	user := models.User{Username: "mcp-refresh-lifetime-user", Password: "password", DisplayName: "Mcp Refresh Lifetime User"}
+	if err := db.Create(&user).Error; err != nil {
+		t.Fatalf("failed to create user: %v", err)
+	}
+
+	audience := "https://receipts.example.com/mcp"
+
+	before := time.Now()
+	_, refreshToken, _, err := GenerateMcpJWT(user.ID, audience)
+	if err != nil {
+		t.Fatalf("failed to generate mcp jwt: %v", err)
+	}
+	after := time.Now()
+
+	mcpValidator, err := InitMcpTokenValidator(audience)
+	if err != nil {
+		t.Fatalf("failed to build mcp validator: %v", err)
+	}
+	refreshClaims := validateClaims(t, mcpValidator, refreshToken)
+	assertWithinWindow(t, "mcp refresh token claim", refreshClaims.ExpiresAt.Time, before, after, 6*time.Hour)
+}
+
+// assertWithinWindow checks that expiry lands inside [before+lifetime,
+// after+lifetime], allowing a second of slack for the JWT NumericDate's
+// second-level precision.
+func assertWithinWindow(t *testing.T, what string, expiry time.Time, before time.Time, after time.Time, lifetime time.Duration) {
+	t.Helper()
+
+	earliest := before.Add(lifetime).Add(-time.Second)
+	latest := after.Add(lifetime).Add(time.Second)
+
+	if expiry.Before(earliest) || expiry.After(latest) {
+		t.Errorf("%s expiry %v is not approximately %v from now (expected between %v and %v)", what, expiry, lifetime, earliest, latest)
+	}
+}
+
+// validateClaims verifies a token against the given validator and unwraps the
+// custom claims, failing the test on any error.
+func validateClaims(t *testing.T, v *validator.Validator, token string) *structs.Claims {
+	t.Helper()
+
+	rawClaims, err := v.ValidateToken(context.Background(), token)
+	if err != nil {
+		t.Fatalf("failed to validate token: %v", err)
+	}
+
+	return rawClaims.(*validator.ValidatedClaims).CustomClaims.(*structs.Claims)
+}

--- a/api/internal/utils/auth.go
+++ b/api/internal/utils/auth.go
@@ -20,10 +20,18 @@ func HashPassword(password string) ([]byte, error) {
 	return bytes, nil
 }
 
-func GetRefreshTokenExpiryDate() *jwt.NumericDate {
-	return jwt.NewNumericDate(time.Now().Add(24 * time.Hour))
+// GetRefreshTokenExpiryDate returns the expiry for a refresh token minted now.
+// The lifetime is configurable per install, so callers resolve it (see
+// services.GetRefreshTokenLifetime) and pass it in — this package deliberately
+// imports nothing from internal/, so it cannot read System Settings itself.
+func GetRefreshTokenExpiryDate(lifetime time.Duration) *jwt.NumericDate {
+	return jwt.NewNumericDate(time.Now().Add(lifetime))
 }
 
+// GetAccessTokenExpiryDate returns the expiry for an access token minted now.
+// This one is intentionally NOT configurable: the access token is stateless and
+// cannot be revoked, and both clients proactively refresh on a 15-minute timer
+// sized against this 20-minute window.
 func GetAccessTokenExpiryDate() *jwt.NumericDate {
 	return jwt.NewNumericDate(time.Now().Add(20 * time.Minute))
 }

--- a/api/internal/utils/auth_test.go
+++ b/api/internal/utils/auth_test.go
@@ -97,23 +97,33 @@ func TestHashPasswordShouldProduceDifferentHashesForSamePassword(t *testing.T) {
 	}
 }
 
-func TestGetRefreshTokenExpiryDateShouldReturn24HoursFromNow(t *testing.T) {
-	before := time.Now().Truncate(time.Second)
-	expiryDate := GetRefreshTokenExpiryDate()
-	after := time.Now().Add(time.Second).Truncate(time.Second)
-
-	if expiryDate == nil {
-		t.Errorf("Expected non-nil expiry date, got nil")
-		return
+func TestGetRefreshTokenExpiryDateShouldHonorTheGivenLifetime(t *testing.T) {
+	// The lifetime is configurable per install (System Settings), so this helper
+	// must apply whatever it is handed rather than a baked-in constant.
+	lifetimes := map[string]time.Duration{
+		"one hour":             time.Hour,
+		"the default 24 hours": 24 * time.Hour,
+		"the 30 day maximum":   720 * time.Hour,
 	}
 
-	expected24HoursFromBefore := before.Add(24 * time.Hour)
-	expected24HoursFromAfter := after.Add(24 * time.Hour)
+	for name, lifetime := range lifetimes {
+		t.Run(name, func(t *testing.T) {
+			before := time.Now().Truncate(time.Second)
+			expiryDate := GetRefreshTokenExpiryDate(lifetime)
+			after := time.Now().Add(time.Second).Truncate(time.Second)
 
-	// The expiry date should be between 24 hours from before and 24 hours from after
-	// JWT NumericDate has second precision, so we truncate comparisons to seconds
-	if expiryDate.Time.Before(expected24HoursFromBefore) || expiryDate.Time.After(expected24HoursFromAfter) {
-		t.Errorf("Expected expiry date to be approximately 24 hours from now, got %v", expiryDate.Time)
+			if expiryDate == nil {
+				t.Errorf("Expected non-nil expiry date, got nil")
+				return
+			}
+
+			// The expiry date should be between <lifetime> from before and <lifetime>
+			// from after. JWT NumericDate has second precision, so we truncate
+			// comparisons to seconds.
+			if expiryDate.Time.Before(before.Add(lifetime)) || expiryDate.Time.After(after.Add(lifetime)) {
+				t.Errorf("Expected expiry date to be approximately %v from now, got %v", lifetime, expiryDate.Time)
+			}
+		})
 	}
 }
 

--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -5785,6 +5785,20 @@ components:
             mobileServerUrl:
               type: string
               description: Server/API URL mobile clients connect to; encoded into the login QR's deep link
+            refreshTokenValidForHours:
+              type: integer
+              description: >-
+                How long a refresh token stays valid, in hours. Refresh tokens rotate on every use,
+                so this is how long a user can be away and still return signed in, not an absolute
+                session cap. 1-720 (30 days); 0 means unset and falls back to the default.
+              default: 24
+            mcpRefreshTokenValidForHours:
+              type: integer
+              description: >-
+                The same for MCP/OAuth connector refresh tokens, kept separate so a long window
+                chosen for human convenience does not extend third-party client tokens.
+                1-720 (30 days); 0 means unset and falls back to the default.
+              default: 24
     UpsertSystemSettingsCommand:
       type: object
       required:
@@ -5848,6 +5862,20 @@ components:
         mobileServerUrl:
           type: string
           description: Server/API URL mobile clients connect to; encoded into the login QR's deep link
+        refreshTokenValidForHours:
+          type: integer
+          description: >-
+            How long a refresh token stays valid, in hours. 0 means unset and falls back to the
+            default of 24.
+          minimum: 0
+          maximum: 720
+        mcpRefreshTokenValidForHours:
+          type: integer
+          description: >-
+            How long an MCP/OAuth connector refresh token stays valid, in hours. 0 means unset and
+            falls back to the default of 24.
+          minimum: 0
+          maximum: 720
     CheckEmailConnectivityCommand:
       type: object
       properties:

--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -5865,15 +5865,17 @@ components:
         refreshTokenValidForHours:
           type: integer
           description: >-
-            How long a refresh token stays valid, in hours. 0 means unset and falls back to the
-            default of 24.
+            How long a refresh token stays valid, in hours. Accepted values are 1-720 (30 days), or
+            0 meaning unset, which falls back to the default of 24. Omit the key entirely to leave
+            the currently configured value unchanged.
           minimum: 0
           maximum: 720
         mcpRefreshTokenValidForHours:
           type: integer
           description: >-
-            How long an MCP/OAuth connector refresh token stays valid, in hours. 0 means unset and
-            falls back to the default of 24.
+            How long an MCP/OAuth connector refresh token stays valid, in hours. Accepted values are
+            1-720 (30 days), or 0 meaning unset, which falls back to the default of 24. Omit the key
+            entirely to leave the currently configured value unchanged.
           minimum: 0
           maximum: 720
     CheckEmailConnectivityCommand:

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -609,6 +609,52 @@ divider-only-with-`headerText`, turned back off, and the stale-generation guard)
 `feature-config.state.spec.ts`, `auth-form.component.spec.ts` and `about.component.spec.ts` (each
 pinning that its page wires the shared component up), and `system-settings-form.component.spec.ts`.
 
+## Session lifetime settings (Hours/Days selector over an hours-based API)
+
+The System Settings form exposes two configurable refresh-token lifetimes (see `api/CLAUDE.md` →
+"Session lifetime"): a **Session** `app-form-section` with **"Stay signed in for"**
+(`refreshTokenValidForHours`) and, inside the existing **MCP Server** section, **"Connector sign-in
+lasts"** (`mcpRefreshTokenValidForHours`).
+
+**Hours are the wire format; the unit is presentation only.** Each setting is edited as a pair of
+**form-only** controls — `<name>Value` (an `app-input type="number"`) and `<name>Unit` (an
+`app-select` over `durationUnits`) — which `submit()` folds back into `<name>Hours` via `toHours(...)`
+before `delete`-ing the four helper keys from the payload. The exact-payload assertion in
+`system-settings-form.component.spec.ts` fails if any of them leak.
+
+The conversion lives in **`src/utils/duration.utils.ts`** (`splitHours` / `toHours` / `maxForUnit`),
+shared by both settings so they cannot drift. `splitHours` renders a value as Days only when it
+divides evenly into whole days and is at least 24 (720 → 30 Days, 36 → 36 Hours), and falls back to
+the 24h default for the `0`/null the API sends when the setting is unset — so the view page shows
+"1 Days", not "0 Hours". Note `toHours` guards on `parsed <= 0`, not just `Number.isFinite`:
+`Number(null)` and `Number("")` are both `0`, so an emptied number field would otherwise submit a
+zero-length lifetime.
+
+**The max tracks the selected unit** (720 hours === 30 days). `listenForDurationUnitChanges(value,
+unit)` — one parameterised method called twice — re-applies
+`[Validators.required, durationValueValidator(maxForUnit(...))]` whenever the unit flips, the same
+shape as `urlValidators()` above (`setValidators` replaces the whole list, so `required` must be
+re-supplied each time rather than declared in `initForm`). All four controls are also added to the
+**view-mode disable block**, or they stay editable on the read-only page.
+
+**E2E:** `e2e/session-lifetime.spec.ts` (serial, admin `storageState`; the setting is **global**, so
+`afterAll` re-reads live settings and restores only the captured field). It is the only test that
+proves the value survives **model → command → DB → JWT → Set-Cookie**: an admin saves "2 Days", the
+API stores `48`, the view page renders it back as "2 Days", and a fresh login's `refresh_token`
+cookie expiry lands in the configured window while the `jwt` cookie stays inside 20 minutes.
+
+**`durationValueValidator`** (`src/validators/duration-validators.ts`) replaces
+`Validators.min`/`max` here for two reasons, both of which cost real UX:
+
+- **Whole numbers.** The API field is a Go `int`, so a fractional entry (`type="number"` accepts
+  decimals) fails `json.Unmarshal` outright and returns an unparseable-body error rather than a
+  field-level message.
+- **Visible messages.** `BaseInputComponent.errorMessages` only maps `required`/`email`/`duplicate`/
+  `min`, so a `Validators.max` failure renders as an **empty** `mat-error` — a red field with no
+  explanation. This validator emits its message as the error *value*, which takes that component's
+  `typeof value === "string"` path and renders verbatim. Reach for the same trick for any new
+  validator whose error key is not in that map.
+
 ## Signals & Zoneless Change Detection
 
 This application uses Angular's signal-based reactivity model with zoneless change detection (`provideZonelessChangeDetection()`). All new code MUST follow these patterns.

--- a/desktop/e2e/session-lifetime.spec.ts
+++ b/desktop/e2e/session-lifetime.spec.ts
@@ -1,0 +1,164 @@
+import { expect, test } from '@playwright/test';
+import { creds, stubTokenRefresh } from './helpers/auth';
+import { withAdminApi } from './helpers/provisioning';
+
+// 2 days. Chosen because it divides evenly into days, so it also pins the
+// hours <-> unit round trip: the form must render 48 stored hours back as
+// "2 Days", not "48 Hours".
+const LIFETIME_DAYS = 2;
+const LIFETIME_HOURS = LIFETIME_DAYS * 24;
+
+// Allow generous slack on the expiry assertion -- the value is minted when the
+// server handles the login, which is some way after this suite reads the clock.
+const SLACK_MS = 10 * 60 * 1000;
+
+// `refreshTokenValidForHours` is a GLOBAL system setting, so these tests mutate
+// shared server state and must run serially. afterAll puts the field back to
+// whatever it was before the suite -- never a hardcoded default, which would
+// silently retune sessions on an environment that had configured it.
+test.describe.serial('Session lifetime (System Settings → refresh cookie)', () => {
+  let originalRefreshTokenValidForHours: unknown;
+
+  test.beforeAll(async () => {
+    await withAdminApi(async (api) => {
+      const res = await api.get('/api/systemSettings');
+      if (!res.ok()) {
+        throw new Error(`GET /api/systemSettings failed: HTTP ${res.status()}`);
+      }
+      originalRefreshTokenValidForHours = (await res.json())
+        .refreshTokenValidForHours;
+    });
+  });
+
+  test.afterAll(async () => {
+    // Re-read the live settings and overlay only the captured field, so a
+    // concurrent change to an unrelated setting isn't clobbered by a stale
+    // snapshot (the PUT is an upsert needing the full object).
+    try {
+      await withAdminApi(async (api) => {
+        // Playwright's request methods resolve on 4xx/5xx, so both calls need
+        // an explicit status check or a failed restore passes silently.
+        const getResponse = await api.get('/api/systemSettings');
+        if (!getResponse.ok()) {
+          throw new Error(
+            `GET /api/systemSettings failed: HTTP ${getResponse.status()}`,
+          );
+        }
+        const current = await getResponse.json();
+
+        const putResponse = await api.put('/api/systemSettings', {
+          data: {
+            ...current,
+            refreshTokenValidForHours: originalRefreshTokenValidForHours ?? 24,
+          },
+        });
+        if (!putResponse.ok()) {
+          throw new Error(
+            `PUT /api/systemSettings failed: HTTP ${putResponse.status()}`,
+          );
+        }
+      });
+    } catch (error) {
+      // Best-effort teardown -- report the failure but don't mask the suite's
+      // real result by throwing out of afterAll.
+      console.warn('Failed to restore session lifetime system setting', error);
+    }
+  });
+
+  test('admin sets the session lifetime in days and it persists as hours', async ({
+    browser,
+  }) => {
+    const context = await browser.newContext({
+      storageState: 'e2e/.auth/admin.json',
+    });
+    const page = await context.newPage();
+    await stubTokenRefresh(page);
+
+    await page.goto('/system-settings/settings/edit');
+    await page.getByLabel('Stay signed in for').fill(String(LIFETIME_DAYS));
+    await page
+      .locator('app-form-section')
+      .filter({ hasText: 'Stay signed in for' })
+      .getByLabel('Unit')
+      .click();
+    await page.getByRole('option', { name: 'Days' }).click();
+    await page.getByRole('button', { name: 'Save' }).click();
+    await expect(page).toHaveURL(/\/system-settings\/settings\/view/);
+
+    // The unit is presentation only -- the wire and the DB store whole hours.
+    await withAdminApi(async (api) => {
+      const settings = await (await api.get('/api/systemSettings')).json();
+      expect(settings.refreshTokenValidForHours).toBe(LIFETIME_HOURS);
+    });
+
+    // ...and the view page renders those hours back in the friendlier unit.
+    await page.reload();
+    await expect(page.getByLabel('Stay signed in for')).toHaveValue(
+      String(LIFETIME_DAYS),
+    );
+
+    await context.close();
+  });
+
+  test('a fresh login gets a refresh cookie sized to the configured lifetime', async ({
+    browser,
+  }) => {
+    // A fresh, unauthenticated context so the cookies come from this login and
+    // not from a stored session.
+    const context = await browser.newContext({
+      storageState: { cookies: [], origins: [] },
+    });
+    const page = await context.newPage();
+
+    const { username, password } = creds('admin');
+    await page.goto('/auth/login');
+    await page.getByLabel('Username').fill(username);
+    await page.getByLabel('Password').fill(password);
+
+    const before = Date.now();
+    await page.getByRole('button', { name: 'Login' }).click();
+    await expect(page).toHaveURL(/\/dashboard\/group\/\d+/, { timeout: 15_000 });
+
+    const cookies = await context.cookies();
+    const refreshToken = cookies.find((c) => c.name === 'refresh_token');
+    const jwt = cookies.find((c) => c.name === 'jwt');
+
+    expect(refreshToken, 'refresh_token cookie should be set').toBeDefined();
+    expect(jwt, 'jwt cookie should be set').toBeDefined();
+
+    // This is the assertion the unit tests cannot make: it proves the value
+    // survived model → command → DB → JWT → Set-Cookie.
+    const refreshExpiresMs = refreshToken!.expires * 1000;
+    const expected = before + LIFETIME_HOURS * 60 * 60 * 1000;
+    expect(refreshExpiresMs).toBeGreaterThan(expected - SLACK_MS);
+    expect(refreshExpiresMs).toBeLessThan(expected + SLACK_MS);
+
+    // The access token is deliberately NOT configurable and stays at 20
+    // minutes -- both clients size their refresh timer against that window.
+    const jwtExpiresMs = jwt!.expires * 1000;
+    expect(jwtExpiresMs).toBeGreaterThan(before);
+    expect(jwtExpiresMs).toBeLessThan(before + 25 * 60 * 1000);
+
+    await context.close();
+  });
+
+  test('the form rejects a lifetime above the 30 day maximum', async ({
+    browser,
+  }) => {
+    const context = await browser.newContext({
+      storageState: 'e2e/.auth/admin.json',
+    });
+    const page = await context.newPage();
+    await stubTokenRefresh(page);
+
+    await page.goto('/system-settings/settings/edit');
+    await page.getByLabel('Stay signed in for').fill('31');
+    await page.getByLabel('Stay signed in for').blur();
+
+    // The message has to be visible -- Validators.max has no message mapping in
+    // BaseInputComponent and would render an empty mat-error.
+    await expect(page.getByText('Must be at most 30.')).toBeVisible();
+
+    await context.close();
+  });
+});

--- a/desktop/src/open-api/model/systemSettings.ts
+++ b/desktop/src/open-api/model/systemSettings.ts
@@ -81,6 +81,14 @@ export interface SystemSettings {
      * Server/API URL mobile clients connect to; encoded into the login QR\'s deep link
      */
     mobileServerUrl?: string;
+    /**
+     * How long a refresh token stays valid, in hours. Refresh tokens rotate on every use, so this is how long a user can be away and still return signed in, not an absolute session cap. 1-720 (30 days); 0 means unset and falls back to the default.
+     */
+    refreshTokenValidForHours?: number;
+    /**
+     * The same for MCP/OAuth connector refresh tokens, kept separate so a long window chosen for human convenience does not extend third-party client tokens. 1-720 (30 days); 0 means unset and falls back to the default.
+     */
+    mcpRefreshTokenValidForHours?: number;
 }
 export namespace SystemSettings {
 }

--- a/desktop/src/open-api/model/upsertSystemSettingsCommand.ts
+++ b/desktop/src/open-api/model/upsertSystemSettingsCommand.ts
@@ -71,11 +71,11 @@ export interface UpsertSystemSettingsCommand {
      */
     mobileServerUrl?: string;
     /**
-     * How long a refresh token stays valid, in hours. 0 means unset and falls back to the default of 24.
+     * How long a refresh token stays valid, in hours. Accepted values are 1-720 (30 days), or 0 meaning unset, which falls back to the default of 24. Omit the key entirely to leave the currently configured value unchanged.
      */
     refreshTokenValidForHours?: number;
     /**
-     * How long an MCP/OAuth connector refresh token stays valid, in hours. 0 means unset and falls back to the default of 24.
+     * How long an MCP/OAuth connector refresh token stays valid, in hours. Accepted values are 1-720 (30 days), or 0 meaning unset, which falls back to the default of 24. Omit the key entirely to leave the currently configured value unchanged.
      */
     mcpRefreshTokenValidForHours?: number;
 }

--- a/desktop/src/open-api/model/upsertSystemSettingsCommand.ts
+++ b/desktop/src/open-api/model/upsertSystemSettingsCommand.ts
@@ -70,6 +70,14 @@ export interface UpsertSystemSettingsCommand {
      * Server/API URL mobile clients connect to; encoded into the login QR\'s deep link
      */
     mobileServerUrl?: string;
+    /**
+     * How long a refresh token stays valid, in hours. 0 means unset and falls back to the default of 24.
+     */
+    refreshTokenValidForHours?: number;
+    /**
+     * How long an MCP/OAuth connector refresh token stays valid, in hours. 0 means unset and falls back to the default of 24.
+     */
+    mcpRefreshTokenValidForHours?: number;
 }
 export namespace UpsertSystemSettingsCommand {
 }

--- a/desktop/src/system-settings/system-settings-form/system-settings-form.component.html
+++ b/desktop/src/system-settings/system-settings-form/system-settings-form.component.html
@@ -136,6 +136,33 @@
     ></app-checkbox>
   </app-form-section>
   <app-form-section
+    headerText="Session"
+  >
+    <p class="text-muted mb-3">
+      How long a signed-in user can be away before they have to log in again. Sessions renew
+      themselves while the app is in use, so this is an inactivity window rather than a hard limit —
+      someone who uses Receipt Wrangler regularly is never signed out. Lower it for a tighter
+      security posture, raise it so people stay signed in longer. Maximum 720 hours (30 days).
+    </p>
+    <div class="d-flex gap-3">
+      <app-input
+        class="flex-grow-1"
+        label="Stay signed in for"
+        type="number"
+        [inputFormControl]="form | formGet:'refreshTokenValidForValue'"
+        [readonly]="formConfig.mode | inputReadonly"
+      ></app-input>
+      <app-select
+        class="flex-grow-1"
+        label="Unit"
+        optionValueKey="value"
+        optionDisplayKey="displayValue"
+        [inputFormControl]="form | formGet:'refreshTokenValidForUnit'"
+        [options]="durationUnits"
+      ></app-select>
+    </div>
+  </app-form-section>
+  <app-form-section
     headerText="MCP Server"
   >
     <p class="text-muted mb-3">
@@ -154,6 +181,24 @@
       [readonly]="formConfig.mode | inputReadonly"
       [inputFormControl]="form | formGet:'mcpPublicUrl'"
     ></app-input>
+    <div class="d-flex gap-3">
+      <app-input
+        class="flex-grow-1"
+        label="Connector sign-in lasts"
+        type="number"
+        hint="How long a connected client stays authorized before it has to sign in again. Kept separate from the app session above so a long user-facing window does not extend third-party access. Maximum 720 hours (30 days)."
+        [inputFormControl]="form | formGet:'mcpRefreshTokenValidForValue'"
+        [readonly]="formConfig.mode | inputReadonly"
+      ></app-input>
+      <app-select
+        class="flex-grow-1"
+        label="Unit"
+        optionValueKey="value"
+        optionDisplayKey="displayValue"
+        [inputFormControl]="form | formGet:'mcpRefreshTokenValidForUnit'"
+        [options]="durationUnits"
+      ></app-select>
+    </div>
     @if ((form | formGet:'mcpEnabled').value && (form | formGet:'mcpPublicUrl').value) {
       <div class="d-flex flex-column mb-2">
         <strong>Connector URL</strong>

--- a/desktop/src/system-settings/system-settings-form/system-settings-form.component.spec.ts
+++ b/desktop/src/system-settings/system-settings-form/system-settings-form.component.spec.ts
@@ -102,6 +102,12 @@ describe("SystemSettingsFormComponent", () => {
       mcpPublicUrl: null,
       showLoginQr: null,
       mobileServerUrl: null,
+      // With no stored value, splitHours falls back to the 24h default and
+      // renders it as the friendlier "1 Days".
+      refreshTokenValidForValue: 1,
+      refreshTokenValidForUnit: "DAYS",
+      mcpRefreshTokenValidForValue: 1,
+      mcpRefreshTokenValidForUnit: "DAYS",
     });
   });
 
@@ -128,6 +134,8 @@ describe("SystemSettingsFormComponent", () => {
       mcpPublicUrl: "https://receipts.example.com",
       showLoginQr: true,
       mobileServerUrl: "https://receipts.example.com/api",
+      refreshTokenValidForHours: 720,
+      mcpRefreshTokenValidForHours: 6,
     };
 
     component.ngOnInit();
@@ -153,6 +161,12 @@ describe("SystemSettingsFormComponent", () => {
       mcpPublicUrl: "https://receipts.example.com",
       showLoginQr: true,
       mobileServerUrl: "https://receipts.example.com/api",
+      // 720 hours divides evenly into days, so it renders as 30 Days; 6 does
+      // not, so it stays in hours.
+      refreshTokenValidForValue: 30,
+      refreshTokenValidForUnit: "DAYS",
+      mcpRefreshTokenValidForValue: 6,
+      mcpRefreshTokenValidForUnit: "HOURS",
     });
   });
 
@@ -270,6 +284,78 @@ describe("SystemSettingsFormComponent", () => {
     expect(mcpPublicUrl.valid).toBe(true);
   });
 
+  it("caps the session lifetime at 720 hours or 30 days depending on the unit", () => {
+    component.ngOnInit();
+
+    const value = component.form.get("refreshTokenValidForValue")!;
+    const unit = component.form.get("refreshTokenValidForUnit")!;
+
+    unit.setValue("HOURS");
+    value.setValue(720);
+    expect(value.valid).toBe(true);
+
+    value.setValue(721);
+    expect(value.valid).toBe(false);
+
+    // Flipping the unit has to retarget the max, or 30 days would be rejected
+    // as if it were 30 hours over the limit.
+    unit.setValue("DAYS");
+    value.setValue(30);
+    expect(value.valid).toBe(true);
+
+    value.setValue(31);
+    expect(value.valid).toBe(false);
+  });
+
+  it("requires a positive whole-number session lifetime", () => {
+    component.ngOnInit();
+
+    const value = component.form.get("refreshTokenValidForValue")!;
+
+    value.setValue(0);
+    expect(value.valid).toBe(false);
+
+    value.setValue(null);
+    expect(value.valid).toBe(false);
+
+    // The API stores this as a Go int, so a fractional value would fail
+    // json.Unmarshal instead of coming back as a field error.
+    value.setValue(1.5);
+    expect(value.valid).toBe(false);
+
+    value.setValue(1);
+    expect(value.valid).toBe(true);
+  });
+
+  it("surfaces a readable message when the lifetime is out of range", () => {
+    component.ngOnInit();
+
+    const value = component.form.get("refreshTokenValidForValue")!;
+    component.form.get("refreshTokenValidForUnit")!.setValue("DAYS");
+
+    value.setValue(31);
+
+    // The message rides on the error value so BaseInputComponent renders it —
+    // Validators.max has no message mapping and would show a blank error.
+    expect(value.errors?.["duration"]).toBe("Must be at most 30.");
+  });
+
+  it("caps the mcp connector lifetime independently of the session lifetime", () => {
+    component.ngOnInit();
+
+    component.form.get("mcpRefreshTokenValidForUnit")!.setValue("DAYS");
+    const mcpValue = component.form.get("mcpRefreshTokenValidForValue")!;
+
+    mcpValue.setValue(31);
+    expect(mcpValue.valid).toBe(false);
+
+    mcpValue.setValue(30);
+    expect(mcpValue.valid).toBe(true);
+
+    // The app-session control keeps its own unit and bound.
+    expect(component.form.get("refreshTokenValidForUnit")!.value).toBe("DAYS");
+  });
+
   it("should submit form", () => {
     const systemSettingsService = TestBed.inject(SystemSettingsService);
     const snackbarService = TestBed.inject(SnackbarService);
@@ -301,6 +387,10 @@ describe("SystemSettingsFormComponent", () => {
       mcpPublicUrl: "https://receipts.example.com",
       showLoginQr: true,
       mobileServerUrl: "https://receipts.example.com/api",
+      refreshTokenValidForValue: "14",
+      refreshTokenValidForUnit: "DAYS",
+      mcpRefreshTokenValidForValue: "12",
+      mcpRefreshTokenValidForUnit: "HOURS",
     });
 
     // Update the quick_scan queue priority specifically
@@ -337,6 +427,10 @@ describe("SystemSettingsFormComponent", () => {
       mcpPublicUrl: "https://receipts.example.com",
       showLoginQr: true,
       mobileServerUrl: "https://receipts.example.com/api",
+      // The value/unit pairs are folded into hours and the presentation-only
+      // controls are stripped — toEqual would fail if any of them leaked.
+      refreshTokenValidForHours: 336,
+      mcpRefreshTokenValidForHours: 12,
     });
 
     expect(snackbarServiceSpy).toHaveBeenCalled();

--- a/desktop/src/system-settings/system-settings-form/system-settings-form.component.ts
+++ b/desktop/src/system-settings/system-settings-form/system-settings-form.component.ts
@@ -21,7 +21,8 @@ import { InputReadonlyPipe } from "../../pipes/input-readonly.pipe";
 import { SnackbarService } from "../../services";
 import { SetFeatureConfig } from "../../store";
 import { SetCurrencyData, SetCurrencyDisplay } from "../../store/system-settings.state.actions";
-import { absoluteUrlValidator } from "../../validators";
+import { DurationUnit, maxForUnit, splitHours, toHours } from "../../utils";
+import { absoluteUrlValidator, durationValueValidator } from "../../validators";
 
 interface QueueData extends FormOption {
   description: string;
@@ -69,6 +70,22 @@ export class SystemSettingsFormComponent extends BaseFormComponent implements On
       value: QueueName.QuickScan,
       displayValue: "Quick Scan",
       description: "Processes quick scan receipts"
+    }
+  ];
+
+  // The backend caps a refresh-token lifetime at 720 hours (30 days) and treats
+  // 0 as "unset, use the default". Mirrored here so the form rejects what the
+  // server would reject.
+  public static readonly MAX_TOKEN_LIFETIME_HOURS = 720;
+
+  public readonly durationUnits: FormOption[] = [
+    {
+      displayValue: "Hours",
+      value: "HOURS"
+    },
+    {
+      displayValue: "Days",
+      value: "DAYS"
     }
   ];
 
@@ -126,6 +143,9 @@ export class SystemSettingsFormComponent extends BaseFormComponent implements On
   }
 
   private initForm(): void {
+    const refreshTokenLifetime = splitHours(this.originalSystemSettings?.refreshTokenValidForHours);
+    const mcpRefreshTokenLifetime = splitHours(this.originalSystemSettings?.mcpRefreshTokenValidForHours);
+
     this.form = this.formBuilder.group({
       enableLocalSignUp: [this.originalSystemSettings?.enableLocalSignUp],
       debugOcr: [this.originalSystemSettings?.debugOcr],
@@ -144,6 +164,12 @@ export class SystemSettingsFormComponent extends BaseFormComponent implements On
       mcpPublicUrl: [this.originalSystemSettings?.mcpPublicUrl],
       showLoginQr: [this.originalSystemSettings?.showLoginQr],
       mobileServerUrl: [this.originalSystemSettings?.mobileServerUrl],
+      // Form-only controls. The API stores hours; the unit is presentation and
+      // is folded back into `<name>Hours` in submit().
+      refreshTokenValidForValue: [refreshTokenLifetime.value],
+      refreshTokenValidForUnit: [refreshTokenLifetime.unit],
+      mcpRefreshTokenValidForValue: [mcpRefreshTokenLifetime.value],
+      mcpRefreshTokenValidForUnit: [mcpRefreshTokenLifetime.unit],
     });
 
     if (this.inputReadonlyPipe.transform(this.formConfig.mode)) {
@@ -157,12 +183,40 @@ export class SystemSettingsFormComponent extends BaseFormComponent implements On
       this.form.get("mcpPublicUrl")?.disable();
       this.form.get("showLoginQr")?.disable();
       this.form.get("mobileServerUrl")?.disable();
+      this.form.get("refreshTokenValidForValue")?.disable();
+      this.form.get("refreshTokenValidForUnit")?.disable();
+      this.form.get("mcpRefreshTokenValidForValue")?.disable();
+      this.form.get("mcpRefreshTokenValidForUnit")?.disable();
     }
 
     this.listenForReceiptProcessingSettingsChanges();
     this.listenForHideDecimalPlacesChanges();
     this.listenForMcpEnabledChanges();
     this.listenForShowLoginQrChanges();
+    this.listenForDurationUnitChanges("refreshTokenValidForValue", "refreshTokenValidForUnit");
+    this.listenForDurationUnitChanges("mcpRefreshTokenValidForValue", "mcpRefreshTokenValidForUnit");
+  }
+
+  // The maximum depends on the selected unit (720 hours === 30 days), so the
+  // value control's validators are re-applied whenever the unit flips. Like
+  // urlValidators() below, setValidators replaces the whole list, so required
+  // has to be re-supplied each time rather than declared in initForm.
+  private listenForDurationUnitChanges(valueControlName: string, unitControlName: string): void {
+    const valueControl = this.form.get(valueControlName);
+
+    this.form.get(unitControlName)?.valueChanges
+      .pipe(
+        startWith(this.form.get(unitControlName)?.value),
+        untilDestroyed(this),
+        tap((unit: DurationUnit) => {
+          valueControl?.setValidators([
+            Validators.required,
+            durationValueValidator(maxForUnit(SystemSettingsFormComponent.MAX_TOKEN_LIFETIME_HOURS, unit)),
+          ]);
+          valueControl?.updateValueAndValidity({ emitEvent: false });
+        })
+      )
+      .subscribe();
   }
 
   // TODO: finish implementing UI for taskQueueConfigurations
@@ -272,6 +326,20 @@ export class SystemSettingsFormComponent extends BaseFormComponent implements On
 
   public submit(): void {
     const formValue = this.form.getRawValue();
+    // Fold the value/unit pairs back into the hours the API stores, then drop
+    // the presentation-only controls so they never reach the wire.
+    formValue["refreshTokenValidForHours"] = toHours(
+      formValue["refreshTokenValidForValue"],
+      formValue["refreshTokenValidForUnit"]
+    );
+    formValue["mcpRefreshTokenValidForHours"] = toHours(
+      formValue["mcpRefreshTokenValidForValue"],
+      formValue["mcpRefreshTokenValidForUnit"]
+    );
+    delete formValue["refreshTokenValidForValue"];
+    delete formValue["refreshTokenValidForUnit"];
+    delete formValue["mcpRefreshTokenValidForValue"];
+    delete formValue["mcpRefreshTokenValidForUnit"];
     formValue["emailPollingInterval"] = Number.parseInt(formValue["emailPollingInterval"]);
     formValue["taskConcurrency"] = Number.parseInt(formValue["taskConcurrency"]);
     formValue["pdfDpi"] = Number.parseInt(formValue["pdfDpi"]);

--- a/desktop/src/utils/duration.utils.spec.ts
+++ b/desktop/src/utils/duration.utils.spec.ts
@@ -1,0 +1,74 @@
+import { DEFAULT_DURATION_HOURS, maxForUnit, splitHours, toHours } from "./duration.utils";
+
+describe("duration.utils", () => {
+  describe("splitHours", () => {
+    it("renders whole days as days", () => {
+      expect(splitHours(24)).toEqual({ value: 1, unit: "DAYS" });
+      expect(splitHours(168)).toEqual({ value: 7, unit: "DAYS" });
+      expect(splitHours(720)).toEqual({ value: 30, unit: "DAYS" });
+    });
+
+    it("keeps values that are not whole days in hours", () => {
+      expect(splitHours(1)).toEqual({ value: 1, unit: "HOURS" });
+      expect(splitHours(6)).toEqual({ value: 6, unit: "HOURS" });
+      expect(splitHours(36)).toEqual({ value: 36, unit: "HOURS" });
+    });
+
+    it("keeps sub-day values in hours rather than showing a fractional day", () => {
+      expect(splitHours(12)).toEqual({ value: 12, unit: "HOURS" });
+      expect(splitHours(23)).toEqual({ value: 23, unit: "HOURS" });
+    });
+
+    // 0 is what the API sends for "unset", and what an older client would send.
+    it("falls back to the default when unset or invalid", () => {
+      const fallback = { value: DEFAULT_DURATION_HOURS / 24, unit: "DAYS" };
+
+      expect(splitHours(0)).toEqual(fallback);
+      expect(splitHours(null)).toEqual(fallback);
+      expect(splitHours(undefined)).toEqual(fallback);
+      expect(splitHours(-5)).toEqual(fallback);
+      expect(splitHours(NaN)).toEqual(fallback);
+    });
+  });
+
+  describe("toHours", () => {
+    it("passes hours through and multiplies days", () => {
+      expect(toHours(6, "HOURS")).toBe(6);
+      expect(toHours(30, "DAYS")).toBe(720);
+      expect(toHours(1, "DAYS")).toBe(24);
+    });
+
+    // Number inputs hand back strings, so the conversion has to coerce.
+    it("coerces string input from number fields", () => {
+      expect(toHours("14", "DAYS")).toBe(336);
+      expect(toHours("12", "HOURS")).toBe(12);
+    });
+
+    // Number(null) and Number("") are both 0, so an emptied number field would
+    // otherwise silently submit a zero-length lifetime.
+    it("falls back to the default for empty or unparseable input", () => {
+      expect(toHours(null, "HOURS")).toBe(DEFAULT_DURATION_HOURS);
+      expect(toHours(undefined, "HOURS")).toBe(DEFAULT_DURATION_HOURS);
+      expect(toHours("", "DAYS")).toBe(DEFAULT_DURATION_HOURS);
+      expect(toHours("abc", "HOURS")).toBe(DEFAULT_DURATION_HOURS);
+      expect(toHours(0, "DAYS")).toBe(DEFAULT_DURATION_HOURS);
+      expect(toHours(-3, "HOURS")).toBe(DEFAULT_DURATION_HOURS);
+    });
+  });
+
+  describe("round trip", () => {
+    it("preserves every value the backend accepts", () => {
+      for (const hours of [1, 2, 6, 12, 23, 24, 36, 48, 168, 719, 720]) {
+        const split = splitHours(hours);
+        expect(toHours(split.value, split.unit)).toBe(hours);
+      }
+    });
+  });
+
+  describe("maxForUnit", () => {
+    it("expresses the hour cap in the selected unit", () => {
+      expect(maxForUnit(720, "HOURS")).toBe(720);
+      expect(maxForUnit(720, "DAYS")).toBe(30);
+    });
+  });
+});

--- a/desktop/src/utils/duration.utils.ts
+++ b/desktop/src/utils/duration.utils.ts
@@ -1,0 +1,60 @@
+/**
+ * Helpers for editing an hours-based duration setting with a Hours/Days
+ * selector.
+ *
+ * Hours are the single source of truth: the API stores and transports hours, and
+ * the unit exists only so an admin can type "30 Days" instead of "720". Keep the
+ * conversion here rather than in the form component so the two settings that use
+ * it cannot drift.
+ */
+export type DurationUnit = "HOURS" | "DAYS";
+
+export const HOURS_PER_DAY = 24;
+
+/** Fallback shown when a duration setting is unset (0/null on the wire). */
+export const DEFAULT_DURATION_HOURS = 24;
+
+export interface SplitDuration {
+  value: number;
+  unit: DurationUnit;
+}
+
+/**
+ * Picks the friendliest unit for an hours value: Days when it divides evenly
+ * into whole days, Hours otherwise. An unset/invalid value falls back to the
+ * default, matching the backend's own clamp.
+ */
+export function splitHours(hours?: number | null): SplitDuration {
+  const total = Number(hours);
+  const safeTotal = Number.isFinite(total) && total > 0 ? total : DEFAULT_DURATION_HOURS;
+
+  if (safeTotal >= HOURS_PER_DAY && safeTotal % HOURS_PER_DAY === 0) {
+    return { value: safeTotal / HOURS_PER_DAY, unit: "DAYS" };
+  }
+
+  return { value: safeTotal, unit: "HOURS" };
+}
+
+/**
+ * Converts an edited value back to the hours the API expects. Anything that is
+ * not a positive number falls back to the default — note `Number(null)` and
+ * `Number("")` are both 0, so an emptied field must be caught by the positivity
+ * check, not by isFinite alone.
+ */
+export function toHours(value: number | string | null | undefined, unit: DurationUnit): number {
+  const parsed = Number(value);
+
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_DURATION_HOURS;
+  }
+
+  return unit === "DAYS" ? parsed * HOURS_PER_DAY : parsed;
+}
+
+/**
+ * The upper bound expressed in the given unit. The backend caps the lifetime at
+ * 720 hours, so the form's max has to track whichever unit is selected.
+ */
+export function maxForUnit(maxHours: number, unit: DurationUnit): number {
+  return unit === "DAYS" ? Math.floor(maxHours / HOURS_PER_DAY) : maxHours;
+}

--- a/desktop/src/utils/index.ts
+++ b/desktop/src/utils/index.ts
@@ -5,3 +5,4 @@ export * from "./permission.utils";
 export * from "./sort-by-displayname";
 export * from "./status.utils";
 export * from "./app-data.utill";
+export * from "./duration.utils";

--- a/desktop/src/validators/duration-validators.spec.ts
+++ b/desktop/src/validators/duration-validators.spec.ts
@@ -1,0 +1,43 @@
+import { FormControl } from "@angular/forms";
+import { durationValueValidator } from "./duration-validators";
+
+describe("durationValueValidator", () => {
+  const validate = (value: any, max = 720) =>
+    durationValueValidator(max)(new FormControl(value));
+
+  it("accepts whole numbers within range", () => {
+    expect(validate(1)).toBeNull();
+    expect(validate(24)).toBeNull();
+    expect(validate(720)).toBeNull();
+    expect(validate(30, 30)).toBeNull();
+  });
+
+  // The API field is a Go int, so a decimal fails json.Unmarshal rather than
+  // returning a field-level error.
+  it("rejects fractional values", () => {
+    expect(validate(1.5)?.["duration"]).toBe("Must be a whole number.");
+    expect(validate("2.5")?.["duration"]).toBe("Must be a whole number.");
+  });
+
+  it("rejects values below 1", () => {
+    expect(validate(0)?.["duration"]).toBe("Must be at least 1.");
+    expect(validate(-4)?.["duration"]).toBe("Must be at least 1.");
+  });
+
+  it("rejects values above the max, naming the max in the message", () => {
+    expect(validate(721)?.["duration"]).toBe("Must be at most 720.");
+    expect(validate(31, 30)?.["duration"]).toBe("Must be at most 30.");
+  });
+
+  it("rejects non-numeric input", () => {
+    expect(validate("abc")?.["duration"]).toBe("Must be a whole number.");
+  });
+
+  // Emptiness belongs to Validators.required, so this validator stays quiet and
+  // the input renders the standard "<label> is required." message instead.
+  it("leaves emptiness to Validators.required", () => {
+    expect(validate(null)).toBeNull();
+    expect(validate(undefined)).toBeNull();
+    expect(validate("")).toBeNull();
+  });
+});

--- a/desktop/src/validators/duration-validators.ts
+++ b/desktop/src/validators/duration-validators.ts
@@ -1,0 +1,47 @@
+import { AbstractControl, ValidationErrors, ValidatorFn } from "@angular/forms";
+
+/**
+ * Bounds a duration setting edited as a number + unit pair: a whole number, at
+ * least 1, at most `max` (expressed in the currently selected unit).
+ *
+ * It replaces `Validators.min` / `Validators.max` here for two reasons:
+ *
+ * - **Whole numbers.** The API stores these as a Go `int`. A fractional entry
+ *   like `1.5` fails `json.Unmarshal` outright, so the request comes back as an
+ *   unparseable-body error rather than a field-level message. `type="number"`
+ *   accepts decimals, so the form has to reject them.
+ * - **Visible messages.** `BaseInputComponent` only maps `required` / `email` /
+ *   `duplicate` / `min` to text, so a `Validators.max` failure renders as an
+ *   empty `mat-error` — a red field with no explanation. Emitting the message as
+ *   the error *value* takes the `typeof value === "string"` path in that
+ *   component, which renders it verbatim.
+ */
+export function durationValueValidator(max: number): ValidatorFn {
+  return (control: AbstractControl): ValidationErrors | null => {
+    const raw = control.value;
+
+    // Emptiness is Validators.required's job, not ours.
+    if (raw === null || raw === undefined || raw === "") {
+      return null;
+    }
+
+    const value = Number(raw);
+    if (!Number.isFinite(value)) {
+      return { duration: "Must be a whole number." };
+    }
+
+    if (!Number.isInteger(value)) {
+      return { duration: "Must be a whole number." };
+    }
+
+    if (value < 1) {
+      return { duration: "Must be at least 1." };
+    }
+
+    if (value > max) {
+      return { duration: `Must be at most ${max}.` };
+    }
+
+    return null;
+  };
+}

--- a/desktop/src/validators/index.ts
+++ b/desktop/src/validators/index.ts
@@ -1,3 +1,4 @@
+export * from './duration-validators';
 export * from './text-validators';
 export * from './url-validators';
 export * from './user-validators';

--- a/mobile/api/doc/SystemSettings.md
+++ b/mobile/api/doc/SystemSettings.md
@@ -31,6 +31,8 @@ Name | Type | Description | Notes
 **mcpPublicUrl** | **String** | Externally reachable origin used for MCP OAuth/metadata/redirect URLs and token audience | [optional] 
 **showLoginQr** | **bool** | Whether to show the mobile-setup QR code on the desktop login page | [optional] [default to false]
 **mobileServerUrl** | **String** | Server/API URL mobile clients connect to; encoded into the login QR's deep link | [optional] 
+**refreshTokenValidForHours** | **int** | How long a refresh token stays valid, in hours. Refresh tokens rotate on every use, so this is how long a user can be away and still return signed in, not an absolute session cap. 1-720 (30 days); 0 means unset and falls back to the default. | [optional] [default to 24]
+**mcpRefreshTokenValidForHours** | **int** | The same for MCP/OAuth connector refresh tokens, kept separate so a long window chosen for human convenience does not extend third-party client tokens. 1-720 (30 days); 0 means unset and falls back to the default. | [optional] [default to 24]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/mobile/api/doc/UpsertSystemSettingsCommand.md
+++ b/mobile/api/doc/UpsertSystemSettingsCommand.md
@@ -26,6 +26,8 @@ Name | Type | Description | Notes
 **mcpPublicUrl** | **String** | Externally reachable origin used for MCP OAuth/metadata/redirect URLs and token audience | [optional] 
 **showLoginQr** | **bool** | Whether to show the mobile-setup QR code on the desktop login page | [optional] 
 **mobileServerUrl** | **String** | Server/API URL mobile clients connect to; encoded into the login QR's deep link | [optional] 
+**refreshTokenValidForHours** | **int** | How long a refresh token stays valid, in hours. 0 means unset and falls back to the default of 24. | [optional] 
+**mcpRefreshTokenValidForHours** | **int** | How long an MCP/OAuth connector refresh token stays valid, in hours. 0 means unset and falls back to the default of 24. | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/mobile/api/doc/UpsertSystemSettingsCommand.md
+++ b/mobile/api/doc/UpsertSystemSettingsCommand.md
@@ -26,8 +26,8 @@ Name | Type | Description | Notes
 **mcpPublicUrl** | **String** | Externally reachable origin used for MCP OAuth/metadata/redirect URLs and token audience | [optional] 
 **showLoginQr** | **bool** | Whether to show the mobile-setup QR code on the desktop login page | [optional] 
 **mobileServerUrl** | **String** | Server/API URL mobile clients connect to; encoded into the login QR's deep link | [optional] 
-**refreshTokenValidForHours** | **int** | How long a refresh token stays valid, in hours. 0 means unset and falls back to the default of 24. | [optional] 
-**mcpRefreshTokenValidForHours** | **int** | How long an MCP/OAuth connector refresh token stays valid, in hours. 0 means unset and falls back to the default of 24. | [optional] 
+**refreshTokenValidForHours** | **int** | How long a refresh token stays valid, in hours. Accepted values are 1-720 (30 days), or 0 meaning unset, which falls back to the default of 24. Omit the key entirely to leave the currently configured value unchanged. | [optional] 
+**mcpRefreshTokenValidForHours** | **int** | How long an MCP/OAuth connector refresh token stays valid, in hours. Accepted values are 1-720 (30 days), or 0 meaning unset, which falls back to the default of 24. Omit the key entirely to leave the currently configured value unchanged. | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/mobile/api/lib/src/model/system_settings.dart
+++ b/mobile/api/lib/src/model/system_settings.dart
@@ -39,6 +39,8 @@ part 'system_settings.g.dart';
 /// * [mcpPublicUrl] - Externally reachable origin used for MCP OAuth/metadata/redirect URLs and token audience
 /// * [showLoginQr] - Whether to show the mobile-setup QR code on the desktop login page
 /// * [mobileServerUrl] - Server/API URL mobile clients connect to; encoded into the login QR's deep link
+/// * [refreshTokenValidForHours] - How long a refresh token stays valid, in hours. Refresh tokens rotate on every use, so this is how long a user can be away and still return signed in, not an absolute session cap. 1-720 (30 days); 0 means unset and falls back to the default.
+/// * [mcpRefreshTokenValidForHours] - The same for MCP/OAuth connector refresh tokens, kept separate so a long window chosen for human convenience does not extend third-party client tokens. 1-720 (30 days); 0 means unset and falls back to the default.
 @BuiltValue()
 abstract class SystemSettings implements BaseModel, Built<SystemSettings, SystemSettingsBuilder> {
   /// Whether the OAuth 2.1-protected MCP server is enabled
@@ -89,6 +91,10 @@ abstract class SystemSettings implements BaseModel, Built<SystemSettings, System
   @BuiltValueField(wireName: r'mobileServerUrl')
   String? get mobileServerUrl;
 
+  /// How long a refresh token stays valid, in hours. Refresh tokens rotate on every use, so this is how long a user can be away and still return signed in, not an absolute session cap. 1-720 (30 days); 0 means unset and falls back to the default.
+  @BuiltValueField(wireName: r'refreshTokenValidForHours')
+  int? get refreshTokenValidForHours;
+
   @BuiltValueField(wireName: r'currencySymbolPosition')
   CurrencySymbolPosition? get currencySymbolPosition;
   // enum currencySymbolPositionEnum {  START,  END,  };
@@ -109,6 +115,10 @@ abstract class SystemSettings implements BaseModel, Built<SystemSettings, System
   @BuiltValueField(wireName: r'enableLocalSignUp')
   bool? get enableLocalSignUp;
 
+  /// The same for MCP/OAuth connector refresh tokens, kept separate so a long window chosen for human convenience does not extend third-party client tokens. 1-720 (30 days); 0 means unset and falls back to the default.
+  @BuiltValueField(wireName: r'mcpRefreshTokenValidForHours')
+  int? get mcpRefreshTokenValidForHours;
+
   @BuiltValueField(wireName: r'taskQueueConfigurations')
   BuiltList<TaskQueueConfiguration> get taskQueueConfigurations;
 
@@ -121,16 +131,18 @@ abstract class SystemSettings implements BaseModel, Built<SystemSettings, System
       ..mcpEnabled = false
       ..pdfDpi = 300
       ..currencyDisplay = r'$'
-      ..showLoginQr = false
       ..currencyHideDecimalPlaces = false
-      ..debugOcr = false
-      ..createdBy = 0
-      ..taskConcurrency = 10
-      ..emailPollingInterval = 1800
       ..numWorkers = 1
       ..enableLocalSignUp = false
+      ..mcpRefreshTokenValidForHours = 24
       ..createdByString = ''
-      ..updatedAt = '';
+      ..updatedAt = ''
+      ..showLoginQr = false
+      ..debugOcr = false
+      ..refreshTokenValidForHours = 24
+      ..createdBy = 0
+      ..taskConcurrency = 10
+      ..emailPollingInterval = 1800;
 
   @BuiltValueSerializer(custom: true)
   static Serializer<SystemSettings> get serializer => _$SystemSettingsSerializer();
@@ -155,13 +167,6 @@ class _$SystemSettingsSerializer implements PrimitiveSerializer<SystemSettings> 
         specifiedType: const FullType(bool),
       );
     }
-    if (object.currencyThousandthsSeparator != null) {
-      yield r'currencyThousandthsSeparator';
-      yield serializers.serialize(
-        object.currencyThousandthsSeparator,
-        specifiedType: const FullType(CurrencySeparator),
-      );
-    }
     if (object.pdfDpi != null) {
       yield r'pdfDpi';
       yield serializers.serialize(
@@ -176,17 +181,83 @@ class _$SystemSettingsSerializer implements PrimitiveSerializer<SystemSettings> 
         specifiedType: const FullType(String),
       );
     }
-    if (object.showLoginQr != null) {
-      yield r'showLoginQr';
-      yield serializers.serialize(
-        object.showLoginQr,
-        specifiedType: const FullType(bool),
-      );
-    }
     if (object.currencyHideDecimalPlaces != null) {
       yield r'currencyHideDecimalPlaces';
       yield serializers.serialize(
         object.currencyHideDecimalPlaces,
+        specifiedType: const FullType(bool),
+      );
+    }
+    if (object.currencyDecimalSeparator != null) {
+      yield r'currencyDecimalSeparator';
+      yield serializers.serialize(
+        object.currencyDecimalSeparator,
+        specifiedType: const FullType(CurrencySeparator),
+      );
+    }
+    yield r'createdAt';
+    yield serializers.serialize(
+      object.createdAt,
+      specifiedType: const FullType(String),
+    );
+    if (object.mobileServerUrl != null) {
+      yield r'mobileServerUrl';
+      yield serializers.serialize(
+        object.mobileServerUrl,
+        specifiedType: const FullType(String),
+      );
+    }
+    if (object.numWorkers != null) {
+      yield r'numWorkers';
+      yield serializers.serialize(
+        object.numWorkers,
+        specifiedType: const FullType(int),
+      );
+    }
+    if (object.enableLocalSignUp != null) {
+      yield r'enableLocalSignUp';
+      yield serializers.serialize(
+        object.enableLocalSignUp,
+        specifiedType: const FullType(bool),
+      );
+    }
+    yield r'id';
+    yield serializers.serialize(
+      object.id,
+      specifiedType: const FullType(int),
+    );
+    if (object.mcpRefreshTokenValidForHours != null) {
+      yield r'mcpRefreshTokenValidForHours';
+      yield serializers.serialize(
+        object.mcpRefreshTokenValidForHours,
+        specifiedType: const FullType(int),
+      );
+    }
+    if (object.createdByString != null) {
+      yield r'createdByString';
+      yield serializers.serialize(
+        object.createdByString,
+        specifiedType: const FullType(String),
+      );
+    }
+    if (object.updatedAt != null) {
+      yield r'updatedAt';
+      yield serializers.serialize(
+        object.updatedAt,
+        specifiedType: const FullType(String),
+      );
+    }
+    if (object.currencyThousandthsSeparator != null) {
+      yield r'currencyThousandthsSeparator';
+      yield serializers.serialize(
+        object.currencyThousandthsSeparator,
+        specifiedType: const FullType(CurrencySeparator),
+      );
+    }
+    if (object.showLoginQr != null) {
+      yield r'showLoginQr';
+      yield serializers.serialize(
+        object.showLoginQr,
         specifiedType: const FullType(bool),
       );
     }
@@ -195,13 +266,6 @@ class _$SystemSettingsSerializer implements PrimitiveSerializer<SystemSettings> 
       yield serializers.serialize(
         object.mcpPublicUrl,
         specifiedType: const FullType(String),
-      );
-    }
-    if (object.currencyDecimalSeparator != null) {
-      yield r'currencyDecimalSeparator';
-      yield serializers.serialize(
-        object.currencyDecimalSeparator,
-        specifiedType: const FullType(CurrencySeparator),
       );
     }
     if (object.debugOcr != null) {
@@ -218,11 +282,6 @@ class _$SystemSettingsSerializer implements PrimitiveSerializer<SystemSettings> 
         specifiedType: const FullType(int),
       );
     }
-    yield r'createdAt';
-    yield serializers.serialize(
-      object.createdAt,
-      specifiedType: const FullType(String),
-    );
     if (object.receiptProcessingSettingsId != null) {
       yield r'receiptProcessingSettingsId';
       yield serializers.serialize(
@@ -230,11 +289,11 @@ class _$SystemSettingsSerializer implements PrimitiveSerializer<SystemSettings> 
         specifiedType: const FullType(int),
       );
     }
-    if (object.mobileServerUrl != null) {
-      yield r'mobileServerUrl';
+    if (object.refreshTokenValidForHours != null) {
+      yield r'refreshTokenValidForHours';
       yield serializers.serialize(
-        object.mobileServerUrl,
-        specifiedType: const FullType(String),
+        object.refreshTokenValidForHours,
+        specifiedType: const FullType(int),
       );
     }
     if (object.createdBy != null) {
@@ -265,44 +324,11 @@ class _$SystemSettingsSerializer implements PrimitiveSerializer<SystemSettings> 
         specifiedType: const FullType(int),
       );
     }
-    if (object.numWorkers != null) {
-      yield r'numWorkers';
-      yield serializers.serialize(
-        object.numWorkers,
-        specifiedType: const FullType(int),
-      );
-    }
-    if (object.enableLocalSignUp != null) {
-      yield r'enableLocalSignUp';
-      yield serializers.serialize(
-        object.enableLocalSignUp,
-        specifiedType: const FullType(bool),
-      );
-    }
-    yield r'id';
-    yield serializers.serialize(
-      object.id,
-      specifiedType: const FullType(int),
-    );
     yield r'taskQueueConfigurations';
     yield serializers.serialize(
       object.taskQueueConfigurations,
       specifiedType: const FullType(BuiltList, [FullType(TaskQueueConfiguration)]),
     );
-    if (object.createdByString != null) {
-      yield r'createdByString';
-      yield serializers.serialize(
-        object.createdByString,
-        specifiedType: const FullType(String),
-      );
-    }
-    if (object.updatedAt != null) {
-      yield r'updatedAt';
-      yield serializers.serialize(
-        object.updatedAt,
-        specifiedType: const FullType(String),
-      );
-    }
   }
 
   @override
@@ -333,13 +359,6 @@ class _$SystemSettingsSerializer implements PrimitiveSerializer<SystemSettings> 
           ) as bool;
           result.mcpEnabled = valueDes;
           break;
-        case r'currencyThousandthsSeparator':
-          final valueDes = serializers.deserialize(
-            value,
-            specifiedType: const FullType(CurrencySeparator),
-          ) as CurrencySeparator;
-          result.currencyThousandthsSeparator = valueDes;
-          break;
         case r'pdfDpi':
           final valueDes = serializers.deserialize(
             value,
@@ -354,13 +373,6 @@ class _$SystemSettingsSerializer implements PrimitiveSerializer<SystemSettings> 
           ) as String;
           result.currencyDisplay = valueDes;
           break;
-        case r'showLoginQr':
-          final valueDes = serializers.deserialize(
-            value,
-            specifiedType: const FullType(bool),
-          ) as bool;
-          result.showLoginQr = valueDes;
-          break;
         case r'currencyHideDecimalPlaces':
           final valueDes = serializers.deserialize(
             value,
@@ -368,19 +380,89 @@ class _$SystemSettingsSerializer implements PrimitiveSerializer<SystemSettings> 
           ) as bool;
           result.currencyHideDecimalPlaces = valueDes;
           break;
-        case r'mcpPublicUrl':
-          final valueDes = serializers.deserialize(
-            value,
-            specifiedType: const FullType(String),
-          ) as String;
-          result.mcpPublicUrl = valueDes;
-          break;
         case r'currencyDecimalSeparator':
           final valueDes = serializers.deserialize(
             value,
             specifiedType: const FullType(CurrencySeparator),
           ) as CurrencySeparator;
           result.currencyDecimalSeparator = valueDes;
+          break;
+        case r'createdAt':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType(String),
+          ) as String;
+          result.createdAt = valueDes;
+          break;
+        case r'mobileServerUrl':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType(String),
+          ) as String;
+          result.mobileServerUrl = valueDes;
+          break;
+        case r'numWorkers':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType(int),
+          ) as int;
+          result.numWorkers = valueDes;
+          break;
+        case r'enableLocalSignUp':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType(bool),
+          ) as bool;
+          result.enableLocalSignUp = valueDes;
+          break;
+        case r'id':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType(int),
+          ) as int;
+          result.id = valueDes;
+          break;
+        case r'mcpRefreshTokenValidForHours':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType(int),
+          ) as int;
+          result.mcpRefreshTokenValidForHours = valueDes;
+          break;
+        case r'createdByString':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType(String),
+          ) as String;
+          result.createdByString = valueDes;
+          break;
+        case r'updatedAt':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType(String),
+          ) as String;
+          result.updatedAt = valueDes;
+          break;
+        case r'currencyThousandthsSeparator':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType(CurrencySeparator),
+          ) as CurrencySeparator;
+          result.currencyThousandthsSeparator = valueDes;
+          break;
+        case r'showLoginQr':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType(bool),
+          ) as bool;
+          result.showLoginQr = valueDes;
+          break;
+        case r'mcpPublicUrl':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType(String),
+          ) as String;
+          result.mcpPublicUrl = valueDes;
           break;
         case r'debugOcr':
           final valueDes = serializers.deserialize(
@@ -396,13 +478,6 @@ class _$SystemSettingsSerializer implements PrimitiveSerializer<SystemSettings> 
           ) as int;
           result.fallbackReceiptProcessingSettingsId = valueDes;
           break;
-        case r'createdAt':
-          final valueDes = serializers.deserialize(
-            value,
-            specifiedType: const FullType(String),
-          ) as String;
-          result.createdAt = valueDes;
-          break;
         case r'receiptProcessingSettingsId':
           final valueDes = serializers.deserialize(
             value,
@@ -410,12 +485,12 @@ class _$SystemSettingsSerializer implements PrimitiveSerializer<SystemSettings> 
           ) as int;
           result.receiptProcessingSettingsId = valueDes;
           break;
-        case r'mobileServerUrl':
+        case r'refreshTokenValidForHours':
           final valueDes = serializers.deserialize(
             value,
-            specifiedType: const FullType(String),
-          ) as String;
-          result.mobileServerUrl = valueDes;
+            specifiedType: const FullType(int),
+          ) as int;
+          result.refreshTokenValidForHours = valueDes;
           break;
         case r'createdBy':
           final valueDes = serializers.deserialize(
@@ -445,47 +520,12 @@ class _$SystemSettingsSerializer implements PrimitiveSerializer<SystemSettings> 
           ) as int;
           result.emailPollingInterval = valueDes;
           break;
-        case r'numWorkers':
-          final valueDes = serializers.deserialize(
-            value,
-            specifiedType: const FullType(int),
-          ) as int;
-          result.numWorkers = valueDes;
-          break;
-        case r'enableLocalSignUp':
-          final valueDes = serializers.deserialize(
-            value,
-            specifiedType: const FullType(bool),
-          ) as bool;
-          result.enableLocalSignUp = valueDes;
-          break;
-        case r'id':
-          final valueDes = serializers.deserialize(
-            value,
-            specifiedType: const FullType(int),
-          ) as int;
-          result.id = valueDes;
-          break;
         case r'taskQueueConfigurations':
           final valueDes = serializers.deserialize(
             value,
             specifiedType: const FullType(BuiltList, [FullType(TaskQueueConfiguration)]),
           ) as BuiltList<TaskQueueConfiguration>;
           result.taskQueueConfigurations.replace(valueDes);
-          break;
-        case r'createdByString':
-          final valueDes = serializers.deserialize(
-            value,
-            specifiedType: const FullType(String),
-          ) as String;
-          result.createdByString = valueDes;
-          break;
-        case r'updatedAt':
-          final valueDes = serializers.deserialize(
-            value,
-            specifiedType: const FullType(String),
-          ) as String;
-          result.updatedAt = valueDes;
           break;
         default:
           unhandled.add(key);

--- a/mobile/api/lib/src/model/system_settings.g.dart
+++ b/mobile/api/lib/src/model/system_settings.g.dart
@@ -32,6 +32,8 @@ class _$SystemSettings extends SystemSettings {
   @override
   final String? mobileServerUrl;
   @override
+  final int? refreshTokenValidForHours;
+  @override
   final CurrencySymbolPosition? currencySymbolPosition;
   @override
   final int? taskConcurrency;
@@ -41,6 +43,8 @@ class _$SystemSettings extends SystemSettings {
   final int? numWorkers;
   @override
   final bool? enableLocalSignUp;
+  @override
+  final int? mcpRefreshTokenValidForHours;
   @override
   final BuiltList<TaskQueueConfiguration> taskQueueConfigurations;
   @override
@@ -70,11 +74,13 @@ class _$SystemSettings extends SystemSettings {
       this.fallbackReceiptProcessingSettingsId,
       this.receiptProcessingSettingsId,
       this.mobileServerUrl,
+      this.refreshTokenValidForHours,
       this.currencySymbolPosition,
       this.taskConcurrency,
       this.emailPollingInterval,
       this.numWorkers,
       this.enableLocalSignUp,
+      this.mcpRefreshTokenValidForHours,
       required this.taskQueueConfigurations,
       required this.id,
       required this.createdAt,
@@ -106,11 +112,13 @@ class _$SystemSettings extends SystemSettings {
             other.fallbackReceiptProcessingSettingsId &&
         receiptProcessingSettingsId == other.receiptProcessingSettingsId &&
         mobileServerUrl == other.mobileServerUrl &&
+        refreshTokenValidForHours == other.refreshTokenValidForHours &&
         currencySymbolPosition == other.currencySymbolPosition &&
         taskConcurrency == other.taskConcurrency &&
         emailPollingInterval == other.emailPollingInterval &&
         numWorkers == other.numWorkers &&
         enableLocalSignUp == other.enableLocalSignUp &&
+        mcpRefreshTokenValidForHours == other.mcpRefreshTokenValidForHours &&
         taskQueueConfigurations == other.taskQueueConfigurations &&
         id == other.id &&
         createdAt == other.createdAt &&
@@ -134,11 +142,13 @@ class _$SystemSettings extends SystemSettings {
     _$hash = $jc(_$hash, fallbackReceiptProcessingSettingsId.hashCode);
     _$hash = $jc(_$hash, receiptProcessingSettingsId.hashCode);
     _$hash = $jc(_$hash, mobileServerUrl.hashCode);
+    _$hash = $jc(_$hash, refreshTokenValidForHours.hashCode);
     _$hash = $jc(_$hash, currencySymbolPosition.hashCode);
     _$hash = $jc(_$hash, taskConcurrency.hashCode);
     _$hash = $jc(_$hash, emailPollingInterval.hashCode);
     _$hash = $jc(_$hash, numWorkers.hashCode);
     _$hash = $jc(_$hash, enableLocalSignUp.hashCode);
+    _$hash = $jc(_$hash, mcpRefreshTokenValidForHours.hashCode);
     _$hash = $jc(_$hash, taskQueueConfigurations.hashCode);
     _$hash = $jc(_$hash, id.hashCode);
     _$hash = $jc(_$hash, createdAt.hashCode);
@@ -165,11 +175,13 @@ class _$SystemSettings extends SystemSettings {
               fallbackReceiptProcessingSettingsId)
           ..add('receiptProcessingSettingsId', receiptProcessingSettingsId)
           ..add('mobileServerUrl', mobileServerUrl)
+          ..add('refreshTokenValidForHours', refreshTokenValidForHours)
           ..add('currencySymbolPosition', currencySymbolPosition)
           ..add('taskConcurrency', taskConcurrency)
           ..add('emailPollingInterval', emailPollingInterval)
           ..add('numWorkers', numWorkers)
           ..add('enableLocalSignUp', enableLocalSignUp)
+          ..add('mcpRefreshTokenValidForHours', mcpRefreshTokenValidForHours)
           ..add('taskQueueConfigurations', taskQueueConfigurations)
           ..add('id', id)
           ..add('createdAt', createdAt)
@@ -250,6 +262,11 @@ class SystemSettingsBuilder
   set mobileServerUrl(covariant String? mobileServerUrl) =>
       _$this._mobileServerUrl = mobileServerUrl;
 
+  int? _refreshTokenValidForHours;
+  int? get refreshTokenValidForHours => _$this._refreshTokenValidForHours;
+  set refreshTokenValidForHours(covariant int? refreshTokenValidForHours) =>
+      _$this._refreshTokenValidForHours = refreshTokenValidForHours;
+
   CurrencySymbolPosition? _currencySymbolPosition;
   CurrencySymbolPosition? get currencySymbolPosition =>
       _$this._currencySymbolPosition;
@@ -275,6 +292,12 @@ class SystemSettingsBuilder
   bool? get enableLocalSignUp => _$this._enableLocalSignUp;
   set enableLocalSignUp(covariant bool? enableLocalSignUp) =>
       _$this._enableLocalSignUp = enableLocalSignUp;
+
+  int? _mcpRefreshTokenValidForHours;
+  int? get mcpRefreshTokenValidForHours => _$this._mcpRefreshTokenValidForHours;
+  set mcpRefreshTokenValidForHours(
+          covariant int? mcpRefreshTokenValidForHours) =>
+      _$this._mcpRefreshTokenValidForHours = mcpRefreshTokenValidForHours;
 
   ListBuilder<TaskQueueConfiguration>? _taskQueueConfigurations;
   ListBuilder<TaskQueueConfiguration> get taskQueueConfigurations =>
@@ -325,11 +348,13 @@ class SystemSettingsBuilder
           $v.fallbackReceiptProcessingSettingsId;
       _receiptProcessingSettingsId = $v.receiptProcessingSettingsId;
       _mobileServerUrl = $v.mobileServerUrl;
+      _refreshTokenValidForHours = $v.refreshTokenValidForHours;
       _currencySymbolPosition = $v.currencySymbolPosition;
       _taskConcurrency = $v.taskConcurrency;
       _emailPollingInterval = $v.emailPollingInterval;
       _numWorkers = $v.numWorkers;
       _enableLocalSignUp = $v.enableLocalSignUp;
+      _mcpRefreshTokenValidForHours = $v.mcpRefreshTokenValidForHours;
       _taskQueueConfigurations = $v.taskQueueConfigurations.toBuilder();
       _id = $v.id;
       _createdAt = $v.createdAt;
@@ -372,11 +397,13 @@ class SystemSettingsBuilder
                 fallbackReceiptProcessingSettingsId,
             receiptProcessingSettingsId: receiptProcessingSettingsId,
             mobileServerUrl: mobileServerUrl,
+            refreshTokenValidForHours: refreshTokenValidForHours,
             currencySymbolPosition: currencySymbolPosition,
             taskConcurrency: taskConcurrency,
             emailPollingInterval: emailPollingInterval,
             numWorkers: numWorkers,
             enableLocalSignUp: enableLocalSignUp,
+            mcpRefreshTokenValidForHours: mcpRefreshTokenValidForHours,
             taskQueueConfigurations: taskQueueConfigurations.build(),
             id: BuiltValueNullFieldError.checkNotNull(
                 id, r'SystemSettings', 'id'),

--- a/mobile/api/lib/src/model/upsert_system_settings_command.dart
+++ b/mobile/api/lib/src/model/upsert_system_settings_command.dart
@@ -33,6 +33,8 @@ part 'upsert_system_settings_command.g.dart';
 /// * [mcpPublicUrl] - Externally reachable origin used for MCP OAuth/metadata/redirect URLs and token audience
 /// * [showLoginQr] - Whether to show the mobile-setup QR code on the desktop login page
 /// * [mobileServerUrl] - Server/API URL mobile clients connect to; encoded into the login QR's deep link
+/// * [refreshTokenValidForHours] - How long a refresh token stays valid, in hours. 0 means unset and falls back to the default of 24.
+/// * [mcpRefreshTokenValidForHours] - How long an MCP/OAuth connector refresh token stays valid, in hours. 0 means unset and falls back to the default of 24.
 @BuiltValue()
 abstract class UpsertSystemSettingsCommand implements Built<UpsertSystemSettingsCommand, UpsertSystemSettingsCommandBuilder> {
   /// Whether local sign up is enabled
@@ -104,6 +106,14 @@ abstract class UpsertSystemSettingsCommand implements Built<UpsertSystemSettings
   /// Server/API URL mobile clients connect to; encoded into the login QR's deep link
   @BuiltValueField(wireName: r'mobileServerUrl')
   String? get mobileServerUrl;
+
+  /// How long a refresh token stays valid, in hours. 0 means unset and falls back to the default of 24.
+  @BuiltValueField(wireName: r'refreshTokenValidForHours')
+  int? get refreshTokenValidForHours;
+
+  /// How long an MCP/OAuth connector refresh token stays valid, in hours. 0 means unset and falls back to the default of 24.
+  @BuiltValueField(wireName: r'mcpRefreshTokenValidForHours')
+  int? get mcpRefreshTokenValidForHours;
 
   UpsertSystemSettingsCommand._();
 
@@ -243,6 +253,20 @@ class _$UpsertSystemSettingsCommandSerializer implements PrimitiveSerializer<Ups
       yield serializers.serialize(
         object.mobileServerUrl,
         specifiedType: const FullType(String),
+      );
+    }
+    if (object.refreshTokenValidForHours != null) {
+      yield r'refreshTokenValidForHours';
+      yield serializers.serialize(
+        object.refreshTokenValidForHours,
+        specifiedType: const FullType(int),
+      );
+    }
+    if (object.mcpRefreshTokenValidForHours != null) {
+      yield r'mcpRefreshTokenValidForHours';
+      yield serializers.serialize(
+        object.mcpRefreshTokenValidForHours,
+        specifiedType: const FullType(int),
       );
     }
   }
@@ -393,6 +417,20 @@ class _$UpsertSystemSettingsCommandSerializer implements PrimitiveSerializer<Ups
             specifiedType: const FullType(String),
           ) as String;
           result.mobileServerUrl = valueDes;
+          break;
+        case r'refreshTokenValidForHours':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType(int),
+          ) as int;
+          result.refreshTokenValidForHours = valueDes;
+          break;
+        case r'mcpRefreshTokenValidForHours':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType(int),
+          ) as int;
+          result.mcpRefreshTokenValidForHours = valueDes;
           break;
         default:
           unhandled.add(key);

--- a/mobile/api/lib/src/model/upsert_system_settings_command.dart
+++ b/mobile/api/lib/src/model/upsert_system_settings_command.dart
@@ -33,8 +33,8 @@ part 'upsert_system_settings_command.g.dart';
 /// * [mcpPublicUrl] - Externally reachable origin used for MCP OAuth/metadata/redirect URLs and token audience
 /// * [showLoginQr] - Whether to show the mobile-setup QR code on the desktop login page
 /// * [mobileServerUrl] - Server/API URL mobile clients connect to; encoded into the login QR's deep link
-/// * [refreshTokenValidForHours] - How long a refresh token stays valid, in hours. 0 means unset and falls back to the default of 24.
-/// * [mcpRefreshTokenValidForHours] - How long an MCP/OAuth connector refresh token stays valid, in hours. 0 means unset and falls back to the default of 24.
+/// * [refreshTokenValidForHours] - How long a refresh token stays valid, in hours. Accepted values are 1-720 (30 days), or 0 meaning unset, which falls back to the default of 24. Omit the key entirely to leave the currently configured value unchanged.
+/// * [mcpRefreshTokenValidForHours] - How long an MCP/OAuth connector refresh token stays valid, in hours. Accepted values are 1-720 (30 days), or 0 meaning unset, which falls back to the default of 24. Omit the key entirely to leave the currently configured value unchanged.
 @BuiltValue()
 abstract class UpsertSystemSettingsCommand implements Built<UpsertSystemSettingsCommand, UpsertSystemSettingsCommandBuilder> {
   /// Whether local sign up is enabled
@@ -107,11 +107,11 @@ abstract class UpsertSystemSettingsCommand implements Built<UpsertSystemSettings
   @BuiltValueField(wireName: r'mobileServerUrl')
   String? get mobileServerUrl;
 
-  /// How long a refresh token stays valid, in hours. 0 means unset and falls back to the default of 24.
+  /// How long a refresh token stays valid, in hours. Accepted values are 1-720 (30 days), or 0 meaning unset, which falls back to the default of 24. Omit the key entirely to leave the currently configured value unchanged.
   @BuiltValueField(wireName: r'refreshTokenValidForHours')
   int? get refreshTokenValidForHours;
 
-  /// How long an MCP/OAuth connector refresh token stays valid, in hours. 0 means unset and falls back to the default of 24.
+  /// How long an MCP/OAuth connector refresh token stays valid, in hours. Accepted values are 1-720 (30 days), or 0 meaning unset, which falls back to the default of 24. Omit the key entirely to leave the currently configured value unchanged.
   @BuiltValueField(wireName: r'mcpRefreshTokenValidForHours')
   int? get mcpRefreshTokenValidForHours;
 

--- a/mobile/api/lib/src/model/upsert_system_settings_command.g.dart
+++ b/mobile/api/lib/src/model/upsert_system_settings_command.g.dart
@@ -43,6 +43,10 @@ class _$UpsertSystemSettingsCommand extends UpsertSystemSettingsCommand {
   final bool? showLoginQr;
   @override
   final String? mobileServerUrl;
+  @override
+  final int? refreshTokenValidForHours;
+  @override
+  final int? mcpRefreshTokenValidForHours;
 
   factory _$UpsertSystemSettingsCommand(
           [void Function(UpsertSystemSettingsCommandBuilder)? updates]) =>
@@ -66,7 +70,9 @@ class _$UpsertSystemSettingsCommand extends UpsertSystemSettingsCommand {
       this.mcpEnabled,
       this.mcpPublicUrl,
       this.showLoginQr,
-      this.mobileServerUrl})
+      this.mobileServerUrl,
+      this.refreshTokenValidForHours,
+      this.mcpRefreshTokenValidForHours})
       : super._();
   @override
   UpsertSystemSettingsCommand rebuild(
@@ -99,7 +105,9 @@ class _$UpsertSystemSettingsCommand extends UpsertSystemSettingsCommand {
         mcpEnabled == other.mcpEnabled &&
         mcpPublicUrl == other.mcpPublicUrl &&
         showLoginQr == other.showLoginQr &&
-        mobileServerUrl == other.mobileServerUrl;
+        mobileServerUrl == other.mobileServerUrl &&
+        refreshTokenValidForHours == other.refreshTokenValidForHours &&
+        mcpRefreshTokenValidForHours == other.mcpRefreshTokenValidForHours;
   }
 
   @override
@@ -123,6 +131,8 @@ class _$UpsertSystemSettingsCommand extends UpsertSystemSettingsCommand {
     _$hash = $jc(_$hash, mcpPublicUrl.hashCode);
     _$hash = $jc(_$hash, showLoginQr.hashCode);
     _$hash = $jc(_$hash, mobileServerUrl.hashCode);
+    _$hash = $jc(_$hash, refreshTokenValidForHours.hashCode);
+    _$hash = $jc(_$hash, mcpRefreshTokenValidForHours.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -148,7 +158,9 @@ class _$UpsertSystemSettingsCommand extends UpsertSystemSettingsCommand {
           ..add('mcpEnabled', mcpEnabled)
           ..add('mcpPublicUrl', mcpPublicUrl)
           ..add('showLoginQr', showLoginQr)
-          ..add('mobileServerUrl', mobileServerUrl))
+          ..add('mobileServerUrl', mobileServerUrl)
+          ..add('refreshTokenValidForHours', refreshTokenValidForHours)
+          ..add('mcpRefreshTokenValidForHours', mcpRefreshTokenValidForHours))
         .toString();
   }
 }
@@ -253,6 +265,16 @@ class UpsertSystemSettingsCommandBuilder
   set mobileServerUrl(String? mobileServerUrl) =>
       _$this._mobileServerUrl = mobileServerUrl;
 
+  int? _refreshTokenValidForHours;
+  int? get refreshTokenValidForHours => _$this._refreshTokenValidForHours;
+  set refreshTokenValidForHours(int? refreshTokenValidForHours) =>
+      _$this._refreshTokenValidForHours = refreshTokenValidForHours;
+
+  int? _mcpRefreshTokenValidForHours;
+  int? get mcpRefreshTokenValidForHours => _$this._mcpRefreshTokenValidForHours;
+  set mcpRefreshTokenValidForHours(int? mcpRefreshTokenValidForHours) =>
+      _$this._mcpRefreshTokenValidForHours = mcpRefreshTokenValidForHours;
+
   UpsertSystemSettingsCommandBuilder() {
     UpsertSystemSettingsCommand._defaults(this);
   }
@@ -279,6 +301,8 @@ class UpsertSystemSettingsCommandBuilder
       _mcpPublicUrl = $v.mcpPublicUrl;
       _showLoginQr = $v.showLoginQr;
       _mobileServerUrl = $v.mobileServerUrl;
+      _refreshTokenValidForHours = $v.refreshTokenValidForHours;
+      _mcpRefreshTokenValidForHours = $v.mcpRefreshTokenValidForHours;
       _$v = null;
     }
     return this;
@@ -336,6 +360,8 @@ class UpsertSystemSettingsCommandBuilder
             mcpPublicUrl: mcpPublicUrl,
             showLoginQr: showLoginQr,
             mobileServerUrl: mobileServerUrl,
+            refreshTokenValidForHours: refreshTokenValidForHours,
+            mcpRefreshTokenValidForHours: mcpRefreshTokenValidForHours,
           );
     } catch (_) {
       late String _$failedField;


### PR DESCRIPTION
## Summary
Adds admin-configurable refresh token lifetimes to System Settings, allowing operators to control how long users stay signed in. Refresh tokens now rotate on every use, making this an inactivity window rather than an absolute session cap. Two separate settings keep app and MCP/OAuth connector tokens independent so a long window for human convenience doesn't extend third-party client tokens.

## Key Changes

**Backend (api/)**
- Added `refreshTokenValidForHours` and `mcpRefreshTokenValidForHours` fields to `SystemSettings` model (1-720 hours, default 24; 0 means unset)
- Implemented `GetRefreshTokenLifetime()` and `GetMcpRefreshTokenLifetime()` in `services/auth.go` with `clampRefreshTokenLifetime()` to enforce bounds and fall back to defaults
- Updated `GenerateJWT()` and `GenerateMcpJWT()` to stamp configured lifetimes into refresh token claims and persisted rows
- Added validation in `UpsertSystemSettingsCommand.Validate()` to enforce 1-720 range (0 allowed for unset)
- Fixed `RevokeRefreshToken` middleware to use atomic read-modify-write for single-use enforcement under concurrent refresh races
- Updated `GetRefreshTokenExpiryDate()` to accept a lifetime parameter instead of hardcoding 24 hours
- Added comprehensive tests in `refresh_token_lifetime_test.go` covering clamping, independence, JWT stamping, and MCP separation

**Frontend (desktop/)**
- Added "Session" form section with "Stay signed in for" input (value + unit selector)
- Added "Connector sign-in lasts" field in MCP Server section for `mcpRefreshTokenValidForHours`
- Implemented `duration.utils.ts` with `splitHours()` (renders whole days as days, keeps sub-day values in hours), `toHours()` (converts back to API format), and `maxForUnit()` (bounds validation)
- Added `durationValueValidator()` to enforce whole numbers, 1+ minimum, and unit-aware maximums
- Form submission folds the value+unit pairs into single `*Hours` fields before sending to API
- Added e2e test in `session-lifetime.spec.ts` verifying admin can set lifetime in days, it persists as hours, and fresh logins get correctly-sized refresh cookies

**Mobile (mobile/api/)**
- Regenerated Dart client models and commands to include new fields

**OpenAPI & Documentation**
- Updated `swagger.yml` with new fields and descriptions
- Updated `api/CLAUDE.md` with session lifetime architecture and inactivity-window semantics
- Updated `desktop/CLAUDE.md` with Hours/Days selector pattern and conversion utilities

## Implementation Details

- **Hours are the wire format; unit is presentation only.** All conversions live in `duration.utils.ts` so both settings cannot drift.
- **Inactivity window, not absolute cap.** Refresh tokens rotate on every use; actively-used sessions renew indefinitely. Lowering the setting takes effect at the next refresh for active sessions.
- **Separate MCP setting by design.** Prevents a long app window from silently extending third-party connector tokens. Tests assert both directions to prevent future collapse.
- **Atomic refresh token consumption.** Concurrent refreshes of the same token now use a single atomic operation to ensure exactly one racer succeeds, fixing a replay-detection gap.
- **Zero means unset.** Clients omitting the field are tolerated (0 → default) rather than rejected, following the `pdfDpi` convention.

https://claude.ai/code/session_013sEsxFDp36cqcqPGt1bw8c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable refresh-token lifetimes for standard sessions and MCP/OAuth connector sessions.
  * Added system settings controls with hours or days units, validation, 24-hour defaults, and a maximum lifetime of 30 days.
  * Access-token expiration remains fixed at 20 minutes.
  * Refresh-token rotation now enforces inactivity expiration.

* **Bug Fixes**
  * Improved refresh-token handling so only one simultaneous refresh attempt can succeed.
  * Preserved existing lifetime settings when update fields are omitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->