### PR TITLE
Add navigation arrows to multi-page scan carousel

### DIFF
--- a/mobile/CLAUDE.md
+++ b/mobile/CLAUDE.md
@@ -411,10 +411,28 @@ backend enforces the two permissions **separately** (`handlers.QuickScan` → `g
   field and hides the submit button, so once the success snackbar fades the sheet would otherwise sit
   there greyed out with nothing saying why. Extraction is an async backend job, so the wording
   promises a result rather than showing one.
-- **The sheet shows a page counter** (`quick-scan-page-indicator`) when a scan carries more than one
-  page. A scan can carry up to 100, and the carousel gives no other hint that the pages after the
-  first exist — without it a multi-page scan reads as a single-page one and the forms behind it go
-  unfilled.
+- **The sheet pages a multi-page scan with arrows as well as the swipe.** Under the image sits a nav
+  row (`lib/receipts/widgets/quick_scan.dart`): a counter (`quick-scan-page-indicator`, `"2 of 3"`)
+  flanked by `quick-scan-previous-page` / `quick-scan-next-page`, which call the carousel
+  controller's `previousItem()` / `nextItem()`. The whole row is absent below two pages. A scan can
+  carry up to 100 pages and the carousel gives no other hint that the ones after the first exist —
+  without this a multi-page scan reads as a single-page one and the forms behind it go unfilled, and
+  the counter alone left that to a line of text ("swipe for the next", now dropped) which is easy to
+  skip past.
+  - **An arrow at the end of the scan is dropped, not disabled**, so every arrow shown leads
+    somewhere. It is replaced by a `SizedBox.square(dimension: kMinInteractiveDimension)` — the
+    `IconButton` default constraint — so the counter stays put instead of sliding as the arrows come
+    and go.
+  - **The row reads the `itemBuilder`'s `realIndex`, not a tracked selection.** The carousel builds
+    only the item on screen, so the page's own index *is* the visible one; deriving from it is what
+    lets the delete icon (which does `images.removeAt(controller.selectedItem)`) shrink the scan
+    without leaving a stale index behind an arrow that points off the end. That is why `QuickScan` is
+    a `StatelessWidget` with no `onIndexChanged`.
+  - Arrows stay live after submit, unlike the upload/delete icons: paging a queued scan is read-only
+    browsing, and the swipe allows it either way.
+  - Covered by `test/widgets/quick_scan_sheet_test.dart` ("the arrows only ever point at a page that
+    exists"). There is **no e2e** for it: `installDocumentScannerMock()` returns a single fixed PNG,
+    so no integration spec can reach a second page.
 - **The sheet re-checks its own gate** and resolves `canCreateManual` **at the caller's context**.
   Its `bottomSheetWidget` is built inside the modal route, which is outside the GoRouter subtree, so
   `GoRouterState.of` throws there — resolve before opening and pass the result down.

--- a/mobile/lib/receipts/widgets/quick_scan.dart
+++ b/mobile/lib/receipts/widgets/quick_scan.dart
@@ -6,7 +6,7 @@ import 'package:receipt_wrangler_mobile/shared/widgets/image_viewer.dart';
 import 'package:receipt_wrangler_mobile/utils/receipts.dart';
 import 'package:rxdart/rxdart.dart';
 
-class QuickScan extends StatefulWidget {
+class QuickScan extends StatelessWidget {
   const QuickScan(
       {super.key,
       required this.imageSubject,
@@ -19,73 +19,109 @@ class QuickScan extends StatefulWidget {
 
   final BehaviorSubject<bool> isCompletedSubject;
 
-  @override
-  State<QuickScan> createState() => _QuickScan();
-}
-
-class _QuickScan extends State<QuickScan> {
-  /// Which page the carousel is showing, so the counter below the preview can
-  /// say so. Tracked here because `InfiniteScrollController.selectedItem` only
-  /// updates the controller -- it doesn't rebuild anything.
-  int _visibleIndex = 0;
-
-  Widget _buildImagePreview(int index) {
-    var image = Image.memory(widget.imageSubject.value[index].bytes);
+  Widget _buildImagePreview(BuildContext context, int index) {
+    var image = Image.memory(imageSubject.value[index].bytes);
     return SizedBox(
         height: getImagePreviewHeight(context),
         width: getImagePreviewWidth(context),
         child: ImageViewer(image: image));
   }
 
-  /// Tells the user there is more than one page and that swiping reaches it.
+  /// An arrow, or the space one would take.
+  ///
+  /// The ends of the scan drop their arrow rather than disabling it, so the
+  /// arrows that remain always lead somewhere. The placeholder keeps the
+  /// counter between them centered instead of letting it slide as the arrows
+  /// come and go -- [kMinInteractiveDimension] is the `IconButton` default
+  /// constraint, so the swap is exactly the same size.
+  Widget _buildNavArrow(
+      {required bool show,
+      required Key key,
+      required IconData icon,
+      required String tooltip,
+      required VoidCallback onPressed}) {
+    if (!show) {
+      return const SizedBox.square(dimension: kMinInteractiveDimension);
+    }
+
+    return IconButton(
+      key: key,
+      icon: Icon(icon),
+      tooltip: tooltip,
+      onPressed: onPressed,
+    );
+  }
+
+  /// Tells the user there is more than one page, and gives them a way to reach
+  /// it that isn't a swipe.
   ///
   /// A scan can carry up to 100 pages, and the carousel gives no other hint
   /// that the pages after the first exist -- so without this a multi-page scan
-  /// looks like a single-page one, and the forms behind it go unfilled.
-  Widget _buildPageIndicator(int pageCount) {
+  /// looks like a single-page one, and the forms behind it go unfilled. The
+  /// swipe alone left that hint to a line of text, which is easy to skip past.
+  ///
+  /// [index] is the page this row belongs to, not the page in view: the
+  /// carousel builds only the item on screen, and taking the index from the
+  /// item rather than tracking the selection means a page can never render an
+  /// arrow that points off the end of a scan an image was just deleted from.
+  Widget _buildPageNav(BuildContext context, int index, int pageCount) {
     if (pageCount < 2) {
       return const SizedBox.shrink();
     }
 
     return Padding(
       padding: const EdgeInsets.only(top: 8),
-      child: Text(
-        key: const ValueKey('quick-scan-page-indicator'),
-        '${_visibleIndex + 1} of $pageCount \u00b7 swipe for the next',
-        style: Theme.of(context).textTheme.bodySmall,
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          _buildNavArrow(
+            show: index > 0,
+            key: const ValueKey('quick-scan-previous-page'),
+            icon: Icons.chevron_left,
+            tooltip: 'Previous page',
+            onPressed: () => infiniteScrollController.previousItem(),
+          ),
+          Text(
+            key: const ValueKey('quick-scan-page-indicator'),
+            '${index + 1} of $pageCount',
+            style: Theme.of(context).textTheme.bodySmall,
+          ),
+          _buildNavArrow(
+            show: index < pageCount - 1,
+            key: const ValueKey('quick-scan-next-page'),
+            icon: Icons.chevron_right,
+            tooltip: 'Next page',
+            onPressed: () => infiniteScrollController.nextItem(),
+          ),
+        ],
       ),
     );
   }
 
-  Widget _buildCarousel(bool isCompleted) {
+  Widget _buildCarousel(BuildContext context, bool isCompleted) {
     return InfiniteCarousel.builder(
-      itemCount: widget.imageSubject.value.length,
+      itemCount: imageSubject.value.length,
       itemExtent: MediaQuery.of(context).size.width,
       center: false,
       velocityFactor: 0.2,
-      onIndexChanged: (index) {
-        if (mounted && index != _visibleIndex) {
-          setState(() => _visibleIndex = index);
-        }
-      },
-      controller: widget.infiniteScrollController,
+      controller: infiniteScrollController,
       axisDirection: Axis.horizontal,
       loop: false,
       itemBuilder: (BuildContext context, int itemIndex, int realIndex) {
         return SingleChildScrollView(
           child: Column(
             children: [
-              _buildImagePreview(realIndex),
-              _buildPageIndicator(widget.imageSubject.value.length),
+              _buildImagePreview(context, realIndex),
+              _buildPageNav(context, realIndex, imageSubject.value.length),
               Padding(
                 padding: getImageDataPadding(),
                 child: QuickScanForm(
-                  formKey: widget.imageSubject.value[realIndex].formKey,
-                  image: widget.imageSubject.value[realIndex],
+                  formKey: imageSubject.value[realIndex].formKey,
+                  image: imageSubject.value[realIndex],
                   index: realIndex,
                   enabled: !isCompleted,
                   onFormChangeCallback: (values) {
-                    var newImage = widget.imageSubject.value[realIndex];
+                    var newImage = imageSubject.value[realIndex];
                     newImage.groupId = values.groupId;
                     newImage.paidByUserId = values.paidByUserId;
                     newImage.status = values.status;
@@ -93,10 +129,10 @@ class _QuickScan extends State<QuickScan> {
                     newImage.tags = values.tags;
                     newImage.comment = values.comment;
 
-                    var newImages = widget.imageSubject.value;
+                    var newImages = imageSubject.value;
 
                     newImages[realIndex] = newImage;
-                    widget.imageSubject.add(newImages);
+                    imageSubject.add(newImages);
                   },
                 ),
               )
@@ -110,12 +146,12 @@ class _QuickScan extends State<QuickScan> {
   @override
   Widget build(BuildContext context) {
     return StreamBuilder<bool>(
-        stream: widget.isCompletedSubject.stream,
+        stream: isCompletedSubject.stream,
         builder: (context, completedSnapshot) {
           final isCompleted = completedSnapshot.hasData && completedSnapshot.data == true;
 
           return StreamBuilder<List<QuickScanImage>>(
-              stream: widget.imageSubject.stream,
+              stream: imageSubject.stream,
               builder: (context, imageSnapshot) {
                 if (imageSnapshot.hasData && imageSnapshot.data!.isEmpty) {
                   return const Center(
@@ -127,7 +163,7 @@ class _QuickScan extends State<QuickScan> {
                   return SizedBox(
                     height: MediaQuery.of(context).size.height,
                     width: MediaQuery.of(context).size.width,
-                    child: _buildCarousel(isCompleted),
+                    child: _buildCarousel(context, isCompleted),
                   );
                 }
 

--- a/mobile/test/widgets/quick_scan_sheet_test.dart
+++ b/mobile/test/widgets/quick_scan_sheet_test.dart
@@ -21,6 +21,8 @@ void main() {
   const create = api.Permission.groupPeriodReceiptsPeriodCreate;
   const manualLinkKey = ValueKey('quick-scan-manual-entry-link');
   const pageIndicatorKey = ValueKey('quick-scan-page-indicator');
+  const previousPageKey = ValueKey('quick-scan-previous-page');
+  const nextPageKey = ValueKey('quick-scan-next-page');
 
   late BuildContext capturedContext;
 
@@ -64,11 +66,12 @@ void main() {
   /// [pumpSheet] can never reach a loaded state -- it can only prove the counter
   /// is absent. Mounting [QuickScan] directly is what lets the counter be
   /// asserted present, which is the whole point of keying it.
-  Future<void> pumpCarousel(
+  Future<InfiniteScrollController> pumpCarousel(
     WidgetTester tester, {
     required int pageCount,
   }) async {
     final images = List.generate(pageCount, (_) => buildQuickScanImage(groupId: 5));
+    final controller = InfiniteScrollController();
 
     final router = GoRouter(
       initialLocation: '/',
@@ -78,7 +81,7 @@ void main() {
           builder: (context, state) => Scaffold(
             body: QuickScan(
               imageSubject: BehaviorSubject.seeded(images),
-              infiniteScrollController: InfiniteScrollController(),
+              infiniteScrollController: controller,
               isCompletedSubject: BehaviorSubject.seeded(false),
             ),
           ),
@@ -93,6 +96,8 @@ void main() {
       groups: [buildGroup(id: 5, name: 'Household')],
     ));
     await tester.pump();
+
+    return controller;
   }
 
   testWidgets('opens for a user who holds the quick-scan permission',
@@ -146,20 +151,57 @@ void main() {
     expect(find.text(quickScanQueuedMessage), findsNothing);
   });
 
-  testWidgets('a single-page scan gets no page counter', (tester) async {
+  testWidgets('a single-page scan gets no page counter and no arrows',
+      (tester) async {
     await pumpCarousel(tester, pageCount: 1);
 
     expect(find.byKey(pageIndicatorKey), findsNothing,
-        reason: 'nothing to swipe to');
+        reason: 'nothing to page to');
+    expect(find.byKey(previousPageKey), findsNothing);
+    expect(find.byKey(nextPageKey), findsNothing);
   });
 
   testWidgets('a multi-page scan counts its pages', (tester) async {
     await pumpCarousel(tester, pageCount: 3);
 
     expect(find.byKey(pageIndicatorKey), findsOneWidget);
-    expect(find.text('1 of 3 · swipe for the next'), findsOneWidget,
+    expect(find.text('1 of 3'), findsOneWidget,
         reason: 'a scan carries up to 100 pages and the carousel gives no '
             'other hint the later ones exist');
+  });
+
+  testWidgets('the arrows only ever point at a page that exists',
+      (tester) async {
+    final controller = await pumpCarousel(tester, pageCount: 3);
+
+    expect(find.byKey(previousPageKey), findsNothing,
+        reason: 'the first page has nothing behind it');
+    expect(find.byKey(nextPageKey), findsOneWidget);
+
+    await tester.tap(find.byKey(nextPageKey));
+    await tester.pumpAndSettle();
+
+    expect(controller.selectedItem, 1);
+    expect(find.text('2 of 3'), findsOneWidget);
+    expect(find.byKey(previousPageKey), findsOneWidget,
+        reason: 'a middle page can go either way');
+    expect(find.byKey(nextPageKey), findsOneWidget);
+
+    await tester.tap(find.byKey(nextPageKey));
+    await tester.pumpAndSettle();
+
+    expect(controller.selectedItem, 2);
+    expect(find.text('3 of 3'), findsOneWidget);
+    expect(find.byKey(nextPageKey), findsNothing,
+        reason: 'the last page has nothing ahead of it');
+
+    await tester.tap(find.byKey(previousPageKey));
+    await tester.pumpAndSettle();
+
+    expect(controller.selectedItem, 1,
+        reason: 'the arrows are the swipe, not a separate notion of where the '
+            'user is');
+    expect(find.text('2 of 3'), findsOneWidget);
   });
 
   testWidgets('the manual link closes the sheet and opens the form',


### PR DESCRIPTION
## Summary
Converts `QuickScan` from a `StatefulWidget` to a `StatelessWidget` and adds explicit navigation arrows to the multi-page scan carousel, complementing the existing swipe gesture. The page counter now displays alongside previous/next buttons that conditionally appear based on the current page position.

## Key Changes

- **Refactored `QuickScan` to `StatelessWidget`**: Removed the `_QuickScan` state class and `_visibleIndex` tracking. The carousel now derives the visible page from the `itemBuilder`'s `realIndex` parameter, eliminating stale state when images are deleted.

- **Added navigation arrow UI**: New `_buildNavArrow()` helper renders `IconButton` widgets for previous/next page navigation, or a `SizedBox` placeholder when at the scan boundaries. This keeps the page counter centered as arrows appear and disappear.

- **Replaced page indicator text**: Changed from `"1 of 3 · swipe for the next"` to a row layout with `"1 of 3"` flanked by navigation arrows. The text-only hint was easy to skip; explicit buttons make multi-page scans more discoverable.

- **Renamed `_buildPageIndicator()` to `_buildPageNav()`**: Now returns a full navigation row instead of just text, and accepts the current `index` parameter to determine arrow visibility.

- **Removed `onIndexChanged` callback**: No longer needed since page tracking comes from the carousel's item index rather than state.

- **Updated tests**: Added test cases for arrow visibility at scan boundaries and verified navigation works correctly across pages. Test helper `pumpCarousel()` now returns the controller for assertions.

## Implementation Details

- Arrows are conditionally hidden (replaced by equal-sized placeholders) at the first and last pages, ensuring every visible arrow points to an existing page.
- The row reads `realIndex` from the carousel's `itemBuilder`, not a tracked selection—this prevents stale indices when the delete icon removes images.
- Arrows remain interactive after form submission (unlike upload/delete icons), allowing read-only browsing of queued scans.
- Updated `CLAUDE.md` with detailed rationale for the design decisions and test coverage notes.

https://claude.ai/code/session_01KZzaKAtAki8Azx3gZnnxLD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-page navigation to Quick Scan with previous and next arrows.
  * Added a centered page counter for multi-page scans.
  * Arrows and page indicators are hidden when only one page is available.
  * Navigation updates correctly after submitting scans.

* **Tests**
  * Expanded coverage for page counts, navigation controls, and first, middle, and last pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->