### PR TITLE
Let the login password be revealed, as on desktop

### DIFF
--- a/mobile/lib/auth/login/widgets/auth_form.dart
+++ b/mobile/lib/auth/login/widgets/auth_form.dart
@@ -211,6 +211,7 @@ class _Login extends State<AuthForm> {
                 ])),
             textFieldSpacing,
             FormBuilderTextField(
+                key: const ValueKey("password-field"),
                 name: "password",
                 autofillHints: const [AutofillHints.password],
                 obscureText: obscurePassword,

--- a/mobile/lib/auth/login/widgets/auth_form.dart
+++ b/mobile/lib/auth/login/widgets/auth_form.dart
@@ -34,6 +34,11 @@ class _Login extends State<AuthForm> {
   bool isSignUp = false;
   bool isLoading = false;
 
+  /// Whether the password field is masked. Mirrors the desktop auth screen's
+  /// visibility eye (`app-input`'s `showVisibilityEye`), which starts masked and
+  /// stays however the user left it across a submit or a failed validation.
+  bool obscurePassword = true;
+
   Future<void> _submit() async {
     _formKey.currentState!.save();
 
@@ -135,6 +140,12 @@ class _Login extends State<AuthForm> {
         onPressed: () {
           setState(() {
             isSignUp = !isSignUp;
+            // Desktop re-masks here because Login and Sign Up are separate
+            // routes, so the form is destroyed and rebuilt. This form only
+            // flips a flag and keeps what was typed, so without this a
+            // revealed password would stay on screen across a deliberate
+            // switch -- worse than desktop rather than equal to it.
+            obscurePassword = true;
           });
         },
         child: Text(buttonText));
@@ -202,9 +213,27 @@ class _Login extends State<AuthForm> {
             FormBuilderTextField(
                 name: "password",
                 autofillHints: const [AutofillHints.password],
-                obscureText: true,
-                decoration: const InputDecoration(
-                    labelText: "Password", border: OutlineInputBorder()),
+                obscureText: obscurePassword,
+                decoration: InputDecoration(
+                    labelText: "Password",
+                    border: const OutlineInputBorder(),
+                    // The icon names the ACTION, not the state: an open eye
+                    // while masked ("show me"), a crossed-out one while
+                    // revealed ("hide it"). Same polarity as the desktop eye
+                    // and the delete-account dialog.
+                    suffixIcon: IconButton(
+                      key: const ValueKey("password-visibility-toggle"),
+                      icon: Icon(obscurePassword
+                          ? Icons.visibility
+                          : Icons.visibility_off),
+                      tooltip:
+                          obscurePassword ? "Show Password" : "Hide Password",
+                      onPressed: () {
+                        setState(() {
+                          obscurePassword = !obscurePassword;
+                        });
+                      },
+                    )),
                 validator: FormBuilderValidators.compose([
                   FormBuilderValidators.required(),
                 ])),

--- a/mobile/lib/profile/widgets/delete_account_dialog.dart
+++ b/mobile/lib/profile/widgets/delete_account_dialog.dart
@@ -51,6 +51,10 @@ class _DeleteAccountDialogState extends State<_DeleteAccountDialog> {
           const Text('Please enter your password to confirm account deletion.'),
           const SizedBox(height: 16),
           TextField(
+            // Same key the login form's password field uses -- the two never
+            // share a tree, and matching them keeps both password fields
+            // addressable the same way, as their eye toggles already are.
+            key: const ValueKey('password-field'),
             controller: _passwordController,
             obscureText: _obscurePassword,
             decoration: InputDecoration(

--- a/mobile/lib/profile/widgets/delete_account_dialog.dart
+++ b/mobile/lib/profile/widgets/delete_account_dialog.dart
@@ -56,9 +56,11 @@ class _DeleteAccountDialogState extends State<_DeleteAccountDialog> {
             decoration: InputDecoration(
               labelText: 'Password',
               suffixIcon: IconButton(
+                key: const ValueKey('password-visibility-toggle'),
                 icon: Icon(
                   _obscurePassword ? Icons.visibility : Icons.visibility_off,
                 ),
+                tooltip: _obscurePassword ? 'Show Password' : 'Hide Password',
                 onPressed: () {
                   setState(() {
                     _obscurePassword = !_obscurePassword;

--- a/mobile/test/widgets/auth_form_test.dart
+++ b/mobile/test/widgets/auth_form_test.dart
@@ -18,17 +18,23 @@ void main() {
 
   const toggleKey = ValueKey('password-visibility-toggle');
 
-  /// Locates a `FormBuilderTextField` by its `name`.
+  const passwordFieldKey = ValueKey('password-field');
+
+  /// Locates the password field the way the E2E SUITE does -- by type and
+  /// `name`, not by key.
   ///
-  /// Deliberately a local copy of the e2e suite's `formField` helper rather than
-  /// an import: the widget suite is the gating one and must not depend on
-  /// `integration_test/`.
-  Finder formField(String name) => find.byWidgetPredicate(
+  /// Used only by the contract test at the bottom, which exists to prove that
+  /// locator still resolves; asserting it any other way would defeat the point.
+  /// Deliberately a local copy of `integration_test/helpers/form_actions.dart`'s
+  /// `formField` rather than an import: the widget suite is the gating one and
+  /// must not depend on `integration_test/`.
+  Finder e2eFormFieldLocator(String name) => find.byWidgetPredicate(
         (w) => w is FormBuilderTextField && w.name == name,
       );
 
   bool isObscured(WidgetTester tester) =>
-      tester.widget<FormBuilderTextField>(formField('password')).obscureText;
+      tester.widget<FormBuilderTextField>(find.byKey(passwordFieldKey))
+          .obscureText;
 
   setUp(() async {
     // AuthModel.basePath reads GlobalSharedPreferences during build.
@@ -150,6 +156,16 @@ void main() {
     // find.byWidgetPredicate(w is FormBuilderTextField && w.name == 'password').
     // Renaming it, or wrapping it in a way that mounts a second one, takes out
     // the whole integration suite.
-    expect(formField('password'), findsOneWidget);
+    //
+    // This is the one assertion that must NOT go through the key: it is pinning
+    // the e2e locator itself, so it has to use the same shape the e2e uses.
+    expect(e2eFormFieldLocator('password'), findsOneWidget);
+
+    // ...and the keyed field is that same one, so the rest of this file's
+    // key-based assertions are talking about the field e2e drives.
+    expect(
+      tester.widget<FormBuilderTextField>(find.byKey(passwordFieldKey)).name,
+      'password',
+    );
   });
 }

--- a/mobile/test/widgets/auth_form_test.dart
+++ b/mobile/test/widgets/auth_form_test.dart
@@ -1,0 +1,155 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_form_builder/flutter_form_builder.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openapi/openapi.dart' as api;
+import 'package:provider/provider.dart';
+import 'package:receipt_wrangler_mobile/auth/login/widgets/auth_form.dart';
+import 'package:receipt_wrangler_mobile/models/auth_model.dart';
+import 'package:receipt_wrangler_mobile/persistence/global_shared_preferences.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+// The login form's password field can be unmasked with an eye in its trailing
+// slot, mirroring the desktop auth screen (`app-input`'s showVisibilityEye).
+// The icon names the ACTION rather than the state -- an open eye while masked,
+// a crossed-out one while revealed -- which is the polarity desktop uses and
+// the easiest thing to get backwards.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const toggleKey = ValueKey('password-visibility-toggle');
+
+  /// Locates a `FormBuilderTextField` by its `name`.
+  ///
+  /// Deliberately a local copy of the e2e suite's `formField` helper rather than
+  /// an import: the widget suite is the gating one and must not depend on
+  /// `integration_test/`.
+  Finder formField(String name) => find.byWidgetPredicate(
+        (w) => w is FormBuilderTextField && w.name == name,
+      );
+
+  bool isObscured(WidgetTester tester) =>
+      tester.widget<FormBuilderTextField>(formField('password')).obscureText;
+
+  setUp(() async {
+    // AuthModel.basePath reads GlobalSharedPreferences during build.
+    SharedPreferences.setMockInitialValues({});
+    await GlobalSharedPreferences.initialize();
+  });
+
+  Future<void> pumpForm(
+    WidgetTester tester, {
+    bool enableLocalSignUp = false,
+  }) async {
+    final authModel = AuthModel();
+    authModel.setFeatureConfig((api.FeatureConfigBuilder()
+          ..aiPoweredReceipts = false
+          ..enableLocalSignUp = enableLocalSignUp)
+        .build());
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider<AuthModel>.value(
+        value: authModel,
+        child: const MaterialApp(
+          home: Scaffold(
+            body: SingleChildScrollView(child: AuthForm()),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+  }
+
+  Future<void> tapToggle(WidgetTester tester) async {
+    await tester.ensureVisible(find.byKey(toggleKey));
+    await tester.pump();
+    await tester.tap(find.byKey(toggleKey));
+    await tester.pump();
+  }
+
+  testWidgets('the password starts masked, offering to show it',
+      (tester) async {
+    await pumpForm(tester);
+
+    expect(isObscured(tester), isTrue);
+    expect(find.byKey(toggleKey), findsOneWidget);
+    expect(
+      tester.widget<IconButton>(find.byKey(toggleKey)).tooltip,
+      'Show Password',
+    );
+    expect(
+      find.descendant(
+          of: find.byKey(toggleKey), matching: find.byIcon(Icons.visibility)),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('tapping the eye reveals the password and offers to hide it',
+      (tester) async {
+    await pumpForm(tester);
+
+    await tapToggle(tester);
+
+    expect(isObscured(tester), isFalse);
+    expect(
+      tester.widget<IconButton>(find.byKey(toggleKey)).tooltip,
+      'Hide Password',
+    );
+    expect(
+      find.descendant(
+          of: find.byKey(toggleKey),
+          matching: find.byIcon(Icons.visibility_off)),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('tapping it again re-masks', (tester) async {
+    await pumpForm(tester);
+
+    await tapToggle(tester);
+    await tapToggle(tester);
+
+    expect(isObscured(tester), isTrue);
+    expect(
+      tester.widget<IconButton>(find.byKey(toggleKey)).tooltip,
+      'Show Password',
+    );
+  });
+
+  testWidgets('revealing does not submit the form', (tester) async {
+    await pumpForm(tester);
+
+    await tapToggle(tester);
+
+    // A submit would have run the required-validator on the empty fields.
+    expect(find.text('This field cannot be empty.'), findsNothing);
+    expect(isObscured(tester), isFalse);
+  });
+
+  testWidgets('switching to sign up re-masks a revealed password',
+      (tester) async {
+    await pumpForm(tester, enableLocalSignUp: true);
+
+    await tapToggle(tester);
+    expect(isObscured(tester), isFalse);
+
+    // Desktop rebuilds the whole form here (separate routes), so it re-masks.
+    // This form only flips a flag and keeps what was typed.
+    await tester.ensureVisible(find.text('Create an Account').last);
+    await tester.pump();
+    await tester.tap(find.text('Create an Account').last);
+    await tester.pump();
+
+    expect(isObscured(tester), isTrue);
+  });
+
+  testWidgets('the field stays a single FormBuilderTextField named password',
+      (tester) async {
+    await pumpForm(tester);
+
+    // ~30 e2e specs log in via helpers/login.dart, which fills this field with
+    // find.byWidgetPredicate(w is FormBuilderTextField && w.name == 'password').
+    // Renaming it, or wrapping it in a way that mounts a second one, takes out
+    // the whole integration suite.
+    expect(formField('password'), findsOneWidget);
+  });
+}

--- a/mobile/test/widgets/delete_account_dialog_test.dart
+++ b/mobile/test/widgets/delete_account_dialog_test.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:receipt_wrangler_mobile/profile/widgets/delete_account_dialog.dart';
+
+// The delete-account dialog masks its password the same way the login form
+// does, and offers the same eye to reveal it -- the icon names the ACTION (an
+// open eye while masked, crossed-out while revealed), matching the desktop
+// visibility eye. Both of the app's password fields must behave identically,
+// so what auth_form_test asserts about the login field is asserted here too.
+void main() {
+  const toggleKey = ValueKey('password-visibility-toggle');
+
+  /// Opens the dialog through its public entry point -- the widget itself is
+  /// private, so `showDeleteAccountDialog` is the only way in, and it is also
+  /// how the profile screen reaches it.
+  Future<void> pumpDialog(WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) => Scaffold(
+            body: Center(
+              child: ElevatedButton(
+                onPressed: () => showDeleteAccountDialog(context),
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+  }
+
+  bool isObscured(WidgetTester tester) =>
+      tester.widget<TextField>(find.byType(TextField)).obscureText;
+
+  Future<void> tapToggle(WidgetTester tester) async {
+    await tester.tap(find.byKey(toggleKey));
+    await tester.pump();
+  }
+
+  testWidgets('the password starts masked, offering to show it',
+      (tester) async {
+    await pumpDialog(tester);
+
+    expect(isObscured(tester), isTrue);
+    expect(find.byKey(toggleKey), findsOneWidget);
+    expect(
+      tester.widget<IconButton>(find.byKey(toggleKey)).tooltip,
+      'Show Password',
+    );
+    expect(
+      find.descendant(
+          of: find.byKey(toggleKey), matching: find.byIcon(Icons.visibility)),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('tapping the eye reveals the password and offers to hide it',
+      (tester) async {
+    await pumpDialog(tester);
+
+    await tapToggle(tester);
+
+    expect(isObscured(tester), isFalse);
+    expect(
+      tester.widget<IconButton>(find.byKey(toggleKey)).tooltip,
+      'Hide Password',
+    );
+    expect(
+      find.descendant(
+          of: find.byKey(toggleKey),
+          matching: find.byIcon(Icons.visibility_off)),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('tapping it again re-masks', (tester) async {
+    await pumpDialog(tester);
+
+    await tapToggle(tester);
+    await tapToggle(tester);
+
+    expect(isObscured(tester), isTrue);
+    expect(
+      tester.widget<IconButton>(find.byKey(toggleKey)).tooltip,
+      'Show Password',
+    );
+  });
+
+  testWidgets('revealing does not submit the dialog', (tester) async {
+    await pumpDialog(tester);
+
+    await tester.enterText(find.byType(TextField), 'MySecretPass123');
+    await tester.pump();
+
+    await tapToggle(tester);
+
+    // Still open, still holding what was typed -- the eye is not a submit.
+    expect(find.text('Delete Account'), findsWidgets);
+    expect(find.text('MySecretPass123'), findsOneWidget);
+    expect(isObscured(tester), isFalse);
+  });
+}

--- a/mobile/test/widgets/delete_account_dialog_test.dart
+++ b/mobile/test/widgets/delete_account_dialog_test.dart
@@ -9,6 +9,7 @@ import 'package:receipt_wrangler_mobile/profile/widgets/delete_account_dialog.da
 // so what auth_form_test asserts about the login field is asserted here too.
 void main() {
   const toggleKey = ValueKey('password-visibility-toggle');
+  const passwordFieldKey = ValueKey('password-field');
 
   /// Opens the dialog through its public entry point -- the widget itself is
   /// private, so `showDeleteAccountDialog` is the only way in, and it is also
@@ -34,7 +35,7 @@ void main() {
   }
 
   bool isObscured(WidgetTester tester) =>
-      tester.widget<TextField>(find.byType(TextField)).obscureText;
+      tester.widget<TextField>(find.byKey(passwordFieldKey)).obscureText;
 
   Future<void> tapToggle(WidgetTester tester) async {
     await tester.tap(find.byKey(toggleKey));
@@ -93,7 +94,7 @@ void main() {
   testWidgets('revealing does not submit the dialog', (tester) async {
     await pumpDialog(tester);
 
-    await tester.enterText(find.byType(TextField), 'MySecretPass123');
+    await tester.enterText(find.byKey(passwordFieldKey), 'MySecretPass123');
     await tester.pump();
 
     await tapToggle(tester);


### PR DESCRIPTION
## What

The desktop auth screen lets you unmask the password with an eye in the field's trailing slot. Mobile hard-coded `obscureText: true`, so a typo in a password you can't see just fails the login with nothing to look at. This adds the same affordance.

Because the mobile login form is also the sign-up form (one `AuthForm`, an `isSignUp` flag), the single change covers both flows — the same structure desktop has, where one component serves `/auth/login` and `/auth/sign-up`.

## Matching desktop

The desktop eye lives in the shared `app-input` component (`desktop/src/input/input/input.component.html:39-51`), opted into per field with `[showVisibilityEye]="true"`. The details that carried over:

| Aspect | Behaviour |
| --- | --- |
| Icon while **masked** | `visibility` — the open eye |
| Icon while **revealed** | `visibility_off` — crossed out |
| Tooltip | `Show Password` / `Hide Password` |
| Position | Trailing slot, inside the field |
| Styling | None. Desktop's `input.component.scss` is empty and its `visibility-eye-button` class is referenced by no SCSS anywhere — it's stock Material, so this is stock Flutter `IconButton` |
| After submit / failed validation | Stays however the user left it |

The icon polarity is the easy thing to get backwards: it names the **action** ("click to show"), not the state. Desktop does it this way and so did mobile's existing delete-account dialog.

**One accessibility improvement over desktop:** its eye carries a `matTooltip` but no `aria-label`, so a screen reader announces an unnamed button. Flutter's `IconButton(tooltip:)` supplies the semantics label too, so we get this right for free rather than replicating the gap.

## One deliberate divergence in mechanism, to match behaviour

Desktop re-masks when you move between Login and Sign Up — but only as a side effect of those being **separate routes**, so the component is destroyed and rebuilt. This form just flips a bool and keeps what was typed.

Left alone, a revealed password would stay on screen across a deliberate screen switch, which is *worse* than desktop rather than equal to it. So the toggle re-masks explicitly, with a comment saying why (it looks arbitrary otherwise).

## Why the eye is inline, not a shared widget

Desktop centralises because it has **seven** password inputs (login, admin create-user, set-password, dummy-user conversion, delete-account, SMTP password, AI api key). Mobile has **two**, and they sit on different base widgets — `FormBuilderTextField` here vs a controller-driven `TextField` in the delete-account dialog — so a wrapper would straddle both for no real gain. Inline `FormBuilderTextField` is also the dominant convention in this repo; there's no generic text-field wrapper.

It would also have been the one genuinely risky shape here. **~30 e2e specs log in through `integration_test/helpers/login.dart`**, which locates the field with `w is FormBuilderTextField && w.name == 'password'`. Adding a `suffixIcon` to the existing decoration is invisible to that; mounting a second field or renaming it would take out the entire integration suite. A test pins that contract explicitly.

## Also in this PR

The delete-account dialog already had an identical toggle with the right icons, but no tooltip and no key — so it didn't quite match desktop, which tooltips every eye. Two lines bring it to parity, and both of mobile's password fields now behave identically.

## Testing

`test/widgets/auth_form_test.dart` is new — there was no widget test for `AuthForm` at all. Six cases: starts masked, reveals, re-masks, the tooltip flips, the sign-up toggle re-masks, and the `name: "password"` / single-field e2e contract.

**Both new behaviours were mutation-checked**, since tests that pass on the first run are worth distrusting:
- hard-coding `obscureText` back to `true` → **3 of the new tests fail**
- dropping the re-mask line → **exactly the sign-up test fails**

Verification:
- `flutter analyze` clean on the touched files
- `flutter test` — **369 passing** (was 363)
- **Android e2e `smoke_login_test` green**, confirming the field still resolves and `enterText` still works through the real login flow. This was the one that mattered.

Not covered: the visual result on a device is unverified by automation — worth a glance that the eye sits where you'd expect inside the field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added password visibility controls to login and account deletion forms.
  * Added contextual tooltips and icons indicating whether passwords are shown or hidden.
  * Passwords are automatically masked when switching between login and sign-up.

* **Bug Fixes**
  * Improved password visibility consistency across authentication flows and account deletion.

* **Tests**
  * Added coverage for toggling, re-masking, tooltips, form transitions, state preservation, and submission behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->