### PR TITLE
Auto-seed receipt group when user has only one choice

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -281,9 +281,16 @@ choice in. **Client-only** — no backend, swagger or generated-client involveme
   `groupsWithoutAll`) and `GroupModel.soleGroupId` (mobile, off `groupsWithoutAllGroup` — which
   `buildGroupDropDownMenuItems` also sources, so the seed can never be an id the dropdown lacks and
   trip `DropdownButton`'s "exactly one item with value" assert).
-- **Precedence.** Manual form: the receipt's own group → the group being browsed (never "All") →
-  sole group → blank. Quick Scan: `userPreferences.quickScanDefaultGroupId` → sole group → blank.
-  The user's own quick-scan default always wins.
+- **Precedence.** Manual form: the receipt's own group → the group being browsed (never "All", and
+  still resolvable) → sole group → blank. Quick Scan: `userPreferences.quickScanDefaultGroupId` →
+  sole group → blank. The user's own quick-scan default always wins.
+- **On desktop the permission gate follows the seed.** `setReceiptPermissions()` and the
+  `/receipts/add` route guard resolve the same `GroupState.addTargetGroupId`, so a sole-group user is
+  not turned away because the group they happen to be browsing is the synthetic "All" one. Both fall
+  back to the selected group when there is no single add target, which keeps multi-group users
+  exactly as they were.
+- **Desktop's blank seed is `""`, never `0`.** `Validators.required` treats `0` as present, so a `0`
+  sentinel would let a group-less receipt submit. See `desktop/CLAUDE.md`.
 - **A seeded group is a picked group.** It applies that group's default custom fields on the add form
   and, in Quick Scan, its show/require field config — exactly as a manual pick does.
 - **Mobile has to mirror the seed into `_ReceiptForm.groupId` too**, not just the dropdown: paid-by,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -269,6 +269,41 @@ A group can declare custom fields that are **always pre-added** to its receipts,
   `desktop/e2e/group-default-custom-fields.spec.ts` and
   `mobile/integration_test/receipt_default_custom_fields_test.dart`.
 
+### Seeding the Group Field
+
+Both clients pre-select the receipt's group instead of handing the user a picker they have no real
+choice in. **Client-only** — no backend, swagger or generated-client involvement.
+
+- **The rule is "the picker has exactly one option", not "the user has one group".** Every user also
+  carries the synthetic **"All" group** (`Group.isAllGroup`), which the API even sorts *first*, so a
+  single-group user has two entries in state and lands on "All" by default. The count must therefore
+  come from the same filtered set the picker offers: `GroupState.soleGroupId` (desktop, built off
+  `groupsWithoutAll`) and `GroupModel.soleGroupId` (mobile, off `groupsWithoutAllGroup` — which
+  `buildGroupDropDownMenuItems` also sources, so the seed can never be an id the dropdown lacks and
+  trip `DropdownButton`'s "exactly one item with value" assert).
+- **Precedence.** Manual form: the receipt's own group → the group being browsed (never "All") →
+  sole group → blank. Quick Scan: `userPreferences.quickScanDefaultGroupId` → sole group → blank.
+  The user's own quick-scan default always wins.
+- **A seeded group is a picked group.** It applies that group's default custom fields on the add form
+  and, in Quick Scan, its show/require field config — exactly as a manual pick does.
+- **Mobile has to mirror the seed into `_ReceiptForm.groupId` too**, not just the dropdown: paid-by,
+  the category/tag pickers and the add-share button all read that State field and stay dead at `0`.
+  It happens in a post-frame callback because the resolution reads the route
+  (`getFormStateFromContext` / `getGroupId`), which is illegal in `initState`.
+- **The user-preferences "Quick Scan Default Group" control is deliberately left blank** — blank is
+  the encoded "no default", and pre-filling it would silently persist a group the user never chose.
+- **E2e per client**, because both unit suites inject a group list into a mocked store and so prove
+  nothing about the wire: `desktop/e2e/single-group-default.spec.ts` and
+  `mobile/integration_test/receipt_single_group_default_test.dart`. Both **provision their own
+  account** — a freshly created user owns exactly "My Receipts" plus "All" — since the shared e2e
+  accounts accumulate groups as other specs run.
+- **E2e helpers must work with the field already filled.** A desktop single-select autocomplete goes
+  `readonly` once it holds a value, so clicking it never opens the panel; mobile's dropdown opens
+  either way, but "wait for the option text to appear" stops meaning "the menu is up". Both suites'
+  shared pickers were hardened for this (`selectFirstOption`/`clearAutocomplete` in
+  `desktop/e2e/receipts.spec.ts`, `selectDropdown` in
+  `mobile/integration_test/helpers/form_actions.dart`).
+
 ### State Management Patterns
 - **Backend**: Service layer handles business logic, repositories handle data access
 - **Desktop**: NGXS store with actions/selectors, persistent storage for auth/preferences

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -482,6 +482,43 @@ non-editable and saved options expose no delete while an appended one does, the 
 control and its direct `PUT /api/customField/:id` 403s, and a type change 400s even for the holder).
 `e2e/legacy-user-visibility.spec.ts` pins that Legacy User sees neither edit nor delete.
 
+### Seeding the receipt group
+
+The Group field is a default, not a lock: when there is only one group to pick, both the receipt form
+and the Quick Scan dialog pre-select it. See the root `CLAUDE.md` → "Seeding the Group Field" for the
+cross-client contract.
+
+- **`GroupState.soleGroupId`** (`src/store/group.state.ts`) is the shared rule, declared as
+  `@Selector([GroupState.groupsWithoutAll])` so it counts exactly the set `app-group-autocomplete`
+  offers. That selector-array form is new to this repo (everything else uses bare `@Selector()` or
+  `createSelector`) but is correct here: with a non-empty dependency list NGXS does **not** prepend
+  the container state, so the function receives the groups directly.
+- **`receipt-form.component.ts` `initForm()`** falls back to it only when the resolved
+  `selectedGroupId` is falsy — the "All" group branch (`""`) and the no-selection branch
+  (`Number("") === 0`). Keeping the original value otherwise preserves the existing `groupId: 0` seed
+  for multi-group users. No `syncSingleDisplay()` is needed: the seed is written while the parent
+  builds the form, which is *before* the child autocomplete's `ngOnInit` seeds its display from the
+  control (unlike Magic Fill, which patches after init).
+- **`setReceiptPermissions()` is deliberately not changed.** In add mode it gates on
+  `GroupState.selectedGroupId`, which can now differ from the seeded form group. That is fine: the
+  "All" group is a real row with a real Legacy Owner membership, so its permissions are present in
+  AppData. Re-pointing the gate at the form control would regress the multi-group case —
+  `Number.parseInt("")` is `NaN`, `groupPermissions[NaN]` is empty, and the add form would render
+  read-only.
+- **`quick-scan-dialog.component.ts` `fileLoaded()`** puts it *after* the user's
+  `quickScanDefaultGroupId`. `configureImages()` already runs at the end of `fileLoaded`, so the
+  seeded group's show/require config lands on that image with no interaction.
+- **The e2e helpers had to learn the field can already be filled.** A single-select `app-autocomlete`
+  binds `[readonly]="readonly || singleOptionSelected()"`, and Material's `_canOpen()` refuses to open
+  a readonly input — so an unconditional `click()` + pick simply times out. `selectFirstOption`
+  (`e2e/receipts.spec.ts`) now skips a filled field, the empty-form validation case clears it first via
+  `clearAutocomplete` (`data-testid="autocomplete-clear"`), and `quick-scan-dialog.spec.ts` routes its
+  pick through the shared `selectImageGroup`. This matters on a **fresh** database, where
+  `api/dev/seed-e2e-users.sh` leaves `e2e-admin`/`e2e-user` with exactly one group until another spec
+  creates one.
+- **E2e:** `e2e/single-group-default.spec.ts` provisions its own Legacy User (a new account owns only
+  "My Receipts" + "All") and asserts both the receipt form and the Quick Scan dialog arrive pre-filled.
+
 ### Per-group default custom fields
 
 A group can declare custom fields that are pre-added to its receipts, configured in a **Default

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -493,18 +493,33 @@ cross-client contract.
   offers. That selector-array form is new to this repo (everything else uses bare `@Selector()` or
   `createSelector`) but is correct here: with a non-empty dependency list NGXS does **not** prepend
   the container state, so the function receives the groups directly.
-- **`receipt-form.component.ts` `initForm()`** falls back to it only when the resolved
-  `selectedGroupId` is falsy — the "All" group branch (`""`) and the no-selection branch
-  (`Number("") === 0`). Keeping the original value otherwise preserves the existing `groupId: 0` seed
-  for multi-group users. No `syncSingleDisplay()` is needed: the seed is written while the parent
-  builds the form, which is *before* the child autocomplete's `ngOnInit` seeds its display from the
-  control (unlike Magic Fill, which patches after init).
-- **`setReceiptPermissions()` is deliberately not changed.** In add mode it gates on
-  `GroupState.selectedGroupId`, which can now differ from the seeded form group. That is fine: the
-  "All" group is a real row with a real Legacy Owner membership, so its permissions are present in
-  AppData. Re-pointing the gate at the form control would regress the multi-group case —
-  `Number.parseInt("")` is `NaN`, `groupPermissions[NaN]` is empty, and the add form would render
-  read-only.
+- **`GroupState.addTargetGroupId`** is the group a *new* receipt would land in: the selected group,
+  or — when that is the "All" group, unset, or **no longer resolvable** — `soleGroupId`. Because it
+  resolves off `groupsWithoutAll`, all three of those are one lookup miss rather than three checks.
+  `selectedGroupId` is persisted to localStorage and `setAppData` only overwrites a *falsy* one
+  (`app-data.utill.ts`), so it genuinely outlives a group the user has left — that stale case is why
+  the resolution is a lookup rather than a `Number()` coercion.
+- **`receipt-form.component.ts` `initForm()`** seeds `addTargetGroupId ?? ""`. No
+  `syncSingleDisplay()` is needed: the seed is written while the parent builds the form, which is
+  *before* the child autocomplete's `ngOnInit` seeds its display from the control (unlike Magic Fill,
+  which patches after init).
+  - **The blank sentinel must stay `""` — never `0`.** `Validators.required` calls Angular's
+    `isEmptyInputValue`, which counts only `null`/`undefined` and zero-length string/array as empty,
+    so a `0` seed leaves a group-less form **valid** and POSTs `groupId: 0`. `0` is also what
+    `app-autocomlete` filters its options by (`_filter` does `value.toString()`), so the dropdown
+    would silently show only groups whose name contains a zero, while `!!0` still suppresses the
+    clear button the e2e helpers rely on. Pinned by an explicit `form.get("groupId").valid === false`
+    assertion in the spec.
+- **`setReceiptPermissions()` and the `/receipts/add` route guard both gate on
+  `addTargetGroupId ?? Number.parseInt(selectedGroupId)`** — the same group the form seeds. Without
+  this a sole-group user whose *All*-group membership lacks `group.receipts.create` is bounced off
+  `/receipts/add` even though they can create in their real group, which is where login lands them.
+  The `??` tail is load-bearing: a multi-group user on the All dashboard has no add target and must
+  keep gating on the All group, because `Number.parseInt("")` is `NaN` and `groupPermissions[NaN]` is
+  empty — gating on the seed alone would render the add form read-only. The guard opts in per route
+  via `data: { useAddTargetGroupId: true }` (a third mode beside `useRouteGroupId`), so a future
+  route that wants "the group being browsed" keeps that by default; `/receipts/add` is the only
+  consumer of the plain selected-group branch today.
 - **`quick-scan-dialog.component.ts` `fileLoaded()`** puts it *after* the user's
   `quickScanDefaultGroupId`. `configureImages()` already runs at the end of `fileLoaded`, so the
   seeded group's show/require config lands on that image with no interaction.

--- a/desktop/e2e/quick-scan-dialog.spec.ts
+++ b/desktop/e2e/quick-scan-dialog.spec.ts
@@ -6,6 +6,7 @@ import {
   uniqueName,
   withAdminApi,
 } from './helpers/provisioning';
+import { selectImageGroup } from './helpers/quick-scan';
 
 // Verifies the quick-scan DIALOG responds to a group's quick-scan configuration — no scan is sent.
 //
@@ -84,10 +85,10 @@ test.describe('Quick scan dialog field response', () => {
     // Before a configured group is chosen, paid-by shows (the unconfigured default).
     await expect(dialog.getByRole('combobox', { name: 'Paid By' })).toBeVisible();
 
-    // Select the injected-config group.
-    await groupField.click();
-    await groupField.fill(group.name);
-    await page.getByRole('option', { name: group.name, exact: true }).click();
+    // Select the injected-config group. Via the shared helper because the field
+    // may already carry a value (it auto-fills for a single-group user), which
+    // makes the input readonly until its X is clicked.
+    await selectImageGroup(page, dialog, group.name);
 
     // Fields now reflect the injected config: paid-by + tags hidden, status + categories shown.
     await expect(dialog.getByRole('combobox', { name: 'Paid By' })).toHaveCount(0);

--- a/desktop/e2e/receipts.spec.ts
+++ b/desktop/e2e/receipts.spec.ts
@@ -19,9 +19,33 @@ async function openAddReceipt(page: Page) {
   await expect(page.getByLabel('Name')).toBeVisible();
 }
 
+/**
+ * Picks the first option of an `app-autocomlete`, unless the field already holds
+ * a value. The Group field auto-selects when the user belongs to exactly one
+ * group — which `e2e-admin` does on a fresh database, before any spec creates
+ * one — and a single-select autocomplete goes `readonly` once it has a value, so
+ * an unconditional click would never open the option panel (the same hazard
+ * `selectImageGroup` works around in helpers/quick-scan.ts).
+ */
 async function selectFirstOption(page: Page, label: string) {
-  await page.getByLabel(label).click();
+  const field = page.getByLabel(label);
+  if (await field.inputValue()) {
+    return;
+  }
+  await field.click();
   await page.getByRole('option').first().click();
+}
+
+/**
+ * Empties an `app-autocomlete` identified by its host testid, if it holds a
+ * value. A single-select autocomplete renders its X (clear) button only once a
+ * value is selected, so its presence is the check.
+ */
+async function clearAutocomplete(page: Page, hostTestId: string) {
+  const clear = page.getByTestId(hostTestId).getByTestId('autocomplete-clear');
+  if (await clear.count()) {
+    await clear.first().click();
+  }
 }
 
 async function fillBasics(page: Page, name: string, amount = '42.00') {
@@ -274,6 +298,10 @@ test.describe('receipts', () => {
 
     test('empty form submit shows all required-field errors and does not navigate', async ({ page }) => {
       await openAddReceipt(page);
+      // Group auto-fills for a user who belongs to exactly one group (which the
+      // seeded e2e accounts do until another spec creates one), so clear it —
+      // otherwise "empty form" isn't empty and the Group error never renders.
+      await clearAutocomplete(page, 'receipt-group');
       await clickSave(page);
 
       await expect(page).toHaveURL(/\/receipts\/add$/);

--- a/desktop/e2e/single-group-default.spec.ts
+++ b/desktop/e2e/single-group-default.spec.ts
@@ -1,0 +1,120 @@
+import { expect, test } from '@playwright/test';
+import { rmSync } from 'node:fs';
+import { stubTokenRefresh } from './helpers/auth';
+import {
+  apiDeleteUserByName,
+  createUserWithRole,
+  uniqueName,
+  withAdminApi,
+} from './helpers/provisioning';
+import {
+  injectQuickScanAppData,
+  openQuickScanDialog,
+  uploadQuickScanImages,
+} from './helpers/quick-scan';
+
+// A picker with one option is not a choice: when a user belongs to exactly one
+// group, the receipt form and the Quick Scan dialog seed it instead of making
+// them pick it (GroupState.soleGroupId).
+//
+// The seeded e2e accounts accumulate groups as other specs run, so the single-
+// group state has to be provisioned: a freshly created user gets exactly one
+// real group ("My Receipts", api/internal/repositories/users.go) plus the
+// synthetic "All" group, which is never a receipt target. That makes this the
+// real wire — the group list comes from AppData, not from a client-side stub,
+// which is the half the unit tests (mocked store) cannot prove.
+
+const NEW_USER_PASSWORD = `${uniqueName('pw')}-Aa1!`;
+const AUTH_FILE = 'e2e/.auth/single-group-user.json';
+
+test.describe('Single-group users get the Group field pre-filled', () => {
+  test.use({ storageState: AUTH_FILE });
+
+  let username: string;
+  let soleGroupId: number;
+
+  test.beforeAll(async ({ browser }) => {
+    username = uniqueName('single-group-user');
+
+    const admin = await browser.newContext({ storageState: 'e2e/.auth/admin.json' });
+    const adminPage = await admin.newPage();
+    await stubTokenRefresh(adminPage);
+    await createUserWithRole(adminPage, {
+      username,
+      password: NEW_USER_PASSWORD,
+      role: 'Legacy User',
+    });
+    await admin.close();
+
+    // Log in once and persist the session (the describe's AUTH_FILE does not
+    // exist yet, so this context opts out of it).
+    const userContext = await browser.newContext({ storageState: undefined });
+    const userPage = await userContext.newPage();
+    await userPage.goto('/auth/login');
+    await userPage.getByLabel('Username').fill(username);
+    await userPage.getByLabel('Password').fill(NEW_USER_PASSWORD);
+    await userPage.getByRole('button', { name: 'Login' }).click();
+    await expect(userPage).toHaveURL(/\/dashboard\/group\/\d+/, { timeout: 15_000 });
+    await userContext.storageState({ path: AUTH_FILE });
+
+    // The one real group, read back off the wire — login lands on whichever
+    // group the API sorts first, which is the "All" group, so it can't be taken
+    // from the URL.
+    const groups = await userPage.evaluate(async () => {
+      const res = await fetch('/api/group/', { credentials: 'include' });
+      return (await res.json()) as { id: number; name: string; isAllGroup: boolean }[];
+    });
+    const real = groups.filter((g) => !g.isAllGroup);
+    expect(real, 'a freshly created user has exactly one real group').toHaveLength(1);
+    soleGroupId = real[0].id;
+
+    await userContext.close();
+  });
+
+  test.afterAll(async () => {
+    try {
+      await withAdminApi(async (api) => {
+        await apiDeleteUserByName(api, username);
+      });
+    } catch {
+      // Best-effort cleanup — don't mask a test failure with a teardown error.
+    }
+    rmSync(AUTH_FILE, { force: true });
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await stubTokenRefresh(page);
+  });
+
+  test('the manual receipt form opens on the user\'s only group and saves', async ({ page }) => {
+    await page.goto('/receipts/add');
+    await expect(page.getByLabel('Name')).toBeVisible();
+
+    // Pre-filled without a pick — and the group-derived Paid By picker is usable
+    // straight away, which is the point of seeding it.
+    await expect(page.getByTestId('receipt-group').getByRole('combobox')).toHaveValue(
+      'My Receipts',
+    );
+
+    await page.getByLabel('Name').fill(uniqueName('single-group-receipt'));
+    await page.getByLabel('Amount').fill('12.34');
+    await page.getByLabel('Paid By').click();
+    await page.getByRole('option').first().click();
+
+    await page.getByRole('button', { name: 'Save', exact: true }).first().click();
+    await expect(page).toHaveURL(/\/receipts\/\d+\/view/);
+  });
+
+  test('the Quick Scan dialog seeds each image with the only group', async ({ page }) => {
+    // Only the AI flag is injected — the single-group state is genuinely the
+    // provisioned user's, so this exercises the real AppData group list.
+    await injectQuickScanAppData(page, {});
+
+    const dialog = await openQuickScanDialog(page, soleGroupId);
+    await uploadQuickScanImages(dialog, 1);
+
+    await expect(dialog.getByRole('combobox', { name: 'Group' })).toHaveValue(
+      'My Receipts',
+    );
+  });
+});

--- a/desktop/e2e/single-group-default.spec.ts
+++ b/desktop/e2e/single-group-default.spec.ts
@@ -32,6 +32,7 @@ test.describe('Single-group users get the Group field pre-filled', () => {
 
   let username: string;
   let soleGroupId: number;
+  let allGroupId: number;
 
   test.beforeAll(async ({ browser }) => {
     username = uniqueName('single-group-user');
@@ -67,6 +68,7 @@ test.describe('Single-group users get the Group field pre-filled', () => {
     const real = groups.filter((g) => !g.isAllGroup);
     expect(real, 'a freshly created user has exactly one real group').toHaveLength(1);
     soleGroupId = real[0].id;
+    allGroupId = groups.find((g) => g.isAllGroup)!.id;
 
     await userContext.close();
   });
@@ -96,13 +98,21 @@ test.describe('Single-group users get the Group field pre-filled', () => {
       'My Receipts',
     );
 
-    await page.getByLabel('Name').fill(uniqueName('single-group-receipt'));
+    const name = uniqueName('single-group-receipt');
+    await page.getByLabel('Name').fill(name);
     await page.getByLabel('Amount').fill('12.34');
     await page.getByLabel('Paid By').click();
     await page.getByRole('option').first().click();
 
     await page.getByRole('button', { name: 'Save', exact: true }).first().click();
     await expect(page).toHaveURL(/\/receipts\/\d+\/view/);
+
+    // The seed is a real selection, not just a label: the receipt is listed
+    // under the group it was seeded with.
+    await page.goto(`/receipts/group/${soleGroupId}`);
+    await expect(
+      page.getByRole('row').filter({ hasText: name }).first(),
+    ).toBeVisible();
   });
 
   test('the Quick Scan dialog seeds each image with the only group', async ({ page }) => {
@@ -110,7 +120,11 @@ test.describe('Single-group users get the Group field pre-filled', () => {
     // provisioned user's, so this exercises the real AppData group list.
     await injectQuickScanAppData(page, {});
 
-    const dialog = await openQuickScanDialog(page, soleGroupId);
+    // Deliberately opened from the "All" group's receipts list, not the sole
+    // group's: the browsed group and the expected group must differ, or the
+    // assertion below would also pass for an implementation that simply used
+    // whichever group the user happened to be looking at.
+    const dialog = await openQuickScanDialog(page, allGroupId);
     await uploadQuickScanImages(dialog, 1);
 
     await expect(dialog.getByRole('combobox', { name: 'Group' })).toHaveValue(

--- a/desktop/src/guards/group-permission.guard.spec.ts
+++ b/desktop/src/guards/group-permission.guard.spec.ts
@@ -5,7 +5,7 @@ import { NgxsModule, Store } from "@ngxs/store";
 import { AuthState } from "../store/auth.state";
 import { SetPermissions } from "../store/auth.state.actions";
 import { GroupState } from "../store/group.state";
-import { SetSelectedGroupId } from "../store/group.state.actions";
+import { SetGroups, SetSelectedGroupId } from "../store/group.state.actions";
 import { groupPermissionGuard } from "./group-permission.guard";
 
 describe("groupPermissionGuard", () => {
@@ -75,6 +75,57 @@ describe("groupPermissionGuard", () => {
     } as unknown as ActivatedRouteSnapshot;
 
     expect(executeGuard(route, {} as any)).toBe(true);
+  });
+
+  describe("useAddTargetGroupId", () => {
+    const route = {
+      data: {
+        groupPermission: "group.receipts.create",
+        useAddTargetGroupId: true,
+      },
+    } as unknown as ActivatedRouteSnapshot;
+
+    const groups = (...ids: number[]) =>
+      [
+        { id: 1, name: "All Groups", isAllGroup: true, groupMembers: [] },
+        ...ids.map((id) => ({
+          id,
+          name: `Group ${id}`,
+          isAllGroup: false,
+          groupMembers: [],
+        })),
+      ] as any[];
+
+    it("gates on the user's only group while they browse the All group", () => {
+      // Login lands a single-group user on the All group, whose own membership
+      // can lack create while their real group has it. Gating on the browsed
+      // group would bounce them off /receipts/add entirely.
+      store.dispatch(new SetGroups(groups(7)));
+      store.dispatch(new SetSelectedGroupId("1"));
+      store.dispatch(new SetPermissions([], { 7: ["group.receipts.create"] }));
+
+      expect(executeGuard(route, {} as any)).toBe(true);
+      expect(navigateSpy).not.toHaveBeenCalled();
+    });
+
+    it("falls back to the browsed group when there is no single add target", () => {
+      // Multi-group user on the All group: unchanged from the plain behaviour.
+      store.dispatch(new SetGroups(groups(7, 8)));
+      store.dispatch(new SetSelectedGroupId("1"));
+      store.dispatch(new SetPermissions([], { 1: ["group.receipts.create"] }));
+
+      expect(executeGuard(route, {} as any)).toBe(true);
+      expect(navigateSpy).not.toHaveBeenCalled();
+    });
+
+    it("still denies when the add target lacks the permission", () => {
+      store.dispatch(new SetGroups(groups(7)));
+      store.dispatch(new SetSelectedGroupId("1"));
+      store.dispatch(new SetPermissions([], { 1: ["group.receipts.create"] }));
+
+      expect(executeGuard(route, {} as any)).toBe(false);
+      expect(navigateSpy).toHaveBeenCalled();
+    });
   });
 
   it("allows a non-member who holds an orApp fallback permission", () => {

--- a/desktop/src/guards/group-permission.guard.ts
+++ b/desktop/src/guards/group-permission.guard.ts
@@ -10,8 +10,10 @@ import { AuthState, GroupState } from "../store";
  * redirects to the group dashboard.
  *
  * Group id resolution: when `route.data['useRouteGroupId']` is set the id comes
- * from the `:id` route param (own or parent), otherwise from the currently
- * selected group in `GroupState`.
+ * from the `:id` route param (own or parent); when `route.data['useAddTargetGroupId']`
+ * is set it comes from `GroupState.addTargetGroupId` (the group a new record
+ * would be created in, which is not always the one being browsed - see the
+ * selector); otherwise from the currently selected group in `GroupState`.
  */
 export const groupPermissionGuard: CanActivateFn = (route) => {
   const store: Store = inject(Store);
@@ -20,15 +22,23 @@ export const groupPermissionGuard: CanActivateFn = (route) => {
   const permission = route.data["groupPermission"] as string;
   const orApp = (route.data["orAppPermissions"] as string[]) ?? [];
 
+  const selectedGroupId = () =>
+    Number.parseInt(store.selectSnapshot(GroupState.selectedGroupId));
+
   let groupId: number;
   if (route.data["useRouteGroupId"]) {
     groupId = Number.parseInt(
       route?.params?.["id"] ?? route?.parent?.params["id"]
     );
+  } else if (route.data["useAddTargetGroupId"]) {
+    // Gate on the group the record would actually be created in, so a member of
+    // exactly one group is not turned away because the group they happen to be
+    // browsing is the synthetic "All" one. Falls back to the selected group when
+    // there is no single add target, which keeps multi-group users unchanged.
+    groupId =
+      store.selectSnapshot(GroupState.addTargetGroupId) ?? selectedGroupId();
   } else {
-    groupId = Number.parseInt(
-      store.selectSnapshot(GroupState.selectedGroupId)
-    );
+    groupId = selectedGroupId();
   }
 
   if (

--- a/desktop/src/receipts/quick-scan-dialog/quick-scan-dialog.component.spec.ts
+++ b/desktop/src/receipts/quick-scan-dialog/quick-scan-dialog.component.spec.ts
@@ -146,6 +146,59 @@ describe("QuickScanDialogComponent", () => {
     expect(component.images).toEqual([{} as any]);
   });
 
+  it("seeds the user's only group when they have no default group preference", () => {
+    // The All group ships alongside every real group and is never a quick-scan
+    // target, so a single-group user still has two entries in state.
+    store.reset({
+      auth: {},
+      groups: {
+        groups: [
+          { id: 1, name: "All Groups", isAllGroup: true },
+          { id: 7, name: "My Receipts", isAllGroup: false },
+        ],
+        selectedGroupId: "",
+        selectedDashboardId: "",
+      },
+    });
+
+    component.fileLoaded({} as any);
+
+    expect(component.groupIds.value).toEqual([7]);
+  });
+
+  it("prefers the quick-scan default group over the user's only group", () => {
+    store.reset({
+      auth: { userPreferences: { quickScanDefaultGroupId: 3 } },
+      groups: {
+        groups: [{ id: 7, name: "My Receipts", isAllGroup: false }],
+        selectedGroupId: "",
+        selectedDashboardId: "",
+      },
+    });
+
+    component.fileLoaded({} as any);
+
+    expect(component.groupIds.value).toEqual([3]);
+  });
+
+  it("leaves the group blank when the user belongs to more than one", () => {
+    store.reset({
+      auth: {},
+      groups: {
+        groups: [
+          { id: 7, name: "My Receipts", isAllGroup: false },
+          { id: 8, name: "Household", isAllGroup: false },
+        ],
+        selectedGroupId: "",
+        selectedDashboardId: "",
+      },
+    });
+
+    component.fileLoaded({} as any);
+
+    expect(component.groupIds.value).toEqual([""]);
+  });
+
   it("should drive field visibility and required-ness from the selected group's settings", () => {
     const group = {
       id: 2,

--- a/desktop/src/receipts/quick-scan-dialog/quick-scan-dialog.component.ts
+++ b/desktop/src/receipts/quick-scan-dialog/quick-scan-dialog.component.ts
@@ -114,7 +114,15 @@ export class QuickScanDialogComponent implements OnInit {
     // Group is always required; paid-by/status validators are applied per-image by configureImages.
     this.paidByUserIds.push(new FormControl(userPreferences?.quickScanDefaultPaidById ?? ""));
     this.statuses.push(new FormControl(userPreferences?.quickScanDefaultStatus ?? ""));
-    this.groupIds.push(new FormControl(userPreferences?.quickScanDefaultGroupId ?? "", Validators.required));
+    // The user's quick-scan default group wins; failing that, a member of exactly
+    // one group has no choice to make, so seed it. configureImages() below then
+    // applies that group's show/require config exactly as a manual pick would.
+    this.groupIds.push(new FormControl(
+      userPreferences?.quickScanDefaultGroupId
+        ?? this.store.selectSnapshot(GroupState.soleGroupId)
+        ?? "",
+      Validators.required
+    ));
     // Categories/tags are multi-selects backed by app-category/tag-autocomplete,
     // which push selections onto a FormArray (see the receipt form). A plain
     // FormControl has no push(), so selecting one would throw — use a FormArray.

--- a/desktop/src/receipts/receipt-form/receipt-form.component.spec.ts
+++ b/desktop/src/receipts/receipt-form/receipt-form.component.spec.ts
@@ -1047,4 +1047,62 @@ describe("ReceiptFormComponent", () => {
       });
     });
   });
+  describe("group seeding on the add form", () => {
+    let store: Store;
+
+    const group = (id: number, isAllGroup = false): any => ({
+      id,
+      name: `Group ${id}`,
+      isAllGroup,
+      groupMembers: [],
+    });
+
+    const openAddForm = (selectedGroupId: string): void => {
+      store.dispatch(new SetSelectedGroupId(selectedGroupId));
+      routeDataSubject.next({ mode: FormMode.add, customFields: [] });
+    };
+
+    beforeEach(() => {
+      store = TestBed.inject(Store);
+    });
+
+    it("seeds the user's only group when the All group is the active one", () => {
+      // The All group sorts first server-side, so it is what a fresh
+      // single-group user lands on - and it is never a receipt target.
+      store.dispatch(new SetGroups([group(1, true), group(7)]));
+
+      openAddForm("1");
+
+      expect(component.form.value.groupId).toEqual(7);
+    });
+
+    it("leaves the group blank when the user belongs to more than one", () => {
+      store.dispatch(new SetGroups([group(1, true), group(7), group(8)]));
+
+      openAddForm("1");
+
+      expect(component.form.value.groupId).toEqual("");
+    });
+
+    it("keeps the actively selected group over the sole-group fallback", () => {
+      store.dispatch(new SetGroups([group(1, true), group(7)]));
+
+      openAddForm("7");
+
+      expect(component.form.value.groupId).toEqual(7);
+    });
+
+    it("keeps an existing receipt's own group in edit mode", () => {
+      store.dispatch(new SetGroups([group(1, true), group(7)]));
+      store.dispatch(new SetSelectedGroupId("1"));
+
+      routeDataSubject.next({
+        mode: FormMode.edit,
+        customFields: [],
+        receipt: { id: 1, name: "R", amount: "1.00", groupId: 9 } as any,
+      });
+
+      expect(component.form.value.groupId).toEqual(9);
+    });
+  });
 });

--- a/desktop/src/receipts/receipt-form/receipt-form.component.spec.ts
+++ b/desktop/src/receipts/receipt-form/receipt-form.component.spec.ts
@@ -98,7 +98,10 @@ describe("ReceiptFormComponent", () => {
       tags: [],
       date: mockedDate,
       paidByUserId: "",
-      groupId: 0,
+      // "" rather than the 0 this used to seed via Number(""): both read as
+      // blank in the picker, but Validators.required treats 0 as PRESENT, so
+      // the old sentinel left a group-less form valid.
+      groupId: "",
       status: ReceiptStatus.Open,
       customFields: [],
       receiptItems: [],
@@ -1082,6 +1085,59 @@ describe("ReceiptFormComponent", () => {
       openAddForm("1");
 
       expect(component.form.value.groupId).toEqual("");
+      // Not 0: Validators.required treats 0 as present, so a 0 seed would let a
+      // group-less receipt submit.
+      expect(component.form.get("groupId")!.valid).toBe(false);
+    });
+
+    it("seeds the user's only group when the active selection is stale", () => {
+      // selectedGroupId is persisted, so it outlives a group the user has left.
+      // Number("404") is truthy, which used to skip the fallback and seed an id
+      // the picker does not offer.
+      store.dispatch(new SetGroups([group(1, true), group(7)]));
+
+      openAddForm("404");
+
+      expect(component.form.value.groupId).toEqual(7);
+    });
+
+    it("still leaves it blank on a stale selection with several groups", () => {
+      store.dispatch(new SetGroups([group(1, true), group(7), group(8)]));
+
+      openAddForm("404");
+
+      expect(component.form.value.groupId).toEqual("");
+      expect(component.form.get("groupId")!.valid).toBe(false);
+    });
+
+    it("gates add-mode permissions on the seeded group, not the browsed one", () => {
+      // The All group carries its own membership, which can be missing create
+      // while the user's real group has it. The gate must follow the group the
+      // receipt is actually going into.
+      store.dispatch(new SetGroups([group(1, true), group(7)]));
+      store.dispatch(
+        new SetPermissions([], { 7: [Permission.GroupReceiptsCreate] })
+      );
+
+      openAddForm("1");
+
+      expect(component.form.value.groupId).toEqual(7);
+      expect(component.canEditReceipt()).toBe(true);
+    });
+
+    it("keeps gating on the browsed group when there is no single add target", () => {
+      // Multi-group user on the All group: no add target, so the gate must stay
+      // on the All group exactly as before - resolving the blank seed instead
+      // would deny and render the whole form read-only.
+      store.dispatch(new SetGroups([group(1, true), group(7), group(8)]));
+      store.dispatch(
+        new SetPermissions([], { 1: [Permission.GroupReceiptsCreate] })
+      );
+
+      openAddForm("1");
+
+      expect(component.form.value.groupId).toEqual("");
+      expect(component.canEditReceipt()).toBe(true);
     });
 
     it("keeps the actively selected group over the sole-group fallback", () => {

--- a/desktop/src/receipts/receipt-form/receipt-form.component.ts
+++ b/desktop/src/receipts/receipt-form/receipt-form.component.ts
@@ -426,6 +426,16 @@ export class ReceiptFormComponent implements OnInit {
     } else {
       selectedGroupId = Number(selectedGroupId);
     }
+
+    // Nothing resolved (no selection yet, or the "All" group, which is not a
+    // receipt target): a member of exactly one group has no choice to make, so
+    // seed it rather than handing them a picker with a single option. Left as-is
+    // when they belong to several, which keeps the blank/0 seed.
+    if (!selectedGroupId) {
+      selectedGroupId =
+        this.store.selectSnapshot(GroupState.soleGroupId) ?? selectedGroupId;
+    }
+
     this.form = this.formBuilder.group({
       name: [this.originalReceipt?.name ?? "", Validators.required],
       amount: [

--- a/desktop/src/receipts/receipt-form/receipt-form.component.ts
+++ b/desktop/src/receipts/receipt-form/receipt-form.component.ts
@@ -386,12 +386,20 @@ export class ReceiptFormComponent implements OnInit {
   }
 
   private setReceiptPermissions(): void {
-    // In add mode there is no saved receipt yet, so gate against the selected
-    // group (the same group the route guard checked + the form's groupId seed);
-    // otherwise gate against the receipt's own group.
+    // In add mode there is no saved receipt yet, so gate against the add target -
+    // the group the receipt would be created in, which is what initForm seeds and
+    // what the route guard checked; otherwise gate against the receipt's own group.
+    //
+    // The selectedGroupId tail is load-bearing, and is the one case where the gate
+    // and the seed legitimately differ: a multi-group user browsing the "All"
+    // group has no add target, so the form is seeded blank (they must pick) while
+    // the gate stays on the All group, which carries real permissions, exactly as
+    // before. Gating on that blank seed instead would resolve NaN, and
+    // hasGroupPermission would deny - rendering the whole add form read-only.
     const groupId =
       this.mode === FormMode.add
-        ? Number.parseInt(this.store.selectSnapshot(GroupState.selectedGroupId))
+        ? (this.store.selectSnapshot(GroupState.addTargetGroupId) ??
+          Number.parseInt(this.store.selectSnapshot(GroupState.selectedGroupId)))
         : (this.originalReceipt?.groupId ?? 0);
     const editPermission =
       this.mode === FormMode.add
@@ -416,25 +424,17 @@ export class ReceiptFormComponent implements OnInit {
     this.autoAppliedCustomFieldIds.clear();
     this.groupChangeIsInitialEmission = true;
 
-    let selectedGroupId: number | string = this.store.selectSnapshot(
-      GroupState.selectedGroupId
-    );
-    const group = this.store.selectSnapshot(GroupState.getGroupById(selectedGroupId));
-
-    if (group?.isAllGroup) {
-      selectedGroupId = "";
-    } else {
-      selectedGroupId = Number(selectedGroupId);
-    }
-
-    // Nothing resolved (no selection yet, or the "All" group, which is not a
-    // receipt target): a member of exactly one group has no choice to make, so
-    // seed it rather than handing them a picker with a single option. Left as-is
-    // when they belong to several, which keeps the blank/0 seed.
-    if (!selectedGroupId) {
-      selectedGroupId =
-        this.store.selectSnapshot(GroupState.soleGroupId) ?? selectedGroupId;
-    }
+    // The group being browsed, or -- when that is not a receipt target (the "All"
+    // group, nothing selected, or a stale persisted id) -- the user's only group.
+    //
+    // The empty-string fallback is deliberate and must not be "modernised" to 0:
+    // Validators.required calls isEmptyInputValue, which treats 0 as PRESENT
+    // (only null/undefined and zero-length string/array count as empty), so a 0
+    // seed would make a group-less form valid and POST groupId: 0. It is also
+    // the value app-autocomlete filters its option list by, and "0" matches only
+    // groups whose name contains a zero.
+    const addTargetGroupId: number | string =
+      this.store.selectSnapshot(GroupState.addTargetGroupId) ?? "";
 
     this.form = this.formBuilder.group({
       name: [this.originalReceipt?.name ?? "", Validators.required],
@@ -453,7 +453,7 @@ export class ReceiptFormComponent implements OnInit {
         Validators.required,
       ],
       groupId: [
-        this.originalReceipt?.groupId ?? selectedGroupId,
+        this.originalReceipt?.groupId ?? addTargetGroupId,
         Validators.required,
       ],
       status: this.originalReceipt?.status ?? ReceiptStatus.Open,

--- a/desktop/src/receipts/receipts-routing.module.ts
+++ b/desktop/src/receipts/receipts-routing.module.ts
@@ -28,6 +28,11 @@ const routes: Routes = [
     data: {
       mode: FormMode.add,
       groupPermission: Permission.GroupReceiptsCreate,
+      // Gate on the group the receipt would be created in, which is what the
+      // form seeds - not merely the group being browsed. Without this a member
+      // of exactly one group is bounced from /receipts/add whenever they are on
+      // the synthetic "All" group, which is where login lands them.
+      useAddTargetGroupId: true,
     },
     canActivate: [groupPermissionGuard],
   },

--- a/desktop/src/store/group.state.spec.ts
+++ b/desktop/src/store/group.state.spec.ts
@@ -182,3 +182,71 @@ describe("GroupState.soleGroupId", () => {
     expect(store.selectSnapshot(GroupState.soleGroupId)).toBeUndefined();
   });
 });
+
+describe("GroupState.addTargetGroupId", () => {
+  let store: Store;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [NgxsModule.forRoot([GroupState, ReceiptTableState])],
+    }).compileComponents();
+
+    store = TestBed.inject(Store);
+  });
+
+  const allGroup = { id: 1, name: "All Groups", isAllGroup: true };
+
+  function seed(groups: Partial<Group>[], selectedGroupId: string): void {
+    store.reset({
+      groups: {
+        groups: groups as Group[],
+        selectedGroupId,
+        selectedDashboardId: "",
+      },
+    });
+  }
+
+  it("returns the actively selected group when it is a real one", () => {
+    seed([allGroup, { id: 7 }, { id: 8 }], "8");
+
+    expect(store.selectSnapshot(GroupState.addTargetGroupId)).toEqual(8);
+  });
+
+  it("falls back to the only group when the All group is selected", () => {
+    // Where a fresh single-group user lands: the API sorts All first.
+    seed([allGroup, { id: 7 }], "1");
+
+    expect(store.selectSnapshot(GroupState.addTargetGroupId)).toEqual(7);
+  });
+
+  it("falls back to the only group when the selection is stale", () => {
+    // selectedGroupId is persisted, so it outlives a group the user has left.
+    seed([allGroup, { id: 7 }], "404");
+
+    expect(store.selectSnapshot(GroupState.addTargetGroupId)).toEqual(7);
+  });
+
+  it("falls back to the only group when nothing is selected", () => {
+    seed([allGroup, { id: 7 }], "");
+
+    expect(store.selectSnapshot(GroupState.addTargetGroupId)).toEqual(7);
+  });
+
+  it("is undefined on the All group when the user has several groups", () => {
+    seed([allGroup, { id: 7 }, { id: 8 }], "1");
+
+    expect(store.selectSnapshot(GroupState.addTargetGroupId)).toBeUndefined();
+  });
+
+  it("is undefined on a stale selection when the user has several groups", () => {
+    seed([allGroup, { id: 7 }, { id: 8 }], "404");
+
+    expect(store.selectSnapshot(GroupState.addTargetGroupId)).toBeUndefined();
+  });
+
+  it("is undefined when the user has no selectable group at all", () => {
+    seed([allGroup], "1");
+
+    expect(store.selectSnapshot(GroupState.addTargetGroupId)).toBeUndefined();
+  });
+});

--- a/desktop/src/store/group.state.spec.ts
+++ b/desktop/src/store/group.state.spec.ts
@@ -122,3 +122,63 @@ describe("GroupState receipt-filter reset on group change", () => {
     expect(store.selectSnapshot(ReceiptTableState.page)).toEqual(1);
   });
 });
+
+describe("GroupState.soleGroupId", () => {
+  let store: Store;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [NgxsModule.forRoot([GroupState, ReceiptTableState])],
+    }).compileComponents();
+
+    store = TestBed.inject(Store);
+  });
+
+  function seedGroups(groups: Partial<Group>[]): void {
+    store.reset({
+      groups: {
+        groups: groups as Group[],
+        selectedGroupId: "",
+        selectedDashboardId: "",
+      },
+    });
+  }
+
+  it("returns the id when the user belongs to exactly one group", () => {
+    seedGroups([{ id: 7, name: "My Receipts", isAllGroup: false }]);
+
+    expect(store.selectSnapshot(GroupState.soleGroupId)).toEqual(7);
+  });
+
+  it("ignores the synthetic All group when counting", () => {
+    // The All group ships alongside every real group, so a single-group user
+    // still has two entries in state — it must not make the count 2.
+    seedGroups([
+      { id: 1, name: "All Groups", isAllGroup: true },
+      { id: 7, name: "My Receipts", isAllGroup: false },
+    ]);
+
+    expect(store.selectSnapshot(GroupState.soleGroupId)).toEqual(7);
+  });
+
+  it("returns undefined when the user belongs to more than one group", () => {
+    seedGroups([
+      { id: 7, name: "My Receipts", isAllGroup: false },
+      { id: 8, name: "Household", isAllGroup: false },
+    ]);
+
+    expect(store.selectSnapshot(GroupState.soleGroupId)).toBeUndefined();
+  });
+
+  it("returns undefined when only the All group is present", () => {
+    seedGroups([{ id: 1, name: "All Groups", isAllGroup: true }]);
+
+    expect(store.selectSnapshot(GroupState.soleGroupId)).toBeUndefined();
+  });
+
+  it("returns undefined when there are no groups at all", () => {
+    seedGroups([]);
+
+    expect(store.selectSnapshot(GroupState.soleGroupId)).toBeUndefined();
+  });
+});

--- a/desktop/src/store/group.state.ts
+++ b/desktop/src/store/group.state.ts
@@ -49,6 +49,18 @@ export class GroupState {
     return state.groups.filter((g) => !g.isAllGroup);
   }
 
+  /**
+   * The user's only real group, when they belong to exactly one -- a picker with
+   * a single option is not a choice, so the receipt form and quick scan seed it
+   * rather than making the user pick it. Undefined when they have several (or
+   * none): built off `groupsWithoutAll` so the auto-selected set and the set the
+   * pickers offer cannot drift apart.
+   */
+  @Selector([GroupState.groupsWithoutAll])
+  static soleGroupId(groups: Group[]): number | undefined {
+    return groups.length === 1 ? groups[0].id : undefined;
+  }
+
   @Selector()
   static groupsWithoutSelectedGroup(state: GroupStateInterface): Group[] {
     return state.groups.filter(

--- a/desktop/src/store/group.state.ts
+++ b/desktop/src/store/group.state.ts
@@ -61,6 +61,34 @@ export class GroupState {
     return groups.length === 1 ? groups[0].id : undefined;
   }
 
+  /**
+   * The group a new receipt would land in when that is not a choice: the
+   * actively selected group, or -- when that is the synthetic "All" group, or
+   * nothing is selected, or the selection no longer resolves (`selectedGroupId`
+   * is persisted, so it outlives a group the user has left) -- the user's only
+   * group. Undefined when they genuinely have to pick.
+   *
+   * Resolved off `groupsWithoutAll`, so "not a real, still-current group" is a
+   * single lookup miss rather than three separate checks. Callers that must
+   * always name a group (the permission gate, the route guard) fall back to
+   * `selectedGroupId` themselves; the form treats undefined as "leave blank".
+   */
+  @Selector([
+    GroupState.groupsWithoutAll,
+    GroupState.selectedGroupId,
+    GroupState.soleGroupId,
+  ])
+  static addTargetGroupId(
+    selectableGroups: Group[],
+    selectedGroupId: string,
+    soleGroupId: number | undefined
+  ): number | undefined {
+    const selected = selectableGroups.find(
+      (g) => g.id.toString() === selectedGroupId
+    );
+    return selected?.id ?? soleGroupId;
+  }
+
   @Selector()
   static groupsWithoutSelectedGroup(state: GroupStateInterface): Group[] {
     return state.groups.filter(

--- a/mobile/CLAUDE.md
+++ b/mobile/CLAUDE.md
@@ -494,6 +494,50 @@ mounts it, so a raw `shellContext` is **null** and tapping Categories/Tags would
 by `test/widgets/quick_scan_form_test.dart` (tap-opens-picker, shellContext null) and on-device by
 `quick_scan_submit_test.dart`.
 
+### Seeding the receipt group
+
+The Group field is a default, not a lock. The add form seeds it from **the group being browsed**, and
+failing that from **the user's only group**; Quick Scan seeds each picked image from the user's
+`quickScanDefaultGroupId` and, failing that, from their only group. See the root `CLAUDE.md` →
+"Seeding the Group Field" for the cross-client contract.
+
+- **`GroupModel.soleGroupId`** is built off `groupsWithoutAllGroup`, and
+  `buildGroupDropDownMenuItems` (`lib/utils/forms.dart`) now sources that same getter rather than
+  re-filtering `groups` inline. That is not cosmetic: it is what guarantees the seed is always one of
+  the dropdown's items, and `DropdownButton` asserts on an `initialValue` that is not.
+- **`_resolveInitialGroupId()`** (`lib/receipts/widgets/receipt_form.dart`) is the single rule, pure
+  and stable across rebuilds, called from both `buildGroupField()` (for `initialValue`, `0` → `null`)
+  and the `initState` post-frame callback. It **must not** be called from `initState` itself —
+  `getFormStateFromContext` and `getGroupId` both do `GoRouterState.of(context)`, an inherited-widget
+  lookup that is illegal there. That is also why the post-frame callback is now registered
+  **unconditionally**: the resolution can produce a group the receipt does not carry.
+- **Seeding the dropdown is not enough.** Paid-by's item list, the category/tag `Visibility` gates and
+  the add-share "+" all read the `groupId` **State** field, so the callback mirrors the resolved id
+  into it with `setState` — after `_applyGroupDefaultCustomFields`, which writes to `ReceiptModel`
+  and must not fire `notifyListeners()` from inside a `setState` callback. Cost: the group-derived
+  parts render one frame late.
+- **The route group comes from `extra`.** `openManualReceipt` (`lib/shared/functions/receipt_entry.dart`)
+  already put the id there; the form simply discarded it before. The synthetic "All" group is rejected
+  explicitly, mirroring desktop's `initForm`. `getGroupId` now pattern-matches `extra` instead of
+  hard-casting it, since it is reached from a build method on every frame.
+- **`_getInitialQuickScanValues`** (`lib/shared/functions/quick_scan.dart`) tests
+  `quickScanDefaultGroupId > 0` rather than null-coalescing — the generated model **defaults it to
+  `0`**, so "unset" never arrives as null (see "Regenerating API Client Models").
+- **`selectDropdown` had to be hardened** (`integration_test/helpers/form_actions.dart`): its
+  `pumpUntilFound(find.text(option))` wait assumed the option text only appears once the menu is
+  open, which stops holding when the dropdown already *shows* that value -- the wait then returns on
+  the first poll and `.last` can resolve the closed-state child. It now drains the open animation
+  afterwards. (Waiting for the match count to *grow* instead looks tighter but is wrong: the same
+  display name can already be on screen in another dropdown, and `receipt_add_share_test` deadlocks
+  on it.)
+- **Tests.** `test/models/group_model_test.dart` (the rule), `test/widgets/receipt_form_group_prefill_test.dart`
+  (seeding *and* the State-field mirror — asserted through the category field, the add-share button
+  and paid-by's items, since the form value alone would pass without it),
+  `test/shared/functions/quick_scan_initial_values_test.dart` (preference-beats-sole-group). **E2E:**
+  `integration_test/receipt_single_group_default_test.dart` — one case per rule, each on an account
+  chosen so only that rule can explain the seed (`provisionPermUser()` with no role → one group;
+  with `roleName` → two).
+
 ### Group default custom fields
 
 A group can declare custom fields that are pre-added to its receipts

--- a/mobile/integration_test/helpers/form_actions.dart
+++ b/mobile/integration_test/helpers/form_actions.dart
@@ -39,6 +39,13 @@ Future<void> selectDropdown(
   // is empty -- which it briefly is on slow targets (Android emulator) while
   // the dropdown menu is still opening. Wait for any match, then tap .last.
   await pumpUntilFound(tester, find.text(optionText));
+  // That wait is only a lower bound now that fields can arrive pre-selected:
+  // a dropdown already showing this option matches in its CLOSED state, so the
+  // wait can return before the menu is built and `.last` would resolve to the
+  // closed-state child. Draining the open animation closes that race.
+  for (int i = 0; i < 5; i++) {
+    await tester.pump(const Duration(milliseconds: 100));
+  }
   // Long menus (e.g. a groupId dropdown with several fixture groups) can lay
   // the target item out below the menu's viewport. ensureVisible jumps the
   // menu's scroll position but does NOT relayout -- pump a frame so the tap

--- a/mobile/integration_test/helpers/receipt_test_helpers.dart
+++ b/mobile/integration_test/helpers/receipt_test_helpers.dart
@@ -135,6 +135,15 @@ Future<int> addManualReceiptViaUI(
   // Offstage state and the BottomSubmitButton tap silently misses.
   await tester.pumpAndSettle(const Duration(seconds: 3));
 
+  return submitManualReceiptForm(tester);
+}
+
+/// Submits a filled receipt form and returns the new receipt's id.
+///
+/// Split out of [addManualReceiptViaUI] for specs that fill the form
+/// differently -- notably the ones asserting a field was pre-seeded, which must
+/// not touch it.
+Future<int> submitManualReceiptForm(WidgetTester tester) async {
   await tester.tap(find.byType(BottomSubmitButton));
   // Assert /view shell has mounted via the ReceiptEditPopupMenu, which
   // only renders on /view (gated on canEditReceipt -- see

--- a/mobile/integration_test/receipt_single_group_default_test.dart
+++ b/mobile/integration_test/receipt_single_group_default_test.dart
@@ -1,0 +1,111 @@
+// The manual receipt form's Group field, end to end against a real backend.
+//
+// Two seeding rules, isolated from each other by the account each case uses:
+//
+//   1. SOLE GROUP -- a freshly provisioned user (no group role, so no fixture
+//      group is created) owns exactly their personal "My Receipts" plus the
+//      synthetic "All" group. A picker with one option is not a choice, so the
+//      form seeds it. The widget tests inject a GroupModel and so prove nothing
+//      about the wire; here the group list arrives on AppData at login.
+//   2. ROUTE GROUP -- a user with TWO groups, so rule 1 cannot fire. Opening
+//      the form from INSIDE a group must still seed that group (the id
+//      `openManualReceipt` puts on the route's `extra`, which the form used to
+//      discard).
+//
+// Both assert what the closed dropdown renders, with no `selectDropdown` call:
+// the whole point is that no pick was needed.
+
+import 'dart:io' show Platform;
+
+import 'package:flutter_form_builder/flutter_form_builder.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'helpers/api.dart';
+import 'helpers/form_actions.dart';
+import 'helpers/login.dart';
+import 'helpers/nav.dart';
+import 'helpers/permission_fixtures.dart';
+import 'helpers/platform_mocks.dart';
+import 'helpers/receipt_test_helpers.dart';
+
+Finder _groupDropdown() => find.byWidgetPredicate(
+      (w) => w is FormBuilderDropdown && w.name == 'groupId',
+    );
+
+/// Asserts the closed dropdown is showing [groupName] -- i.e. what the user
+/// sees on arriving at the form, before touching anything.
+void _expectGroupShown(String groupName) {
+  expect(
+    find.descendant(of: _groupDropdown(), matching: find.text(groupName)),
+    findsOneWidget,
+  );
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    if (Platform.isLinux) {
+      installLinuxDesktopMocks();
+    }
+  });
+
+  testWidgets(
+      'a user with one group opens the manual form on it, without picking',
+      (tester) async {
+    // No roleName: provisionPermUser only creates a fixture group when a group
+    // role resolves, so this account has exactly one selectable group.
+    final fixture = await provisionPermUser();
+
+    await loginAs(
+      tester,
+      username: fixture.username,
+      password: fixture.password,
+    );
+
+    // Opened from the group-select screen, so no route group is in play -- the
+    // seed can only have come from the sole-group rule.
+    await openManualReceiptForm(tester);
+
+    _expectGroupShown('My Receipts');
+
+    // And it is a real selection, not just a label: the receipt saves without
+    // the Group field ever being touched, and lands in that group.
+    await tester.enterText(formField('name'), 'e2e-sole-group');
+    await tester.enterText(formField('amount'), '9.99');
+    await selectDropdown(tester, 'paidByUserId', fixture.displayName);
+    await tester.pumpAndSettle(const Duration(seconds: 3));
+
+    final receiptId = await submitManualReceiptForm(tester);
+
+    // The user's own token, not the admin's: the admin is not a member of
+    // someone else's personal group, so both the read and the cleanup 403.
+    // Registered after provisionPermUser's user-delete so LIFO runs it first.
+    final jwt = await apiLoginAs(fixture.username, fixture.password);
+    addTearDown(() async => deleteReceipt(receiptId, jwt: jwt));
+
+    final soleGroup = await firstNonAllGroup(jwt);
+    expect(soleGroup.name, 'My Receipts');
+    final receipt = await getReceipt(receiptId, jwt: jwt);
+    expect(receipt['groupId'], soleGroup.id);
+  });
+
+  testWidgets('opening the form from inside a group seeds that group',
+      (tester) async {
+    // Two groups (personal + fixture), so the sole-group rule cannot account
+    // for the seed -- only the route can.
+    final fixture = await provisionPermUser(roleName: 'Legacy Owner');
+
+    await loginAs(
+      tester,
+      username: fixture.username,
+      password: fixture.password,
+    );
+    await enterGroup(tester, fixture.groupName!);
+
+    await openManualReceiptForm(tester);
+
+    _expectGroupShown(fixture.groupName!);
+  });
+}

--- a/mobile/lib/models/group_model.dart
+++ b/mobile/lib/models/group_model.dart
@@ -9,6 +9,16 @@ class GroupModel extends ChangeNotifier {
   List<Group> get groupsWithoutAllGroup =>
       _groups.where((group) => !group.isAllGroup).toList();
 
+  /// The user's only real group, when they belong to exactly one -- a picker with
+  /// a single option is not a choice, so the receipt form and quick scan seed it
+  /// rather than making the user pick it. Null when they have several (or none):
+  /// built off [groupsWithoutAllGroup] so the auto-selected set and the set the
+  /// pickers offer cannot drift apart.
+  int? get soleGroupId {
+    final selectable = groupsWithoutAllGroup;
+    return selectable.length == 1 ? selectable.first.id : null;
+  }
+
   void setGroups(List<Group> groups) {
     _groups = groups;
 

--- a/mobile/lib/receipts/widgets/receipt_form.dart
+++ b/mobile/lib/receipts/widgets/receipt_form.dart
@@ -16,6 +16,7 @@ import 'package:receipt_wrangler_mobile/shared/widgets/tag_select_field.dart';
 import 'package:receipt_wrangler_mobile/utils/bottom_sheet.dart';
 import 'package:receipt_wrangler_mobile/utils/date.dart';
 import 'package:receipt_wrangler_mobile/utils/forms.dart';
+import 'package:receipt_wrangler_mobile/utils/group.dart';
 
 import '../../interfaces/form_item.dart';
 import '../../models/category_model.dart';
@@ -68,20 +69,63 @@ class _ReceiptForm extends State<ReceiptForm> {
 
     groupId = modifiedReceipt.groupId;
 
-    if (groupId > 0) {
-      // Seed the group's defaults on an add form that already knows its group
-      // (opened from inside a group, or prefilled). Deferred to after the first
-      // frame because applying mutates ReceiptModel, and notifying its
-      // listeners while the tree is still building throws -- and because
-      // `formState` reads the route, which needs a mounted element.
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (!mounted || formState != WranglerFormState.add) {
-          return;
-        }
+    // Always scheduled, not just when the receipt already knows its group: on an
+    // add form _resolveInitialGroupId can produce one the receipt does not carry
+    // (the group being browsed, or the user's only group). Deferred to after the
+    // first frame because applying the group's defaults mutates ReceiptModel, and
+    // notifying its listeners while the tree is still building throws -- and
+    // because `formState`/`getGroupId` read the route, which needs a mounted
+    // element.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || formState != WranglerFormState.add) {
+        return;
+      }
 
-        _applyGroupDefaultCustomFields(groupId);
-      });
+      // Mirrors what buildGroupField seeded the dropdown with.
+      final resolvedGroupId = _resolveInitialGroupId();
+      if (resolvedGroupId == 0) {
+        return;
+      }
+
+      // Before the setState below: it writes to ReceiptModel, and
+      // notifyListeners() must not fire from inside a setState callback.
+      _applyGroupDefaultCustomFields(resolvedGroupId);
+
+      if (resolvedGroupId != groupId) {
+        // Carry the seed into the State field the group-derived parts of the
+        // form read -- the paid-by members, the category/tag pickers and the
+        // add-share button all stay dead at 0.
+        setState(() {
+          groupId = resolvedGroupId;
+        });
+      }
+    });
+  }
+
+  /// The group the form starts on: the receipt's own group, else -- on an add
+  /// form -- the group being browsed, else the user's only group. Zero when they
+  /// genuinely have to pick one.
+  ///
+  /// Pure and stable across rebuilds, so the dropdown's `initialValue` and the
+  /// [groupId] State field cannot disagree. Reads the route, so it must not be
+  /// called from `initState`.
+  int _resolveInitialGroupId() {
+    if (modifiedReceipt.groupId > 0) {
+      return modifiedReceipt.groupId;
     }
+    if (formState != WranglerFormState.add) {
+      return 0;
+    }
+
+    // The group the user came from -- `openManualReceipt` puts it on the route's
+    // `extra`. The synthetic "All" group is not a receipt target, so it does not
+    // count (mirrors desktop's initForm).
+    final routeGroup = groupModel.getGroupById(getGroupId(context));
+    if (routeGroup != null && !routeGroup.isAllGroup) {
+      return routeGroup.id;
+    }
+
+    return groupModel.soleGroupId ?? 0;
   }
 
   Widget buildAuditDetailSection() {
@@ -140,10 +184,9 @@ class _ReceiptForm extends State<ReceiptForm> {
   }
 
   Widget buildGroupField() {
-    int? initialValue = modifiedReceipt.groupId;
-    if (formState == WranglerFormState.add && initialValue == 0) {
-      initialValue = null;
-    }
+    // Zero means "the user really does have to pick"; the dropdown wants null.
+    final resolvedGroupId = _resolveInitialGroupId();
+    final int? initialValue = resolvedGroupId == 0 ? null : resolvedGroupId;
 
     return FormBuilderDropdown(
       name: "groupId",

--- a/mobile/lib/shared/functions/quick_scan.dart
+++ b/mobile/lib/shared/functions/quick_scan.dart
@@ -102,8 +102,16 @@ List<QuickScanImage> buildQuickScanImages(
   late final userPreferenceModel =
       Provider.of<UserPreferencesModel>(context, listen: false);
   final userPreferences = userPreferenceModel.userPreferences;
+  // Unset reads as 0, not null -- the generated model defaults it (see
+  // mobile/CLAUDE.md -> "Regenerating API Client Models").
+  final preferredGroupId = userPreferences.quickScanDefaultGroupId ?? 0;
   return (
-    groupId: userPreferences.quickScanDefaultGroupId,
+    // The user's own quick-scan default wins. Without one, a member of exactly
+    // one group has no choice to make, so seed it rather than handing them a
+    // picker with a single option.
+    groupId: preferredGroupId > 0
+        ? preferredGroupId
+        : Provider.of<GroupModel>(context, listen: false).soleGroupId,
     paidByUserId: userPreferences.quickScanDefaultPaidById,
     status: userPreferences.quickScanDefaultStatus,
   );

--- a/mobile/lib/utils/forms.dart
+++ b/mobile/lib/utils/forms.dart
@@ -46,9 +46,12 @@ bool isFieldReadOnly(WranglerFormState formState) {
 }
 
 List<DropdownMenuItem> buildGroupDropDownMenuItems(BuildContext context) {
-  var groups = Provider.of<GroupModel>(context, listen: false).groups;
+  // groupsWithoutAllGroup, not groups: the synthetic "All" group is never a
+  // receipt target, and sharing the getter keeps these options and
+  // GroupModel.soleGroupId describing the same set.
+  var groups = Provider.of<GroupModel>(context, listen: false)
+      .groupsWithoutAllGroup;
   return groups
-      .where((group) => !group.isAllGroup)
       .map((group) => DropdownMenuItem(
             value: group.id,
             child: Text(group.name),

--- a/mobile/lib/utils/group.dart
+++ b/mobile/lib/utils/group.dart
@@ -2,8 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
 String getGroupId(BuildContext context) {
-  var extraMap =
-      (GoRouterState.of(context).extra ?? {}) as Map<dynamic, dynamic>;
+  // `extra` is whatever the caller passed, so pattern-match rather than cast:
+  // this runs from build methods now (the receipt form's group seed), where a
+  // route reached with a non-Map extra would otherwise throw on every frame.
+  final extra = GoRouterState.of(context).extra;
+  final extraMap = extra is Map ? extra : const {};
   return GoRouterState.of(context).pathParameters["groupId"] ??
       extraMap["groupId"] ??
       "0";

--- a/mobile/test/models/group_model_test.dart
+++ b/mobile/test/models/group_model_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:receipt_wrangler_mobile/models/group_model.dart';
+
+import '../helpers/receipt_form_test_helpers.dart';
+
+// GroupModel.soleGroupId backs the "a picker with one option is not a choice"
+// rule in the receipt form and Quick Scan. The load-bearing part is that it
+// counts SELECTABLE groups: every user also carries the synthetic "All" group,
+// which is never a receipt target and must not make the count two.
+void main() {
+  GroupModel modelWith(List<int> ids, {int? allGroupId}) => GroupModel()
+    ..setGroups([
+      if (allGroupId != null)
+        buildGroup(id: allGroupId, name: 'All Groups', isAllGroup: true),
+      for (final id in ids) buildGroup(id: id, name: 'Group $id'),
+    ]);
+
+  test('returns the id when the user belongs to exactly one group', () {
+    expect(modelWith([7]).soleGroupId, 7);
+  });
+
+  test('ignores the synthetic All group when counting', () {
+    expect(modelWith([7], allGroupId: 1).soleGroupId, 7);
+  });
+
+  test('returns null when the user belongs to more than one group', () {
+    expect(modelWith([7, 8], allGroupId: 1).soleGroupId, isNull);
+  });
+
+  test('returns null when only the All group is present', () {
+    expect(modelWith(const [], allGroupId: 1).soleGroupId, isNull);
+  });
+
+  test('returns null when there are no groups at all', () {
+    expect(modelWith(const []).soleGroupId, isNull);
+  });
+}

--- a/mobile/test/shared/functions/quick_scan_initial_values_test.dart
+++ b/mobile/test/shared/functions/quick_scan_initial_values_test.dart
@@ -1,0 +1,122 @@
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openapi/openapi.dart' as api;
+import 'package:provider/provider.dart';
+import 'package:receipt_wrangler_mobile/interfaces/upload_multipart_file_data.dart';
+import 'package:receipt_wrangler_mobile/models/group_model.dart';
+import 'package:receipt_wrangler_mobile/models/user_preferences_model.dart';
+import 'package:receipt_wrangler_mobile/shared/functions/quick_scan.dart';
+
+import '../../helpers/receipt_entry_test_helpers.dart';
+import '../../helpers/receipt_form_test_helpers.dart';
+
+// Every Quick Scan entry point funnels through buildQuickScanImages, so this is
+// where a freshly picked image gets its group. Two rules stack: the user's own
+// quick-scan default group wins, and failing that a member of exactly one group
+// has no choice to make.
+//
+// The 0-vs-null distinction is load-bearing: the generated Dart model DEFAULTS
+// quickScanDefaultGroupId to 0, so "unset" never arrives as null.
+
+const _groupOneId = 1;
+const _groupTwoId = 2;
+const _preferredGroupId = 42;
+
+api.UserPreferences _preferences({int? quickScanDefaultGroupId}) =>
+    (api.UserPreferencesBuilder()
+          ..id = 0
+          ..userId = 0
+          ..createdAt = ''
+          ..quickScanDefaultGroupId = quickScanDefaultGroupId ?? 0)
+        .build();
+
+UploadMultipartFileData _uploadedImage() => UploadMultipartFileData(
+      multipartFile: MultipartFile.fromBytes(quickScanTestPngBytes),
+      bytes: quickScanTestPngBytes,
+    );
+
+/// Seeds the two models [buildQuickScanImages] reads and returns the group id
+/// it stamps on a freshly picked image.
+Future<int?> _seededGroupId(
+  WidgetTester tester, {
+  required List<api.Group> groups,
+  int? quickScanDefaultGroupId,
+}) async {
+  late BuildContext capturedContext;
+
+  await tester.pumpWidget(MultiProvider(
+    providers: [
+      ChangeNotifierProvider<GroupModel>.value(value: groupModelWith(groups)),
+      ChangeNotifierProvider<UserPreferencesModel>.value(
+        value: UserPreferencesModel()
+          ..setUserPreferences(_preferences(
+              quickScanDefaultGroupId: quickScanDefaultGroupId)),
+      ),
+    ],
+    child: MaterialApp(
+      home: Builder(builder: (context) {
+        capturedContext = context;
+        return const SizedBox.shrink();
+      }),
+    ),
+  ));
+
+  return buildQuickScanImages(capturedContext, [_uploadedImage()])
+      .first
+      .groupId;
+}
+
+void main() {
+  testWidgets('seeds the only group when there is no default preference',
+      (tester) async {
+    expect(
+      await _seededGroupId(tester,
+          groups: [buildGroup(id: _groupOneId, name: 'My Receipts')]),
+      _groupOneId,
+    );
+  });
+
+  testWidgets('ignores the synthetic All group when counting', (tester) async {
+    expect(
+      await _seededGroupId(tester, groups: [
+        buildGroup(id: 99, name: 'All Groups', isAllGroup: true),
+        buildGroup(id: _groupOneId, name: 'My Receipts'),
+      ]),
+      _groupOneId,
+    );
+  });
+
+  testWidgets('prefers the quick-scan default group over the only group',
+      (tester) async {
+    expect(
+      await _seededGroupId(
+        tester,
+        groups: [buildGroup(id: _groupOneId, name: 'My Receipts')],
+        quickScanDefaultGroupId: _preferredGroupId,
+      ),
+      _preferredGroupId,
+    );
+  });
+
+  testWidgets('leaves the group unset when the user belongs to more than one',
+      (tester) async {
+    expect(
+      await _seededGroupId(tester, groups: [
+        buildGroup(id: _groupOneId),
+        buildGroup(id: _groupTwoId),
+      ]),
+      isNull,
+    );
+  });
+
+  testWidgets('leaves the group unset when the user has no selectable group',
+      (tester) async {
+    expect(
+      await _seededGroupId(tester, groups: [
+        buildGroup(id: 99, name: 'All Groups', isAllGroup: true),
+      ]),
+      isNull,
+    );
+  });
+}

--- a/mobile/test/widgets/receipt_form_group_prefill_test.dart
+++ b/mobile/test/widgets/receipt_form_group_prefill_test.dart
@@ -1,0 +1,188 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_form_builder/flutter_form_builder.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openapi/openapi.dart' as api;
+import 'package:receipt_wrangler_mobile/enums/form_state.dart';
+import 'package:receipt_wrangler_mobile/shared/widgets/category_select_field.dart';
+import 'package:receipt_wrangler_mobile/utils/receipts.dart';
+
+import '../helpers/receipt_form_test_helpers.dart';
+
+// The add form's Group field is a default, not a lock: a picker with one option
+// is not a choice, so the form seeds it (GroupModel.soleGroupId).
+//
+// The subtle half is that seeding the DROPDOWN is not enough -- the rest of the
+// form reads the `groupId` State field, so paid-by, the category/tag pickers and
+// the add-share button stay dead until the post-frame callback mirrors the seed
+// into it. Those are asserted here rather than the form value alone.
+
+const _memberId = 7;
+const _groupOneId = 1;
+const _groupTwoId = 2;
+const _allGroupId = 99;
+const _fieldId = 31;
+
+final _users = [buildUserView(id: _memberId, displayName: 'Only Member')];
+
+final _customField = buildCustomField(
+  id: _fieldId,
+  name: 'PO Number',
+  type: api.CustomFieldType.TEXT,
+);
+
+api.Group _group(int id, {String? name, List<int>? defaultCustomFieldIds}) =>
+    buildGroup(
+      id: id,
+      name: name ?? 'Group $id',
+      members: [buildGroupMember(userId: _memberId, groupId: id)],
+      defaultCustomFieldIds: defaultCustomFieldIds,
+    );
+
+Finder _dropdown(String name) =>
+    find.byWidgetPredicate((w) => w is FormBuilderDropdown && w.name == name);
+
+dynamic _groupValue(ReceiptFormHarness harness) =>
+    harness.formKey.currentState?.fields['groupId']?.value;
+
+/// The add-share "+" -- disabled while `groupId` is 0, so its enabled-ness is
+/// the observable proof that the State field (not just the form value) was set.
+Finder _addShareButton() => find.ancestor(
+      of: find.byIcon(Icons.add),
+      matching: find.byType(IconButton),
+    );
+
+void _expectNoUiErrors(WidgetTester tester) {
+  expect(tester.takeException(), isNull);
+  expect(find.byType(ErrorWidget), findsNothing);
+}
+
+void main() {
+  testWidgets('seeds the group when the user belongs to exactly one',
+      (tester) async {
+    final harness = await pumpReceiptForm(
+      tester,
+      groups: [_group(_groupOneId, name: 'My Receipts')],
+      users: _users,
+    );
+
+    expect(_groupValue(harness), _groupOneId);
+    _expectNoUiErrors(tester);
+  });
+
+  testWidgets('ignores the synthetic All group when counting', (tester) async {
+    // Every user carries the All group alongside their real ones, so a
+    // single-group user still has two entries in GroupModel.
+    final harness = await pumpReceiptForm(
+      tester,
+      groups: [
+        buildGroup(id: _allGroupId, name: 'All Groups', isAllGroup: true),
+        _group(_groupOneId, name: 'My Receipts'),
+      ],
+      users: _users,
+    );
+
+    expect(_groupValue(harness), _groupOneId);
+    _expectNoUiErrors(tester);
+  });
+
+  testWidgets('unlocks the group-derived fields, not just the form value',
+      (tester) async {
+    await pumpReceiptForm(
+      tester,
+      groups: [_group(_groupOneId)],
+      users: _users,
+    );
+
+    // All three read the `groupId` State field, which only the post-frame
+    // mirror sets -- they would stay hidden/disabled if the dropdown alone
+    // had been seeded.
+    expect(find.byType(CategorySelectField), findsOneWidget);
+    expect(tester.widget<IconButton>(_addShareButton().first).onPressed,
+        isNotNull);
+    expect(
+      tester
+          .widget<FormBuilderDropdown>(_dropdown('paidByUserId'))
+          .items
+          .isNotEmpty,
+      isTrue,
+      reason: 'paid-by is group-scoped and empty at groupId 0',
+    );
+    _expectNoUiErrors(tester);
+  });
+
+  testWidgets('applies the sole group\'s default custom fields on load',
+      (tester) async {
+    final harness = await pumpReceiptForm(
+      tester,
+      groups: [_group(_groupOneId, defaultCustomFieldIds: const [_fieldId])],
+      users: _users,
+      customFields: [_customField],
+    );
+
+    expect(
+      harness.receiptModel.modifiedReceipt.customFields
+          .map((value) => value.customFieldId),
+      [_fieldId],
+      reason: 'a seeded group is a picked group -- its defaults apply',
+    );
+    _expectNoUiErrors(tester);
+  });
+
+  testWidgets('leaves the group blank when the user belongs to more than one',
+      (tester) async {
+    final harness = await pumpReceiptForm(
+      tester,
+      groups: [_group(_groupOneId), _group(_groupTwoId)],
+      users: _users,
+    );
+
+    expect(_groupValue(harness), isNull);
+    expect(find.byType(CategorySelectField), findsNothing);
+    expect(
+        tester.widget<IconButton>(_addShareButton().first).onPressed, isNull);
+    _expectNoUiErrors(tester);
+  });
+
+  testWidgets('keeps an existing receipt\'s own group in edit mode',
+      (tester) async {
+    final harness = await pumpReceiptForm(
+      tester,
+      groups: [
+        _group(_groupOneId),
+        _group(_groupTwoId),
+      ],
+      receipt: getDefaultReceipt().rebuild((b) => b
+        ..id = 5
+        ..groupId = _groupTwoId
+        ..paidByUserId = _memberId),
+      users: _users,
+      formState: WranglerFormState.edit,
+    );
+
+    expect(_groupValue(harness), _groupTwoId);
+    _expectNoUiErrors(tester);
+  });
+
+  testWidgets('does not seed a group in view mode', (tester) async {
+    // View mode always has a saved receipt, so the sole-group rule must not
+    // reach it -- a "view" that invented a group would be a lie.
+    final harness = await pumpReceiptForm(
+      tester,
+      groups: [_group(_groupOneId)],
+      receipt: getDefaultReceipt().rebuild((b) => b
+        ..id = 5
+        ..groupId = _groupOneId
+        ..paidByUserId = _memberId),
+      users: _users,
+      formState: WranglerFormState.view,
+    );
+
+    expect(_groupValue(harness), _groupOneId);
+    expect(
+      harness.receiptModel.modifiedReceipt.customFields,
+      isEmpty,
+      reason: 'view mode never applies group defaults',
+    );
+    _expectNoUiErrors(tester);
+  });
+}


### PR DESCRIPTION
## Summary
Implements automatic group pre-selection across both desktop and mobile clients when a user belongs to exactly one selectable group. A picker with a single option is not a choice, so the receipt form and Quick Scan now seed the group instead of requiring manual selection.

## Key Changes

### Core Logic
- **`GroupState.soleGroupId`** (desktop) and **`GroupModel.soleGroupId`** (mobile): identify when a user has exactly one real group, excluding the synthetic "All" group which is never a receipt target
- **`GroupState.addTargetGroupId`** (desktop): the group a *new* receipt would land in — the selected group, or `soleGroupId` when the selection is the "All" group, unset, or no longer resolvable. The form seeds it, and the permission gate and route guard resolve the same value
- **Seeding rules**: Manual form seeds from (1) the receipt's own group, (2) the group being browsed — when it is a real, still-current one, (3) the user's only group, (4) blank. Quick Scan seeds from (1) `quickScanDefaultGroupId`, (2) the user's only group, (3) blank

### Desktop (Angular)
- `receipt-form.component.ts`: `initForm()` seeds `addTargetGroupId ?? ""`, and `setReceiptPermissions()` gates on `addTargetGroupId ?? selectedGroupId` in add mode
- `group-permission.guard.ts`: new `useAddTargetGroupId` resolution mode (beside `useRouteGroupId`), opted into by `/receipts/add` — without it a sole-group user is bounced off the add form whenever they are on the "All" group, which is where login lands them
- `quick-scan-dialog.component.ts`: seeds each image with the user's quick-scan default or their only group
- Updated e2e helpers and specs to cope with a Group field that can already be filled

### Mobile (Flutter)
- `GroupModel.soleGroupId` filters out the "All" group before counting; `buildGroupDropDownMenuItems()` sources the same list so the seed can never be an id the dropdown lacks
- `_resolveInitialGroupId()` in `receipt_form.dart`: pure, stable resolution from receipt / route / sole group
- A post-frame callback mirrors the resolved group into the `groupId` State field so group-derived UI (paid-by picker, category/tag visibility, add-share button) unlocks — seeding the dropdown alone is not enough
- `buildQuickScanImages()` applies the same precedence as the manual form

### Testing
- **Desktop unit**: `GroupState.soleGroupId` / `addTargetGroupId` specs, receipt-form and quick-scan-dialog component specs, guard specs
- **Mobile widget**: `receipt_form_group_prefill_test.dart`, `quick_scan_initial_values_test.dart`, `group_model_test.dart`
- **E2E**: `desktop/e2e/single-group-default.spec.ts` and `mobile/integration_test/receipt_single_group_default_test.dart`, both against a real backend with freshly provisioned single-group users

## Implementation Details

- **The blank sentinel is `""`, never `0`.** `Validators.required` uses Angular's `isEmptyInputValue`, which counts only `null`/`undefined` and zero-length string/array as empty — a `0` seed leaves a group-less form **valid** and POSTs `groupId: 0`. `0` is also what `app-autocomlete` filters its options by. Pinned by an explicit validity assertion
- **Gate and seed agree.** The `?? selectedGroupId` tail is load-bearing: a multi-group user on the "All" dashboard has no add target and must keep gating on the "All" group, or `Number.parseInt("")` yields `NaN` and the add form renders read-only
- **Stale selections are handled.** `selectedGroupId` is persisted to localStorage and `setAppData` only overwrites a falsy one, so it outlives a group the user has left; resolving off `groupsWithoutAll` turns that into a lookup miss rather than a truthy coercion
- **Mobile State synchronization**: the dropdown's `initialValue` and the `groupId` State field derive from one pure resolver, so they cannot disagree
- **Add mode only**: nothing is seeded in edit or view mode — a saved receipt's own group always wins
- **E2E provisioning**: freshly created users, because the synthetic "All" group is server-generated and the shared e2e accounts accumulate groups as other specs run

https://claude.ai/code/session_01XgHGW9WTgen3um6s47UijF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Receipt forms now preselect the user’s only available group, while preserving explicit selections and leaving the field blank for multiple groups.
  * Quick Scan uses the configured default group or sole available group when applicable.
  * Opening a receipt form from a specific group now preselects that group on mobile.
* **Bug Fixes**
  * Improved group selection synchronization, permission handling, and “All Groups” behavior.
* **Tests**
  * Added desktop and mobile coverage for group preselection, saving receipts, and Quick Scan behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->