### PR TITLE
Add DECLINED receipt status with distinct visual treatment

### DIFF
--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -1233,6 +1233,45 @@ See `mobile/CLAUDE.md` → "App Links / Universal Links — server-URL pre-fill 
 `commands/upsert_system_settings_command_test.go` (validation), `services/system_settings_test.go`
 (`BuildLoginQrUrl` compose/encoding + `GetFeatureConfig` mapping).
 
+## Receipt statuses
+
+`models.ReceiptStatus` (`internal/models/receipt_status.go`) is a plain Go `string` type — there is
+no DB enum or CHECK constraint anywhere, so **adding a value needs no migration**, only these four
+edits, which nothing forces to agree with each other:
+
+1. the `const` block,
+2. the `Value()` guard chain (a missing value makes every write fail as a generic 500),
+3. `ReceiptStatuses()` — the single membership list, which drives the only two server-side
+   validations of a caller-supplied status: `handlers/receipts.go` `BulkReceiptStatusUpdate` and
+   `commands/update_group_receipt_settings_command.go` `isValidReceiptStatus`,
+4. the `ReceiptStatus` enum in `swagger.yml` — then regenerate **both** clients, `mobile/api/`
+   included, in the same change (see "API Client Generation").
+
+`models/receipt_status_test.go` → `TestReceiptStatuses` asserts the exact list **and order**, so it
+fails by design on any addition. Update it rather than weakening it.
+
+**`AfterReceiptUpdated` (`repositories/receipts.go`) is the only transition logic** — there is no
+state machine, any status may follow any other, and all three write paths reach it (`UpdateReceipt`,
+`CreateReceipt`, and the bulk handler). Two statuses are **terminal** and cascade the receipt's items
+to `ITEM_RESOLVED`:
+
+- **`RESOLVED`** also stamps `resolved_date`.
+- **`DECLINED`** deliberately does **not** — a decline is not a resolution, and `resolved_date` is a
+  reporting dimension (`receiptsource.KeyResolvedDate` plus its derived day/month/year fields) and a
+  sortable/filterable column. It falls into the existing `Status != RESOLVED` branch, which clears
+  `resolved_date`.
+
+The cascade is what removes a terminal receipt from settlement: `handlers/users.go`
+`GetAmountOwedForUser` filters on **`ITEM_OPEN`**, i.e. the *item* status, never the receipt's. A new
+status that should not count as owed therefore has to be added to that cascade, not just the enum.
+`OPEN` and `NEEDS_ATTENTION` have no cascade and leave items alone.
+
+**Two validation gaps to know about** (both pre-existing): `UpsertReceiptCommand.Validate` and
+`UpdateGroupSettingsCommand.Validate` check a status is **non-empty**, never that it is a member — an
+arbitrary string reaches the DB layer and is caught only by `Value()`, surfacing as a 500. And
+`ReceiptStatus.Scan` never returns an error, so `QuickScanCommand.LoadDataFromRequest` cannot reject
+a bogus status either.
+
 ## Quick Scan Field Configuration
 
 Group admins configure the quick-scan workflow per group on `GroupReceiptSettings` (gated by the

--- a/api/dev/seed-reporting-data.mjs
+++ b/api/dev/seed-reporting-data.mjs
@@ -172,8 +172,8 @@ const TAG_NAMES = [
 
 const MEMBER_NAMES = ["Jordan Rivera", "Casey Morgan", "Taylor Brooks", "Riley Chen", "Avery Patel", "Sam Okafor"];
 
-const STATUSES = ["RESOLVED", "OPEN", "NEEDS_ATTENTION", "DRAFT"];
-const STATUS_WEIGHTS = [0.65, 0.2, 0.1, 0.05];
+const STATUSES = ["RESOLVED", "OPEN", "NEEDS_ATTENTION", "DRAFT", "DECLINED"];
+const STATUS_WEIGHTS = [0.6, 0.2, 0.1, 0.05, 0.05];
 const TAG_COUNT_WEIGHTS = [0.2, 0.4, 0.3, 0.1]; // 0, 1, 2, or 3 tags
 
 // ---------- seed ----------

--- a/api/internal/models/receipt_status.go
+++ b/api/internal/models/receipt_status.go
@@ -12,6 +12,7 @@ const (
 	NEEDS_ATTENTION ReceiptStatus = "NEEDS_ATTENTION"
 	RESOLVED        ReceiptStatus = "RESOLVED"
 	DRAFT           ReceiptStatus = "DRAFT"
+	DECLINED        ReceiptStatus = "DECLINED"
 )
 
 func (self *ReceiptStatus) Scan(value string) error {
@@ -20,12 +21,12 @@ func (self *ReceiptStatus) Scan(value string) error {
 }
 
 func (self ReceiptStatus) Value() (driver.Value, error) {
-	if self != OPEN && self != NEEDS_ATTENTION && self != RESOLVED && self != DRAFT && self != "" {
+	if self != OPEN && self != NEEDS_ATTENTION && self != RESOLVED && self != DRAFT && self != DECLINED && self != "" {
 		return nil, errors.New("invalid receiptStatus")
 	}
 	return string(self), nil
 }
 
 func ReceiptStatuses() []interface{} {
-	return []interface{}{OPEN, NEEDS_ATTENTION, RESOLVED, DRAFT}
+	return []interface{}{OPEN, NEEDS_ATTENTION, RESOLVED, DRAFT, DECLINED}
 }

--- a/api/internal/models/receipt_status_test.go
+++ b/api/internal/models/receipt_status_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestReceiptStatus_Value(t *testing.T) {
-	valid := []ReceiptStatus{OPEN, NEEDS_ATTENTION, RESOLVED, DRAFT}
+	valid := []ReceiptStatus{OPEN, NEEDS_ATTENTION, RESOLVED, DRAFT, DECLINED}
 	for _, v := range valid {
 		assertValuerValid(t, string(v), v, string(v))
 	}
@@ -33,7 +33,7 @@ func TestReceiptStatus_Scan(t *testing.T) {
 func TestReceiptStatuses(t *testing.T) {
 	statuses := ReceiptStatuses()
 
-	expected := []interface{}{OPEN, NEEDS_ATTENTION, RESOLVED, DRAFT}
+	expected := []interface{}{OPEN, NEEDS_ATTENTION, RESOLVED, DRAFT, DECLINED}
 	if len(statuses) != len(expected) {
 		utils.PrintTestError(t, len(statuses), len(expected))
 	}

--- a/api/internal/repositories/receipts.go
+++ b/api/internal/repositories/receipts.go
@@ -286,7 +286,10 @@ func (repository ReceiptRepository) AfterReceiptUpdated(updatedReceipt *models.R
 		return err
 	}
 
-	if updatedReceipt.Status == models.RESOLVED && updatedReceipt.ID > 0 {
+	// RESOLVED and DECLINED are both terminal: the receipt is done being argued about, so its
+	// items are settled and stop counting toward what members owe each other. Only RESOLVED
+	// stamps resolved_date above — a decline is not a resolution, and reports expose that column.
+	if (updatedReceipt.Status == models.RESOLVED || updatedReceipt.Status == models.DECLINED) && updatedReceipt.ID > 0 {
 		err := repository.UpdateItemsToStatus(updatedReceipt, models.ITEM_RESOLVED)
 		if err != nil {
 			return err

--- a/api/internal/repositories/receipts_test.go
+++ b/api/internal/repositories/receipts_test.go
@@ -1622,3 +1622,53 @@ func TestShouldCleanupJunctionTablesForOrphanedItems(t *testing.T) {
 		utils.PrintTestError(t, totalJunctionEntries, 0)
 	}
 }
+
+// DECLINED is terminal like RESOLVED: it settles the receipt's items so the receipt stops
+// counting toward what members owe each other. Unlike RESOLVED it must NOT stamp
+// resolved_date — a decline is not a resolution, and reports expose that column.
+func TestAfterReceiptUpdatedSettlesItemsForDeclinedReceipt(t *testing.T) {
+	defer teardownReceiptTest()
+	setupReceiptTest()
+	createTestReceipts()
+	createTestItems()
+
+	repository := NewReceiptRepository(nil)
+	db := GetDB()
+
+	// Seed a resolved_date so the assertion below proves it is actively cleared.
+	alreadyResolved := time.Now().UTC()
+	err := db.Table("receipts").Where("id = ?", 1).Update("resolved_date", alreadyResolved).Error
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	var receipt models.Receipt
+	db.First(&receipt, 1)
+	receipt.Status = models.DECLINED
+	receipt.ResolvedDate = &alreadyResolved
+
+	err = repository.AfterReceiptUpdated(&receipt)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	var items []models.Item
+	db.Where("receipt_id = ?", receipt.ID).Find(&items)
+	if len(items) == 0 {
+		utils.PrintTestError(t, len(items), "at least one item")
+		return
+	}
+	for _, item := range items {
+		if item.Status != models.ITEM_RESOLVED {
+			utils.PrintTestError(t, item.Status, models.ITEM_RESOLVED)
+		}
+	}
+
+	var refreshed models.Receipt
+	db.First(&refreshed, 1)
+	if refreshed.ResolvedDate != nil {
+		utils.PrintTestError(t, refreshed.ResolvedDate, nil)
+	}
+}

--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -3394,6 +3394,7 @@ components:
         - "NEEDS_ATTENTION"
         - "RESOLVED"
         - "DRAFT"
+        - "DECLINED"
         - ""
     QuickScanDefaultPaidByType:
       description: How the default paid-by is resolved for optional quick-scan paid-by

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -439,6 +439,35 @@ gated by `appPermissionGuard` requiring `app.roles.read` (see **Permission-based
     `e2e/group-delete-any.spec.ts`.
 
 
+### Receipt status colors
+
+Everything visual for a receipt status is the ~20 lines of
+`src/shared-ui/status-chip/status-chip.component.scss` plus the `[ngClass]` map in its template. The
+options themselves need no code: `RECEIPT_STATUS_OPTIONS` (`src/constants/receipt-status-options.ts`)
+derives from `Object.keys(ReceiptStatus)` and `formatStatus` (`src/utils/status.utils.ts`)
+snake→title-cases the label, so **a status added to `swagger.yml` reaches the receipt form, the
+filters, bulk status update and both "default status" settings on regeneration alone** — only a color
+has to be authored.
+
+The convention is a **pale tint carrying the default (dark) `mat-chip` text**:
+
+| Status | Background |
+|---|---|
+| `NEEDS_ATTENTION` | `variables.$warning-amber` (`#ffe0b2`) |
+| `DECLINED` | `map.get(variables.$warn-palette, 100)` (`#f2bfbf`) — the red NEEDS_ATTENTION gave up |
+| `OPEN` | `#fffacd` |
+| `RESOLVED` | `lightgreen` |
+| `DRAFT` | *(no rule — the default chip surface)* |
+
+**Do not set an explicit `color` on these rules.** `.needs-attention` and `.open` used to declare
+`color: white`, i.e. white on `#f2bfbf` / `#fffacd` — about 1.6:1 and 1.2:1, an effectively invisible
+label. The tints are chosen to be legible under the dark default.
+
+The chip is also driven by an unrelated `customStatusColor` input (`"red" | "green" | "gray" |
+"yellow"`) for **system-task** status in the activity list; `'red'` maps to `.declined`, so red still
+means failure there. (`'gray'` maps to no class — a pre-existing dead value.)
+`status-chip.component.spec.ts` pins the whole status → class map, including that repoint.
+
 ### Custom fields
 
 The Manage Custom Fields page (`src/custom-fields/`) is a paged `app-table` plus a single

--- a/desktop/src/open-api/model/receiptStatus.ts
+++ b/desktop/src/open-api/model/receiptStatus.ts
@@ -12,13 +12,14 @@
 /**
  * Status of a receipt
  */
-export type ReceiptStatus = 'OPEN' | 'NEEDS_ATTENTION' | 'RESOLVED' | 'DRAFT' | '';
+export type ReceiptStatus = 'OPEN' | 'NEEDS_ATTENTION' | 'RESOLVED' | 'DRAFT' | 'DECLINED' | '';
 
 export const ReceiptStatus = {
     Open: 'OPEN' as ReceiptStatus,
     NeedsAttention: 'NEEDS_ATTENTION' as ReceiptStatus,
     Resolved: 'RESOLVED' as ReceiptStatus,
     Draft: 'DRAFT' as ReceiptStatus,
+    Declined: 'DECLINED' as ReceiptStatus,
     Empty: '' as ReceiptStatus
 };
 

--- a/desktop/src/pipes/status.pipe.spec.ts
+++ b/desktop/src/pipes/status.pipe.spec.ts
@@ -35,6 +35,13 @@ describe("StatusPipe", () => {
     expect(result).toEqual("Draft");
   });
 
+  it("should return Declined", () => {
+    const pipe = new StatusPipe();
+    const result = pipe.transform(ReceiptStatus.Declined);
+
+    expect(result).toEqual("Declined");
+  });
+
   it("should return empty string", () => {
     const pipe = new StatusPipe();
     const result = pipe.transform(undefined as any);

--- a/desktop/src/shared-ui/status-chip/status-chip.component.html
+++ b/desktop/src/shared-ui/status-chip/status-chip.component.html
@@ -1,6 +1,7 @@
 <mat-chip
   [ngClass]="{
-    'needs-attention': status === receiptStatus.NeedsAttention || customStatusColor() === 'red',
+    'needs-attention': status === receiptStatus.NeedsAttention,
+    declined: status === receiptStatus.Declined || customStatusColor() === 'red',
     open: status === receiptStatus.Open || customStatusColor() === 'yellow',
     resolved: status === receiptStatus.Resolved || customStatusColor() === 'green'
   }"

--- a/desktop/src/shared-ui/status-chip/status-chip.component.scss
+++ b/desktop/src/shared-ui/status-chip/status-chip.component.scss
@@ -1,14 +1,19 @@
 @use "../../variables.scss" as variables;
 @use "sass:map";
 
+// Every status is a pale tint carrying the default (dark) mat-chip text. `color: white`
+// used to be set on .needs-attention and .open, which put white on #f2bfbf / #fffacd —
+// roughly 1.2:1 and 1.6:1 contrast, i.e. an invisible label.
 .needs-attention {
+  background-color: variables.$warning-amber !important;
+}
+
+.declined {
   background-color: map.get(variables.$warn-palette, 100) !important;
-  color: white !important;
 }
 
 .open {
   background-color: #fffacd !important;
-  color: white !important;
 }
 
 .resolved {

--- a/desktop/src/shared-ui/status-chip/status-chip.component.spec.ts
+++ b/desktop/src/shared-ui/status-chip/status-chip.component.spec.ts
@@ -4,10 +4,16 @@ import { StatusChipComponent } from './status-chip.component';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { MatChipsModule } from '@angular/material/chips';
 import { PipesModule } from 'src/pipes/pipes.module';
+import { ReceiptStatus } from 'src/open-api';
 
 describe('StatusChipComponent', () => {
   let component: StatusChipComponent;
   let fixture: ComponentFixture<StatusChipComponent>;
+
+  const chipClasses = (): string[] =>
+    Array.from(
+      fixture.nativeElement.querySelector('mat-chip')?.classList ?? []
+    );
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -24,5 +30,57 @@ describe('StatusChipComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  // The status -> class map is the entire color layer, so it is asserted here rather
+  // than left to the stylesheet. DECLINED owns red; NEEDS_ATTENTION is amber.
+  const statusClassCases: { status: ReceiptStatus; expected: string }[] = [
+    { status: ReceiptStatus.NeedsAttention, expected: 'needs-attention' },
+    { status: ReceiptStatus.Declined, expected: 'declined' },
+    { status: ReceiptStatus.Open, expected: 'open' },
+    { status: ReceiptStatus.Resolved, expected: 'resolved' },
+  ];
+
+  statusClassCases.forEach(({ status, expected }) => {
+    it(`should apply the ${expected} class for ${status}`, async () => {
+      fixture.componentRef.setInput('status', status);
+      await fixture.whenStable();
+
+      const classes = chipClasses();
+      expect(classes).toContain(expected);
+
+      statusClassCases
+        .map((c) => c.expected)
+        .filter((c) => c !== expected)
+        .forEach((other) => expect(classes).not.toContain(other));
+    });
+  });
+
+  it('should apply no status class for DRAFT', async () => {
+    fixture.componentRef.setInput('status', ReceiptStatus.Draft);
+    await fixture.whenStable();
+
+    const classes = chipClasses();
+    statusClassCases.forEach(({ expected }) =>
+      expect(classes).not.toContain(expected)
+    );
+  });
+
+  // The activity list drives the chip with customStatusColor for system-task status.
+  // 'red' must keep meaning red now that NEEDS_ATTENTION is amber.
+  it('should map the red custom status color onto the declined class', async () => {
+    fixture.componentRef.setInput('customStatusColor', 'red');
+    await fixture.whenStable();
+
+    const classes = chipClasses();
+    expect(classes).toContain('declined');
+    expect(classes).not.toContain('needs-attention');
+  });
+
+  it('should map the green custom status color onto the resolved class', async () => {
+    fixture.componentRef.setInput('customStatusColor', 'green');
+    await fixture.whenStable();
+
+    expect(chipClasses()).toContain('resolved');
   });
 });

--- a/desktop/src/variables.scss
+++ b/desktop/src/variables.scss
@@ -120,3 +120,8 @@ $border-radius-xl: 0.75rem;
 $border-radius-2xl: 1rem;
 
 $success-green: #10b981;
+
+// Receipt status chip tint. Statuses render as pale tints with the default dark chip
+// text; DECLINED reuses $warn-palette shade 100 (the red NEEDS_ATTENTION gave up), so
+// this is the one tint the palettes above don't already provide.
+$warning-amber: #ffe0b2;

--- a/mobile/CLAUDE.md
+++ b/mobile/CLAUDE.md
@@ -634,6 +634,47 @@ mounts it, so a raw `shellContext` is **null** and tapping Categories/Tags would
 by `test/widgets/quick_scan_form_test.dart` (tap-opens-picker, shellContext null) and on-device by
 `quick_scan_submit_test.dart`.
 
+### Receipt status presentation
+
+`receiptStatusLabel` / `receiptStatusColor` (`lib/utils/receipts.dart`) are the **single owner** of
+receipt-status presentation; `ReceiptListItem.getStatusText` / `getStatusColor` are thin delegates,
+and `buildReceiptStatusDropDownMenuItems` (`lib/utils/forms.dart`) carries the same labels for the
+form dropdown — the two label lists must stay in sync.
+
+Every status is a **pale tint**, because `ListItemTrailingStatus` paints its label in the default
+dark `onBackground` and `ListItemColorBlock` sits beside dark text. The tints match the desktop chip
+(`desktop/CLAUDE.md` → "Receipt status colors"):
+
+| Status | Tint |
+|---|---|
+| `NEEDS_ATTENTION` | `warningAmber` `#FFE0B2` |
+| `DECLINED` | `errorRed` `#F2BFBF` — the red NEEDS_ATTENTION gave up |
+| `OPEN` | `#FFFACD` |
+| `RESOLVED` | `successGreen` |
+| `DRAFT` (and the fallback) | `neutralStatusGrey` |
+
+**`errorRed` / `successGreen` are shared with the activity list**
+(`group_activity_list_item.dart`), where red still means a failed system task — so DECLINED reusing
+`errorRed` keeps both meanings intact, and changing either constant moves both surfaces.
+
+**Neither function throws on an unrecognized status.** Both used to end in
+`throw Exception("Unknown status: …")`, which was already reachable via `ReceiptStatus.empty` (the
+search screen builds a `Receipt` from a `SearchResult` whose `receiptStatus` is nullable) and would
+take the whole receipt list down for any status the API adds after a build ships. The label falls
+back to `titleCaseStatusName` (SNAKE_CASE → Title Case, matching desktop's `formatStatus`) and the
+tint to the neutral grey. This does **not** rescue an already-released binary — the generated
+`ReceiptStatus` `EnumClass` throws in `_$valueOf` long before either function is reached (see
+"Permission-based UI gating" → the closed-enum note) — it only bounds the damage from here on.
+
+`titleCaseStatusName` is split out because a `ReceiptStatus` the generated enum does not declare
+**cannot be constructed from a test** (the constructor is private to the openapi package), so the
+fallback rule is otherwise unpinnable. Tests:
+`test/utils/receipt_status_presentation_test.dart` (both maps, exhaustive over
+`ReceiptStatus.values`, plus the fallback rule); the mapping is deliberately **not** asserted through
+`ReceiptListItem`, whose trailing pill is a fixed 100px wide — "Needs Attention" reports a render
+overflow that has nothing to do with the mapping. **E2E:**
+`integration_test/receipt_status_lifecycle_test.dart` drives every status through the real API.
+
 ### Seeding the receipt group
 
 The Group field is a default, not a lock. The add form seeds it from **the group being browsed**, and

--- a/mobile/CLAUDE.md
+++ b/mobile/CLAUDE.md
@@ -419,6 +419,32 @@ the swagger, so `Claims` carries only identity claims and the field is gone from
 Run `flutter analyze` after a regen; these surface as compile errors. (Hand-editing generated files
 is otherwise forbidden — these are the documented exception.)
 
+**A third hand-patch, which does NOT surface as a compile error — `ReceiptStatus` enum tolerance.**
+`model/receipt_status.dart` annotates the `empty` member `@BuiltValueEnumConst(wireName: r'',
+fallback: true)`. `build_runner` turns that into `default: return _$empty;` in `_$valueOf`, replacing
+the generated `default: throw ArgumentError(name)`. Without it, one unrecognized wire value fails the
+**entire** enclosing payload — the whole paged receipts response, and **login** when the value rides
+on `AppData` through a group's `emailDefaultReceiptStatus` or either `quickScanDefaultStatus`. That is
+the same closed-enum mechanism behind the two `Permission` login outages (see "Permission-based UI
+gating"); `ReceiptStatus` cannot take that feature's fix of becoming a plain wire string, because it
+is a genuine closed domain backing the status dropdowns.
+
+The openapi-generator never emits `fallback`, so **a regen silently drops it** — and unlike the two
+patches above nothing fails to compile, so the only thing that catches the regression is
+`test/models/receipt_status_ingest_test.dart`. Run `flutter test` after a regen, not just
+`flutter analyze`.
+
+Two consequences worth knowing. An unknown status deserializes to `empty`, which
+`receiptStatusLabel` / `receiptStatusColor` render as a blank neutral chip rather than crashing —
+degraded, not broken. And on the **write** path `empty` serializes back to `""`, which
+`UpsertReceiptCommand.Validate` rejects with a 400 "Status is required": an old build editing a
+receipt whose status it cannot represent gets a visible error instead of silently downgrading it.
+That is the intended failure — loud, and no data loss.
+
+The sibling closed enums (`ItemStatus`, `GroupStatus`, `SystemTaskStatus`, `Permission` as a
+catalog) are **still intolerant**. Adding a value to any of them is a breaking change for released
+builds until they get the same treatment.
+
 ### Receipt entry (Scan / Add)
 
 The bottom-nav slot that used to open an "Add" menu is a **direct action**. A **tap** scans; a
@@ -662,9 +688,14 @@ dark `onBackground` and `ListItemColorBlock` sits beside dark text. The tints ma
 search screen builds a `Receipt` from a `SearchResult` whose `receiptStatus` is nullable) and would
 take the whole receipt list down for any status the API adds after a build ships. The label falls
 back to `titleCaseStatusName` (SNAKE_CASE → Title Case, matching desktop's `formatStatus`) and the
-tint to the neutral grey. This does **not** rescue an already-released binary — the generated
-`ReceiptStatus` `EnumClass` throws in `_$valueOf` long before either function is reached (see
-"Permission-based UI gating" → the closed-enum note) — it only bounds the damage from here on.
+tint to the neutral grey.
+
+These two are the **presentation** half of the tolerance; they are only reachable because the
+**deserialization** half exists — `ReceiptStatus.empty` is annotated `fallback: true` so the
+generated `_$valueOf` returns it instead of throwing (see "Regenerating API Client Models" → the
+third hand-patch). Without that the payload fails at the serializer and neither function is ever
+called. Neither half rescues a binary released *before* both landed; together they mean a build from
+here on degrades to a blank neutral chip rather than losing the whole receipts list.
 
 `titleCaseStatusName` is split out because a `ReceiptStatus` the generated enum does not declare
 **cannot be constructed from a test** (the constructor is private to the openapi package), so the

--- a/mobile/api/lib/src/model/group_receipt_settings.dart
+++ b/mobile/api/lib/src/model/group_receipt_settings.dart
@@ -84,7 +84,7 @@ abstract class GroupReceiptSettings implements BaseModel, Built<GroupReceiptSett
 
   @BuiltValueField(wireName: r'quickScanDefaultStatus')
   ReceiptStatus? get quickScanDefaultStatus;
-  // enum quickScanDefaultStatusEnum {  OPEN,  NEEDS_ATTENTION,  RESOLVED,  DRAFT,  ,  };
+  // enum quickScanDefaultStatusEnum {  OPEN,  NEEDS_ATTENTION,  RESOLVED,  DRAFT,  DECLINED,  ,  };
 
   /// Require the categories field in quick scan
   @BuiltValueField(wireName: r'quickScanCategoriesRequired')

--- a/mobile/api/lib/src/model/group_settings.dart
+++ b/mobile/api/lib/src/model/group_settings.dart
@@ -75,7 +75,7 @@ abstract class GroupSettings implements Built<GroupSettings, GroupSettingsBuilde
   /// Default receipt status
   @BuiltValueField(wireName: r'emailDefaultReceiptStatus')
   ReceiptStatus? get emailDefaultReceiptStatus;
-  // enum emailDefaultReceiptStatusEnum {  OPEN,  NEEDS_ATTENTION,  RESOLVED,  DRAFT,  ,  };
+  // enum emailDefaultReceiptStatusEnum {  OPEN,  NEEDS_ATTENTION,  RESOLVED,  DRAFT,  DECLINED,  ,  };
 
   /// User foreign key
   @BuiltValueField(wireName: r'emailDefaultReceiptPaidById')

--- a/mobile/api/lib/src/model/receipt.dart
+++ b/mobile/api/lib/src/model/receipt.dart
@@ -94,7 +94,7 @@ abstract class Receipt implements Built<Receipt, ReceiptBuilder> {
 
   @BuiltValueField(wireName: r'status')
   ReceiptStatus get status;
-  // enum statusEnum {  OPEN,  NEEDS_ATTENTION,  RESOLVED,  DRAFT,  ,  };
+  // enum statusEnum {  OPEN,  NEEDS_ATTENTION,  RESOLVED,  DRAFT,  DECLINED,  ,  };
 
   /// Tags associated to receipt
   @BuiltValueField(wireName: r'tags')

--- a/mobile/api/lib/src/model/receipt_status.dart
+++ b/mobile/api/lib/src/model/receipt_status.dart
@@ -27,7 +27,13 @@ class ReceiptStatus extends EnumClass {
   @BuiltValueEnumConst(wireName: r'DECLINED')
   static const ReceiptStatus DECLINED = _$DECLINED;
   /// Status of a receipt
-  @BuiltValueEnumConst(wireName: r'')
+  // HAND-PATCH (re-apply after every regen -- see mobile/CLAUDE.md "Known
+  // dart-dio default-value regressions"): `fallback: true` makes the generated
+  // `_$valueOf` return this member for an unrecognized wire value instead of
+  // throwing ArgumentError, which would fail the ENTIRE enclosing payload --
+  // the whole receipts list, or login when the value rides on AppData. The
+  // openapi-generator does not emit it.
+  @BuiltValueEnumConst(wireName: r'', fallback: true)
   static const ReceiptStatus empty = _$empty;
 
   static Serializer<ReceiptStatus> get serializer => _$receiptStatusSerializer;

--- a/mobile/api/lib/src/model/receipt_status.dart
+++ b/mobile/api/lib/src/model/receipt_status.dart
@@ -24,6 +24,9 @@ class ReceiptStatus extends EnumClass {
   @BuiltValueEnumConst(wireName: r'DRAFT')
   static const ReceiptStatus DRAFT = _$DRAFT;
   /// Status of a receipt
+  @BuiltValueEnumConst(wireName: r'DECLINED')
+  static const ReceiptStatus DECLINED = _$DECLINED;
+  /// Status of a receipt
   @BuiltValueEnumConst(wireName: r'')
   static const ReceiptStatus empty = _$empty;
 

--- a/mobile/api/lib/src/model/receipt_status.g.dart
+++ b/mobile/api/lib/src/model/receipt_status.g.dart
@@ -29,7 +29,7 @@ ReceiptStatus _$valueOf(String name) {
     case 'empty':
       return _$empty;
     default:
-      throw ArgumentError(name);
+      return _$empty;
   }
 }
 

--- a/mobile/api/lib/src/model/receipt_status.g.dart
+++ b/mobile/api/lib/src/model/receipt_status.g.dart
@@ -11,6 +11,7 @@ const ReceiptStatus _$NEEDS_ATTENTION =
     const ReceiptStatus._('NEEDS_ATTENTION');
 const ReceiptStatus _$RESOLVED = const ReceiptStatus._('RESOLVED');
 const ReceiptStatus _$DRAFT = const ReceiptStatus._('DRAFT');
+const ReceiptStatus _$DECLINED = const ReceiptStatus._('DECLINED');
 const ReceiptStatus _$empty = const ReceiptStatus._('empty');
 
 ReceiptStatus _$valueOf(String name) {
@@ -23,6 +24,8 @@ ReceiptStatus _$valueOf(String name) {
       return _$RESOLVED;
     case 'DRAFT':
       return _$DRAFT;
+    case 'DECLINED':
+      return _$DECLINED;
     case 'empty':
       return _$empty;
     default:
@@ -36,6 +39,7 @@ final BuiltSet<ReceiptStatus> _$values =
   _$NEEDS_ATTENTION,
   _$RESOLVED,
   _$DRAFT,
+  _$DECLINED,
   _$empty,
 ]);
 
@@ -45,6 +49,7 @@ class _$ReceiptStatusMeta {
   ReceiptStatus get NEEDS_ATTENTION => _$NEEDS_ATTENTION;
   ReceiptStatus get RESOLVED => _$RESOLVED;
   ReceiptStatus get DRAFT => _$DRAFT;
+  ReceiptStatus get DECLINED => _$DECLINED;
   ReceiptStatus get empty => _$empty;
   ReceiptStatus valueOf(String name) => _$valueOf(name);
   BuiltSet<ReceiptStatus> get values => _$values;
@@ -64,6 +69,7 @@ class _$ReceiptStatusSerializer implements PrimitiveSerializer<ReceiptStatus> {
     'NEEDS_ATTENTION': 'NEEDS_ATTENTION',
     'RESOLVED': 'RESOLVED',
     'DRAFT': 'DRAFT',
+    'DECLINED': 'DECLINED',
     'empty': '',
   };
   static const Map<Object, String> _fromWire = const <Object, String>{
@@ -71,6 +77,7 @@ class _$ReceiptStatusSerializer implements PrimitiveSerializer<ReceiptStatus> {
     'NEEDS_ATTENTION': 'NEEDS_ATTENTION',
     'RESOLVED': 'RESOLVED',
     'DRAFT': 'DRAFT',
+    'DECLINED': 'DECLINED',
     '': 'empty',
   };
 

--- a/mobile/api/lib/src/model/search_result.dart
+++ b/mobile/api/lib/src/model/search_result.dart
@@ -43,7 +43,7 @@ abstract class SearchResult implements Built<SearchResult, SearchResultBuilder> 
 
   @BuiltValueField(wireName: r'receiptStatus')
   ReceiptStatus? get receiptStatus;
-  // enum receiptStatusEnum {  OPEN,  NEEDS_ATTENTION,  RESOLVED,  DRAFT,  ,  };
+  // enum receiptStatusEnum {  OPEN,  NEEDS_ATTENTION,  RESOLVED,  DRAFT,  DECLINED,  ,  };
 
   @BuiltValueField(wireName: r'paidByUserId')
   int? get paidByUserId;

--- a/mobile/api/lib/src/model/update_group_receipt_settings_command.dart
+++ b/mobile/api/lib/src/model/update_group_receipt_settings_command.dart
@@ -97,7 +97,7 @@ abstract class UpdateGroupReceiptSettingsCommand implements Built<UpdateGroupRec
 
   @BuiltValueField(wireName: r'quickScanDefaultStatus')
   ReceiptStatus? get quickScanDefaultStatus;
-  // enum quickScanDefaultStatusEnum {  OPEN,  NEEDS_ATTENTION,  RESOLVED,  DRAFT,  ,  };
+  // enum quickScanDefaultStatusEnum {  OPEN,  NEEDS_ATTENTION,  RESOLVED,  DRAFT,  DECLINED,  ,  };
 
   /// Show the categories field in quick scan
   @BuiltValueField(wireName: r'quickScanCategoriesEnabled')

--- a/mobile/api/lib/src/model/update_group_settings_command.dart
+++ b/mobile/api/lib/src/model/update_group_settings_command.dart
@@ -49,7 +49,7 @@ abstract class UpdateGroupSettingsCommand implements Built<UpdateGroupSettingsCo
   /// Default receipt status
   @BuiltValueField(wireName: r'emailDefaultReceiptStatus')
   ReceiptStatus? get emailDefaultReceiptStatus;
-  // enum emailDefaultReceiptStatusEnum {  OPEN,  NEEDS_ATTENTION,  RESOLVED,  DRAFT,  ,  };
+  // enum emailDefaultReceiptStatusEnum {  OPEN,  NEEDS_ATTENTION,  RESOLVED,  DRAFT,  DECLINED,  ,  };
 
   /// User foreign key
   @BuiltValueField(wireName: r'emailDefaultReceiptPaidById')

--- a/mobile/api/lib/src/model/upsert_receipt_command.dart
+++ b/mobile/api/lib/src/model/upsert_receipt_command.dart
@@ -53,7 +53,7 @@ abstract class UpsertReceiptCommand implements Built<UpsertReceiptCommand, Upser
 
   @BuiltValueField(wireName: r'status')
   ReceiptStatus get status;
-  // enum statusEnum {  OPEN,  NEEDS_ATTENTION,  RESOLVED,  DRAFT,  ,  };
+  // enum statusEnum {  OPEN,  NEEDS_ATTENTION,  RESOLVED,  DRAFT,  DECLINED,  ,  };
 
   /// Categories associated to receipt
   @BuiltValueField(wireName: r'categories')

--- a/mobile/api/lib/src/model/user_preferences.dart
+++ b/mobile/api/lib/src/model/user_preferences.dart
@@ -31,7 +31,7 @@ abstract class UserPreferences implements BaseModel, Built<UserPreferences, User
   /// Default quick scan status
   @BuiltValueField(wireName: r'quickScanDefaultStatus')
   ReceiptStatus? get quickScanDefaultStatus;
-  // enum quickScanDefaultStatusEnum {  OPEN,  NEEDS_ATTENTION,  RESOLVED,  DRAFT,  ,  };
+  // enum quickScanDefaultStatusEnum {  OPEN,  NEEDS_ATTENTION,  RESOLVED,  DRAFT,  DECLINED,  ,  };
 
   @BuiltValueField(wireName: r'userShortcuts')
   BuiltList<UserShortcut>? get userShortcuts;

--- a/mobile/integration_test/receipt_status_lifecycle_test.dart
+++ b/mobile/integration_test/receipt_status_lifecycle_test.dart
@@ -14,7 +14,7 @@ import 'helpers/platform_mocks.dart';
 import 'helpers/pump.dart';
 import 'helpers/receipt_test_helpers.dart';
 
-/// Drives a receipt through the four ReceiptStatus values via the
+/// Drives a receipt through every ReceiptStatus value via the
 /// view-screen popup menu → Edit form, asserting after each transition that
 /// the server-side status matches. Catches regressions where:
 ///   - the status dropdown ignores user selection in edit mode,
@@ -54,13 +54,14 @@ void main() {
     expect(initial['status'], 'OPEN',
         reason: 'manual receipt should default to OPEN');
 
-    // OPEN is the starting point, so we drive only the three remaining
-    // transitions plus a round-trip back to OPEN to prove every value is
-    // reachable from any other.
+    // OPEN is the starting point, so we drive only the remaining transitions
+    // plus a round-trip back to OPEN to prove every value is reachable from
+    // any other.
     for (final transition in const [
       _StatusTransition('Needs Attention', 'NEEDS_ATTENTION'),
       _StatusTransition('Resolved', 'RESOLVED'),
       _StatusTransition('Draft', 'DRAFT'),
+      _StatusTransition('Declined', 'DECLINED'),
       _StatusTransition('Open', 'OPEN'),
     ]) {
       await _changeStatusViaUI(tester, transition.label);

--- a/mobile/lib/constants/colors.dart
+++ b/mobile/lib/constants/colors.dart
@@ -3,6 +3,16 @@ import 'dart:ui';
 const successGreen = Color.fromRGBO(144, 238, 144, 1);
 const errorRed = const Color.fromRGBO(242, 191, 191, 1);
 
+/// Receipt status tint for NEEDS_ATTENTION. It gave [errorRed] up to DECLINED, so
+/// "needs attention" now reads as a warning rather than a rejection. Matches the
+/// desktop chip's `$warning-amber`; pale like every other status tint, because
+/// `ListItemTrailingStatus` paints its label in the default dark `onBackground`.
+const warningAmber = Color.fromRGBO(255, 224, 178, 1);
+
+/// Receipt status tint for DRAFT, and the fallback for a status this build does
+/// not recognize.
+const neutralStatusGrey = Color.fromRGBO(224, 224, 224, 1);
+
 /// Background for the in-page notices (the "Quick Scan unavailable" banner on
 /// the receipt form, and the queued confirmation in the Quick Scan sheet).
 ///

--- a/mobile/lib/groups/widgets/receipt_list_item.dart
+++ b/mobile/lib/groups/widgets/receipt_list_item.dart
@@ -10,8 +10,8 @@ import 'package:receipt_wrangler_mobile/shared/widgets/slidable_edit_button.dart
 import 'package:receipt_wrangler_mobile/shared/widgets/slidable_widget.dart';
 import 'package:receipt_wrangler_mobile/utils/currency.dart';
 import 'package:receipt_wrangler_mobile/utils/date.dart';
+import 'package:receipt_wrangler_mobile/utils/receipts.dart';
 
-import '../../constants/colors.dart';
 import '../../models/group_model.dart';
 import '../../models/permissions_model.dart';
 import '../../shared/functions/permissions.dart';
@@ -35,22 +35,9 @@ class _ReceiptListItem extends State<ReceiptListItem> {
   late final groupModel = Provider.of<GroupModel>(context, listen: false);
 
   Widget getStatusText() {
-    var text = "";
-
-    switch (widget.receipt.status) {
-      case api.ReceiptStatus.DRAFT:
-        text = "Draft";
-      case api.ReceiptStatus.NEEDS_ATTENTION:
-        text = "Needs Attention";
-      case api.ReceiptStatus.OPEN:
-        text = "Open";
-      case api.ReceiptStatus.RESOLVED:
-        text = "Resolved";
-      default:
-        throw Exception("Unknown status: ${widget.receipt.status}");
-    }
-
-    return ListItemTrailingStatus(color: getStatusColor(), text: text);
+    return ListItemTrailingStatus(
+        color: getStatusColor(),
+        text: receiptStatusLabel(widget.receipt.status));
   }
 
   Widget getLeadingWidget() {
@@ -59,18 +46,7 @@ class _ReceiptListItem extends State<ReceiptListItem> {
   }
 
   Color getStatusColor() {
-    switch (widget.receipt.status) {
-      case api.ReceiptStatus.DRAFT:
-        return const Color.fromRGBO(224, 224, 224, 1);
-      case api.ReceiptStatus.NEEDS_ATTENTION:
-        return errorRed;
-      case api.ReceiptStatus.OPEN:
-        return const Color.fromRGBO(255, 250, 205, 1);
-      case api.ReceiptStatus.RESOLVED:
-        return successGreen;
-      default:
-        throw Exception("Unknown status: ${widget.receipt.status}");
-    }
+    return receiptStatusColor(widget.receipt.status);
   }
 
   Widget getSubtitleText() {

--- a/mobile/lib/utils/forms.dart
+++ b/mobile/lib/utils/forms.dart
@@ -94,6 +94,10 @@ List<DropdownMenuItem> buildReceiptStatusDropDownMenuItems() {
       value: ReceiptStatus.DRAFT,
       child: Text("Draft"),
     ),
+    DropdownMenuItem(
+      value: ReceiptStatus.DECLINED,
+      child: Text("Declined"),
+    ),
   ];
 }
 

--- a/mobile/lib/utils/receipts.dart
+++ b/mobile/lib/utils/receipts.dart
@@ -6,6 +6,7 @@ import 'package:built_value/json_object.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:openapi/openapi.dart';
+import 'package:receipt_wrangler_mobile/constants/colors.dart';
 import 'package:receipt_wrangler_mobile/enums/form_state.dart';
 import 'package:receipt_wrangler_mobile/utils/forms.dart';
 
@@ -25,6 +26,71 @@ Receipt getDefaultReceipt() {
         ..categories = ListBuilder<Category>([])
         ..tags = ListBuilder<Tag>([]))
       .build();
+}
+
+/// Human label for a receipt status.
+///
+/// A status this build has no case for falls through to the desktop
+/// `formatStatus` rule (SNAKE_CASE -> Title Case) so the two clients degrade
+/// identically, and [ReceiptStatus.empty] — the "unset" sentinel Quick Scan
+/// submits — renders as no label rather than "Empty". Together with
+/// [receiptStatusColor] this is the single owner of receipt-status
+/// presentation on mobile; keep the two exhaustive over the same values.
+String receiptStatusLabel(ReceiptStatus status) {
+  switch (status) {
+    case ReceiptStatus.OPEN:
+      return "Open";
+    case ReceiptStatus.NEEDS_ATTENTION:
+      return "Needs Attention";
+    case ReceiptStatus.RESOLVED:
+      return "Resolved";
+    case ReceiptStatus.DRAFT:
+      return "Draft";
+    case ReceiptStatus.DECLINED:
+      return "Declined";
+    case ReceiptStatus.empty:
+      return "";
+    default:
+      // Degrade instead of throwing, which is what both switches used to do.
+      // That arm was already reachable via ReceiptStatus.empty (the search
+      // screen builds a Receipt from a SearchResult whose receiptStatus is
+      // nullable), and it is what keeps a status added to the API after this
+      // build ships from taking the whole receipt list down.
+      return titleCaseStatusName(status.name);
+  }
+}
+
+/// SNAKE_CASE -> Title Case, the fallback [receiptStatusLabel] uses for a status
+/// this build predates. Split out because a `ReceiptStatus` value the generated
+/// enum does not declare cannot be constructed from a test, so this is the only
+/// way to pin the rule.
+String titleCaseStatusName(String name) {
+  return name
+      .split("_")
+      .where((word) => word.isNotEmpty)
+      .map((word) => word[0].toUpperCase() + word.substring(1).toLowerCase())
+      .join(" ");
+}
+
+/// Tint for a receipt status. Every value is a pale tint, because
+/// `ListItemTrailingStatus` paints its label in the default dark
+/// `onBackground` and `ListItemColorBlock` sits beside dark text too.
+Color receiptStatusColor(ReceiptStatus status) {
+  switch (status) {
+    case ReceiptStatus.OPEN:
+      return const Color.fromRGBO(255, 250, 205, 1);
+    case ReceiptStatus.NEEDS_ATTENTION:
+      return warningAmber;
+    case ReceiptStatus.RESOLVED:
+      return successGreen;
+    case ReceiptStatus.DRAFT:
+      return neutralStatusGrey;
+    case ReceiptStatus.DECLINED:
+      // The red NEEDS_ATTENTION gave up.
+      return errorRed;
+    default:
+      return neutralStatusGrey;
+  }
 }
 
 String getTitleText(WranglerFormState formState, String receiptName) {

--- a/mobile/test/models/receipt_status_ingest_test.dart
+++ b/mobile/test/models/receipt_status_ingest_test.dart
@@ -1,0 +1,93 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openapi/openapi.dart';
+import 'package:receipt_wrangler_mobile/constants/colors.dart';
+import 'package:receipt_wrangler_mobile/utils/receipts.dart';
+
+/// Guards the API boundary for `ReceiptStatus`, the sibling of the two
+/// production login outages that `app_data_permission_ingest_test.dart` covers.
+///
+/// built_value renders an OpenAPI enum as a CLOSED set: `_$valueOf` used to end
+/// in `default: throw ArgumentError(name)`, so a single unrecognized wire value
+/// failed the *entire* enclosing payload -- the whole paged receipts response,
+/// and login itself when the value rode on `AppData` via a group's
+/// `emailDefaultReceiptStatus` or either `quickScanDefaultStatus`. That is the
+/// mechanism by which adding DECLINED server-side would have broken every
+/// already-released build.
+///
+/// `ReceiptStatus.empty` is annotated `fallback: true` (a hand-patch on the
+/// generated `receipt_status.dart` -- see mobile/CLAUDE.md), which makes the
+/// generated `_$valueOf` return it rather than throw. This suite exercises the
+/// REAL generated deserializer, which is where the throw happened and which sits
+/// upstream of the presentation fallback in `receiptStatusLabel`.
+Map<String, Object?> _receiptJson(String status) => {
+      'id': 1,
+      'name': 'Test Receipt',
+      'amount': '12.34',
+      'date': '2026-01-01T00:00:00Z',
+      'paidByUserId': 1,
+      'groupId': 1,
+      'status': status,
+    };
+
+void main() {
+  group('unknown wire status', () {
+    // The headline: a status this build predates no longer throws.
+    test('deserializes to the empty fallback instead of throwing', () {
+      expect(
+        standardSerializers.deserializeWith(
+            ReceiptStatus.serializer, 'AWAITING_REVIEW'),
+        ReceiptStatus.empty,
+      );
+    });
+
+    // The blast radius that actually mattered: one bad value used to take the
+    // whole enclosing object down, not just the field.
+    test('does not fail the enclosing Receipt payload', () {
+      final receipt = standardSerializers.deserializeWith(
+          Receipt.serializer, _receiptJson('AWAITING_REVIEW'));
+
+      expect(receipt, isNotNull);
+      expect(receipt!.name, 'Test Receipt');
+      expect(receipt.status, ReceiptStatus.empty);
+    });
+
+    // Deserialization and presentation have to compose: the fallback member
+    // must render as something harmless rather than crash the list item.
+    test('renders through the presentation layer without throwing', () {
+      final receipt = standardSerializers.deserializeWith(
+          Receipt.serializer, _receiptJson('AWAITING_REVIEW'))!;
+
+      expect(receiptStatusLabel(receipt.status), '');
+      expect(receiptStatusColor(receipt.status), neutralStatusGrey);
+    });
+  });
+
+  group('known wire statuses still round-trip exactly', () {
+    // The fallback must not swallow a value the build DOES know -- that would
+    // silently blank every status in the app.
+    const wireValues = <String, ReceiptStatus>{
+      'OPEN': ReceiptStatus.OPEN,
+      'NEEDS_ATTENTION': ReceiptStatus.NEEDS_ATTENTION,
+      'RESOLVED': ReceiptStatus.RESOLVED,
+      'DRAFT': ReceiptStatus.DRAFT,
+      'DECLINED': ReceiptStatus.DECLINED,
+      '': ReceiptStatus.empty,
+    };
+
+    wireValues.forEach((wire, expected) {
+      test('"$wire" deserializes to ${expected.name}', () {
+        expect(
+          standardSerializers.deserializeWith(ReceiptStatus.serializer, wire),
+          expected,
+        );
+      });
+
+      test('${expected.name} serializes back to "$wire"', () {
+        expect(
+          standardSerializers.serializeWith(ReceiptStatus.serializer, expected),
+          wire,
+        );
+      });
+    });
+  });
+}

--- a/mobile/test/utils/receipt_status_presentation_test.dart
+++ b/mobile/test/utils/receipt_status_presentation_test.dart
@@ -1,0 +1,98 @@
+import 'dart:ui';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openapi/openapi.dart';
+import 'package:receipt_wrangler_mobile/constants/colors.dart';
+import 'package:receipt_wrangler_mobile/utils/receipts.dart';
+
+/// `receiptStatusLabel` / `receiptStatusColor` (lib/utils/receipts.dart) are the
+/// single owner of receipt-status presentation on mobile, and had no coverage
+/// before DECLINED was added. They are tested here rather than through
+/// ReceiptListItem because that widget's trailing pill is a fixed 100px wide, so
+/// a longer label ("Needs Attention") reports a render overflow that has nothing
+/// to do with the mapping under test.
+void main() {
+  group('receiptStatusLabel', () {
+    const cases = <ReceiptStatus, String>{
+      ReceiptStatus.OPEN: 'Open',
+      ReceiptStatus.NEEDS_ATTENTION: 'Needs Attention',
+      ReceiptStatus.RESOLVED: 'Resolved',
+      ReceiptStatus.DRAFT: 'Draft',
+      ReceiptStatus.DECLINED: 'Declined',
+    };
+
+    cases.forEach((status, label) {
+      test('labels ${status.name} as "$label"', () {
+        expect(receiptStatusLabel(status), label);
+      });
+    });
+
+    // The "unset" sentinel Quick Scan submits. It reaches the list through the
+    // search screen, which builds a Receipt from a SearchResult whose
+    // receiptStatus is nullable — and used to throw here.
+    test('renders the empty sentinel as no label', () {
+      expect(receiptStatusLabel(ReceiptStatus.empty), '');
+    });
+
+    test('covers every value the generated enum declares', () {
+      for (final status in ReceiptStatus.values) {
+        expect(
+          () => receiptStatusLabel(status),
+          returnsNormally,
+          reason: '${status.name} has no label',
+        );
+      }
+    });
+  });
+
+  // The fallback for a status added to the API after this build ships. A
+  // ReceiptStatus the generated enum does not declare cannot be constructed,
+  // so the rule is pinned through the helper the default arm delegates to.
+  group('titleCaseStatusName', () {
+    test('title-cases a SNAKE_CASE status name', () {
+      expect(titleCaseStatusName('AWAITING_REVIEW'), 'Awaiting Review');
+    });
+
+    test('handles a single word', () {
+      expect(titleCaseStatusName('DECLINED'), 'Declined');
+    });
+
+    test('does not choke on repeated or trailing separators', () {
+      expect(titleCaseStatusName('A__B_'), 'A B');
+    });
+  });
+
+  group('receiptStatusColor', () {
+    // DECLINED owns the red NEEDS_ATTENTION gave up.
+    const cases = <ReceiptStatus, Color>{
+      ReceiptStatus.OPEN: Color.fromRGBO(255, 250, 205, 1),
+      ReceiptStatus.NEEDS_ATTENTION: warningAmber,
+      ReceiptStatus.RESOLVED: successGreen,
+      ReceiptStatus.DRAFT: neutralStatusGrey,
+      ReceiptStatus.DECLINED: errorRed,
+    };
+
+    cases.forEach((status, color) {
+      test('tints ${status.name}', () {
+        expect(receiptStatusColor(status), color);
+      });
+    });
+
+    test('NEEDS_ATTENTION and DECLINED are visually distinct', () {
+      expect(
+        receiptStatusColor(ReceiptStatus.NEEDS_ATTENTION),
+        isNot(receiptStatusColor(ReceiptStatus.DECLINED)),
+      );
+    });
+
+    test('covers every value the generated enum declares', () {
+      for (final status in ReceiptStatus.values) {
+        expect(
+          () => receiptStatusColor(status),
+          returnsNormally,
+          reason: '${status.name} has no tint',
+        );
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Adds a new `DECLINED` receipt status to the receipt management system across all three components (API, desktop, mobile). This status represents a terminal state where a receipt is rejected, settling its items without marking a resolution date. The status receives distinct visual treatment (red tint) separate from `NEEDS_ATTENTION` (now amber).

## Key Changes

**API (`api/`)**
- Added `DECLINED` constant to `models.ReceiptStatus` with validation in `Value()` guard chain
- Updated `ReceiptStatuses()` membership list used by status validators
- Modified `AfterReceiptUpdated()` to treat `DECLINED` as terminal (cascades items to `ITEM_RESOLVED`) but explicitly does NOT stamp `resolved_date` — a decline is not a resolution
- Added comprehensive test `TestAfterReceiptUpdatedSettlesItemsForDeclinedReceipt` verifying items settle and `resolved_date` remains unset
- Updated `swagger.yml` enum and seed data weights
- Updated model tests to include `DECLINED` in the valid statuses list

**Desktop (`desktop/`)**
- Added `.declined` SCSS class with `#f2bfbf` background (the red `NEEDS_ATTENTION` gave up)
- Updated `status-chip.component.html` to map `DECLINED` status and `'red'` custom color to `.declined` class
- Removed white text color from `.needs-attention` and `.open` (was creating invisible labels on pale backgrounds)
- Added `$warning-amber` SCSS variable (`#ffe0b2`) for `NEEDS_ATTENTION`
- Extended `status-chip.component.spec.ts` with comprehensive test coverage of status→class mapping, including custom color handling
- Updated `StatusPipe` test to cover `DECLINED`

**Mobile (`mobile/`)**
- Created `receiptStatusLabel()` and `receiptStatusColor()` functions as single owners of receipt-status presentation
- Added `titleCaseStatusName()` helper for graceful fallback on unknown statuses (SNAKE_CASE → Title Case)
- Both functions handle `ReceiptStatus.empty` sentinel and unknown statuses without throwing
- Added new color constants: `warningAmber` (`#ffe0b2`) and `neutralStatusGrey` (`#e0e0e0`)
- Refactored `ReceiptListItem` to delegate to new utility functions instead of duplicating logic
- Updated `buildReceiptStatusDropDownMenuItems()` to include `DECLINED` option
- Added comprehensive test suite `receipt_status_presentation_test.dart` covering all statuses, the empty sentinel, and the fallback rule
- Updated `receipt_status_lifecycle_test.dart` to drive every status through the real API

**Generated Clients**
- Regenerated `mobile/api/` Dart client with `DECLINED` enum value
- Regenerated `desktop/src/open-api/` TypeScript client with `DECLINED` type

## Notable Implementation Details

- **Color Semantics**: `errorRed` is reused for `DECLINED` (matching system-task failure in activity list), while `NEEDS_ATTENTION` now uses `warningAmber` to signal a warning rather than rejection
- **Graceful Degradation**: Mobile functions don't throw on unknown statuses — they fall back to title-casing the status name and using neutral grey. This prevents a released binary from crashing if the API adds a status after the build ships
- **Terminal State Handling**: `DECLINED` cascades items to settled state like `RESOLVED`, but explicitly clears `resolved_date` since a decline is not a resolution and that column is a reporting dimension
- **Test Coverage**: Mobile presentation logic is tested in isolation (`receipt_status_presentation_test.dart`) rather than through `ReceiptListItem` to avoid render overflow issues with the fixed-width trailing pill
- **Documentation**: Added detailed CLAUDE.md sections in both `api/` and `mobile/` explaining status architecture, color choices, and validation gaps

https://claude.ai/code/session_01DRXiKpB7ffwmPHcNxPt8Qi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for the **Declined** receipt status across API, desktop, and mobile.
  - Declined receipts now settle associated items and clear previous resolution dates.
  - Added Declined to receipt selectors, settings, lifecycle handling, and API definitions.
  - Added centralized mobile status labels and colors, with neutral fallbacks for unknown statuses.

- **Style**
  - Declined uses red, while Needs Attention uses warning amber.
  - Improved status-chip text contrast and consistency.

- **Tests**
  - Expanded coverage for transitions, presentation, colors, validation, fallbacks, and settlement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->