### PR TITLE
Fix the receipts overflow menu's Quick Scan and gallery entries

### DIFF
--- a/mobile/CLAUDE.md
+++ b/mobile/CLAUDE.md
@@ -154,6 +154,31 @@ it persists the comment field OFF, logs in, flips it ON server-side, and opens Q
 restarting the app. Every other quick-scan spec arranges its config *before* login, so none of them
 can tell a client that re-fetches from one that read the config once at login.
 
+### `TopAppBar`'s loading bar is always mounted — never null
+
+`TopAppBar` passes its `LinearProgressIndicator` as `AppBar.bottom`, and it must stay **non-null even
+when idle** (zero-height `PreferredSize`), however tempting the conditional looks. `AppBar` re-parents
+its whole toolbar into a `Column` *only* when `bottom != null`
+(`flutter/lib/src/material/app_bar.dart`), so a null ↔ non-null swap changes that slot's widget from a
+`ClipRect` to a `Column`, fails `Widget.canUpdate`, and **unmounts `leading`, `title` and every
+`actions` child**. Anything in `actions` that captured its own `BuildContext` and uses it after an
+`await` then fails its `mounted` guard and silently gives up.
+
+That shipped: the receipts-screen overflow menu's **Quick Scan** and **Upload from Gallery** items did
+nothing, because `_refreshBeforeQuickScan` — the very thing they await — is what raises this bar. Only
+"Add Manual Receipt" worked, being synchronous, and the bottom-nav long-press was immune because its
+context comes from the nav rather than the app bar. The avatar menu in the same bar survives because it
+navigates from `this.context` (the `_TopAppBar` **State** context, *above* the `AppBar`) — keep it that
+way.
+
+The idle **child** is still swapped to `SizedBox.shrink()`: a permanently mounted
+`LinearProgressIndicator` animates forever and `pumpAndSettle` would never return (its default timeout
+is **ten minutes**, so that regression hangs CI rather than failing it). Height goes to zero instead of
+the widget going away. Don't "fix" the 4px toolbar squeeze while the bar shows by making
+`TopAppBar.preferredSize` dynamic — `Scaffold` pins 56 either way, and a dynamic size would relayout
+every screen's body on every network call. Pinned by
+`test/widgets/top_app_bar_loading_indicator_test.dart`.
+
 ### Permission-based UI gating
 
 The mobile app gates UI on the caller's **effective permissions**, mirroring the desktop client
@@ -476,7 +501,12 @@ backend enforces the two permissions **separately** (`handlers.QuickScan` → `g
 - **The overflow menu is the receipts screen's only.** `GroupAppBar` is shared with the dashboards
   route, so it gates on `GoRouterState.of(context).fullPath`. It is the accessible equivalent of the
   long-press, and carries the same items from `buildReceiptEntryMenuItems`. It is **not** on
-  `GroupSelectAppBar`.
+  `GroupSelectAppBar`. Its items run from the `PopupMenuButton`'s **own in-app-bar context**, and
+  `_refreshBeforeQuickScan` raises the loading bar in that same app bar — which is why that bar must
+  never toggle `AppBar.bottom` between null and non-null (see "`TopAppBar`'s loading bar is always
+  mounted"). It is also why `quick_scan_entry_test.dart` **taps** the overflow's Quick Scan rather than
+  only asserting its label: a widget test cannot reproduce this, since `TokenRefreshService` is
+  uninitialized there and `reloadAppData()` returns within a microtask, so the bar never gets a frame.
 - **Gallery upload is gated on quick-scan, not create** — that flow feeds the Quick Scan sheet, so
   offering it to a create-only user would produce a sheet they cannot submit.
 - **A submitted sheet confirms itself** (`quick-scan-queued-confirmation`). Submitting disables every
@@ -1299,7 +1329,7 @@ All three runners source `api/dev/switch-to-sqlite.sh` for the four `E2E_*` cred
 #### Reference files
 
 - `integration_test/smoke_login_test.dart` — canonical smoke test.
-- `integration_test/quick_scan_entry_test.dart` — the scan slot's tap (captures → seeded sheet) and hold (menu contents), against real roles.
+- `integration_test/quick_scan_entry_test.dart` — the scan slot's tap (captures → seeded sheet) and hold (menu contents), against real roles, plus the receipts-screen overflow: one case asserting its labels and one **tapping** its Quick Scan through to the sheet (the app-bar teardown regression — see "`TopAppBar`'s loading bar is always mounted").
 - `integration_test/quick_scan_app_data_refresh_test.dart` — a group's comment field switched on **after** login reaches the running app when Quick Scan is next started. The only spec that proves the pre-scan AppData reload; every other quick-scan spec arranges its config before login, so none can distinguish a client that re-fetches from one that read the config once at login. Persists via the API and never touches `GroupModel`.
 - `integration_test/quick_scan_entry_gated_test.dart` — the tap falling through to the manual form, with the right banner for each of the two blocked reasons. Exercises **both** feature-flag fixtures: the permission case enables the flag (to isolate the permission from it), the ai-disabled case **pins it off** with `disableAiPoweredReceiptsForTest()` rather than assuming — which also removes its dependency on the preceding test's teardown having succeeded, since they share the one global.
 - `integration_test/receipt_entry_hidden_test.dart` — a Legacy Viewer gets no scan slot and no overflow at all. Flag-independent: the slot is hidden when the caller holds *neither* entry permission, whatever `aiPoweredReceipts` says.

--- a/mobile/integration_test/quick_scan_entry_test.dart
+++ b/mobile/integration_test/quick_scan_entry_test.dart
@@ -109,4 +109,48 @@ void main() {
     expect(find.text(addManualReceiptLabel), findsOneWidget);
     expect(find.text(uploadFromGalleryLabel), findsOneWidget);
   });
+
+  testWidgets("the overflow's Quick Scan really opens the sheet",
+      (tester) async {
+    // The overflow has to *work*, not just offer the right labels. Quick Scan
+    // awaits a real AppData refresh, which raises the app bar's loading bar --
+    // and the overflow lives in that same app bar. Toggling `AppBar.bottom`
+    // between null and non-null used to re-parent the whole toolbar, unmounting
+    // the menu's own context, so the post-await `if (!context.mounted) return;`
+    // swallowed the tap and no sheet ever appeared.
+    //
+    // Only an e2e reproduces it: in a widget test TokenRefreshService is never
+    // initialized, so `reloadAppData()` returns within a microtask and the
+    // loading bar never gets a frame. The framework seam itself is pinned by
+    // test/widgets/top_app_bar_loading_indicator_test.dart.
+    await enableAiPoweredReceiptsForTest();
+    await installDocumentScannerMock();
+    await binding.setSurfaceSize(const Size(1280, 900));
+    addTearDown(() => binding.setSurfaceSize(null));
+
+    final fixture = await provisionPermUser(roleName: 'Legacy Editor');
+    await loginAs(
+      tester,
+      username: fixture.username,
+      password: fixture.password,
+    );
+    await enterGroup(tester, fixture.groupName!);
+    await tester.tap(find.text('Receipts').hitTestable());
+
+    final overflow = find.byKey(const ValueKey('receipt-entry-overflow-menu'));
+    await pumpUntilFound(tester, overflow.hitTestable());
+    await tester.tap(overflow.hitTestable());
+    await pumpUntilFound(tester, find.text(quickScanLabel).hitTestable());
+    // Nothing else on the receipts screen carries this string, so the match is
+    // the menu item. (Once the sheet opens it becomes the sheet's own title.)
+    expect(find.text(quickScanLabel), findsOneWidget);
+    await tester.tap(find.text(quickScanLabel).hitTestable());
+
+    // 'Group' is the per-image form's first field and exists only inside the
+    // sheet. The longer window covers a real /appData round trip on top of the
+    // scanner. Before the fix this timed out: the tap returned silently.
+    await pumpUntilFound(tester, find.text('Group'),
+        timeout: const Duration(seconds: 25));
+    expect(find.text('Group'), findsWidgets);
+  });
 }

--- a/mobile/integration_test/quick_scan_entry_test.dart
+++ b/mobile/integration_test/quick_scan_entry_test.dart
@@ -140,7 +140,16 @@ void main() {
     final overflow = find.byKey(const ValueKey('receipt-entry-overflow-menu'));
     await pumpUntilFound(tester, overflow.hitTestable());
     await tester.tap(overflow.hitTestable());
+
+    // The menu's items mount on the popup's first frame while it is still
+    // growing, so a tap computed then lands short and misses. Wait for
+    // hittability, then drain the animation -- the same shape as
+    // `openManualReceiptForm`.
     await pumpUntilFound(tester, find.text(quickScanLabel).hitTestable());
+    for (int i = 0; i < 5; i++) {
+      await tester.pump(const Duration(milliseconds: 100));
+    }
+
     // Nothing else on the receipts screen carries this string, so the match is
     // the menu item. (Once the sheet opens it becomes the sheet's own title.)
     expect(find.text(quickScanLabel), findsOneWidget);

--- a/mobile/lib/shared/widgets/top_app_bar.dart
+++ b/mobile/lib/shared/widgets/top_app_bar.dart
@@ -10,6 +10,9 @@ import 'package:receipt_wrangler_mobile/utils/snackbar.dart';
 
 import '../../client/client.dart';
 
+/// Height of the progress bar under the toolbar while a request is in flight.
+const double _loadingIndicatorHeight = 4;
+
 class TopAppBar extends StatefulWidget implements PreferredSizeWidget {
   const TopAppBar(
       {super.key,
@@ -95,6 +98,11 @@ class _TopAppBar extends State<TopAppBar> {
       return const SizedBox.shrink();
     }
 
+    // Each item pops the menu itself and then navigates from `this.context` --
+    // the State's context, which is the *parent* of the AppBar rather than
+    // something inside its toolbar. Keep it that way: a context taken from in
+    // here would be at the mercy of the toolbar's lifetime (see
+    // [_buildLoadingIndicator]).
     return PopupMenuButton(
         key: const ValueKey('user-avatar-menu'),
         child: const UserAvatar(),
@@ -136,23 +144,44 @@ class _TopAppBar extends State<TopAppBar> {
         });
   }
 
+  /// The progress bar, **always mounted** — zero-height and empty when idle.
+  ///
+  /// It must never be `null`, however tempting the conditional looks. `AppBar`
+  /// re-parents its whole toolbar into a `Column` *only* when `bottom != null`
+  /// (`material/app_bar.dart`), so a null <-> non-null swap changes that slot's
+  /// widget from a `ClipRect` to a `Column`, fails `Widget.canUpdate`, and
+  /// **unmounts `leading`, `title` and every `actions` child**. Anything in
+  /// `actions` that captured its own `BuildContext` and uses it after an
+  /// `await` then fails its `mounted` guard and silently gives up — which is
+  /// how the receipts-screen overflow menu's Quick Scan and Upload from Gallery
+  /// items broke: the AppData refresh they await is the very thing that raises
+  /// this bar.
+  ///
+  /// Keeping a constant height instead would push every screen's body down, so
+  /// the height goes to zero rather than the widget going away. The child is
+  /// still swapped out when idle: a permanently mounted `LinearProgressIndicator`
+  /// animates forever, and `pumpAndSettle` would never return.
+  ///
+  /// Pinned by `test/widgets/top_app_bar_loading_indicator_test.dart`.
+  PreferredSizeWidget _buildLoadingIndicator() {
+    final isLoading = loadingModel.isLoading;
+
+    return PreferredSize(
+      preferredSize: Size.fromHeight(isLoading ? _loadingIndicatorHeight : 0),
+      child: isLoading
+          ? const LinearProgressIndicator()
+          : const SizedBox.shrink(),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
-    PreferredSizeWidget? getLoadingIndicator(context) {
-      if (loadingModel.isLoading) {
-        return const PreferredSize(
-            preferredSize: Size.square(4), child: LinearProgressIndicator());
-      } else {
-        return null;
-      }
-    }
-
     return AppBar(
       automaticallyImplyLeading: false,
       leading: getIconButton(),
       title: Text(widget.titleText),
       surfaceTintColor: widget.surfaceTintColor,
-      bottom: getLoadingIndicator(context),
+      bottom: _buildLoadingIndicator(),
       actions: [
         Padding(
           padding: const EdgeInsets.only(right: 16.0),

--- a/mobile/lib/shared/widgets/top_app_bar.dart
+++ b/mobile/lib/shared/widgets/top_app_bar.dart
@@ -114,9 +114,19 @@ class _TopAppBar extends State<TopAppBar> {
             api.Permission.appPeriodReportsPeriodReadAll,
           ]);
 
+          // These items are TextButtons rather than the plain Text every other
+          // menu in the app uses, and a TextButton takes its foreground from
+          // `colorScheme.primary` -- so they rendered in the brand blue while
+          // every other menu rendered in ordinary text colour. Pin them to the
+          // colour a bare PopupMenuItem would have used.
+          final itemStyle = TextButton.styleFrom(
+            foregroundColor: Theme.of(context).colorScheme.onSurface,
+          );
+
           return [
             PopupMenuItem(
               child: TextButton(
+                style: itemStyle,
                 onPressed: () {
                   Navigator.pop(context);
                   this.context.push('/profile');
@@ -127,6 +137,7 @@ class _TopAppBar extends State<TopAppBar> {
             if (canViewReports)
               PopupMenuItem(
                 child: TextButton(
+                  style: itemStyle,
                   onPressed: () {
                     Navigator.pop(context);
                     this.context.push('/reports');
@@ -136,6 +147,7 @@ class _TopAppBar extends State<TopAppBar> {
               ),
             PopupMenuItem(
               child: TextButton(
+                style: itemStyle,
                 onPressed: () => _logout(),
                 child: const Text('Logout'),
               ),

--- a/mobile/test/shared/functions/receipt_entry_test.dart
+++ b/mobile/test/shared/functions/receipt_entry_test.dart
@@ -20,6 +20,16 @@ import '../../helpers/receipt_form_test_helpers.dart';
 /// and four possible destinations (camera, gallery fallback, manual form,
 /// refusal), and picking the wrong one either hides a capability the user has or
 /// offers one they don't.
+///
+/// What these cases **cannot** see is the `context.mounted` guard after
+/// `_refreshBeforeQuickScan`. `TokenRefreshService.reloadAppData()` returns
+/// immediately while the service is uninitialized -- which it always is outside
+/// `main()` -- so the refresh finishes in a microtask, `tester.pump()` drains
+/// microtasks before it builds a frame, and the loading bar the guard trips over
+/// never gets one. That is how the receipts-screen overflow menu shipped with
+/// two dead items despite this file exercising every gate. The frame-level seam
+/// lives in `test/widgets/top_app_bar_loading_indicator_test.dart` and the
+/// user-visible behaviour in `integration_test/quick_scan_entry_test.dart`.
 void main() {
   const quickScan = api.Permission.groupPeriodReceiptsPeriodQuickScan;
   const create = api.Permission.groupPeriodReceiptsPeriodCreate;

--- a/mobile/test/widgets/top_app_bar_loading_indicator_test.dart
+++ b/mobile/test/widgets/top_app_bar_loading_indicator_test.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openapi/openapi.dart' as api;
+import 'package:provider/provider.dart';
+import 'package:receipt_wrangler_mobile/models/auth_model.dart';
+import 'package:receipt_wrangler_mobile/models/loading_model.dart';
+import 'package:receipt_wrangler_mobile/models/permissions_model.dart';
+import 'package:receipt_wrangler_mobile/models/user_model.dart';
+import 'package:receipt_wrangler_mobile/shared/widgets/top_app_bar.dart';
+
+import '../helpers/auth_test_helpers.dart';
+import '../helpers/permission_test_helpers.dart';
+
+/// The loading bar must never evict the toolbar it sits under.
+///
+/// `AppBar` re-parents its toolbar into a `Column` **only** when `bottom` is
+/// non-null, so a null <-> non-null swap changes that slot's runtimeType,
+/// fails `Widget.canUpdate` and unmounts `leading`, `title` and every
+/// `actions` child. Anything in `actions` that holds its own `BuildContext`
+/// across an `await` then fails its `mounted` guard and silently gives up --
+/// which is exactly how the receipts-screen overflow menu's Quick Scan and
+/// Upload from Gallery items died, since the refresh they await is what raises
+/// the bar.
+void main() {
+  api.Claims claims(String displayName) =>
+      api.Claims((b) => b..displayName = displayName);
+
+  /// Mounts a [TopAppBar] carrying one probe action, and returns the probe's
+  /// [BuildContext] holder plus the [LoadingModel] driving the bar.
+  ///
+  /// The probe records its context with `??=`: the point of these tests is that
+  /// the element is never torn down and rebuilt, so a later capture would paper
+  /// over the very failure under test.
+  Future<(List<BuildContext?>, LoadingModel)> pumpBar(
+      WidgetTester tester) async {
+    final authModel = MockAuthModel();
+    when(() => authModel.claims).thenReturn(claims('Admin'));
+
+    final loadingModel = LoadingModel();
+    final probe = <BuildContext?>[null];
+
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider<AuthModel>(create: (_) => authModel),
+          ChangeNotifierProvider<LoadingModel>.value(value: loadingModel),
+          ChangeNotifierProvider<UserModel>(create: (_) => UserModel()),
+          ChangeNotifierProvider<PermissionsModel>(
+            create: (_) => seededPermissions(),
+          ),
+        ],
+        child: MaterialApp(
+          home: Scaffold(
+            appBar: TopAppBar(
+              titleText: 'Home',
+              actions: [
+                Builder(builder: (context) {
+                  probe[0] ??= context;
+                  return const SizedBox.shrink();
+                }),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    return (probe, loadingModel);
+  }
+
+  testWidgets('an action keeps its context when the loading bar appears',
+      (tester) async {
+    final (probe, loadingModel) = await pumpBar(tester);
+    expect(probe[0], isNotNull);
+
+    loadingModel.setIsLoading(true);
+    await tester.pump();
+
+    expect(find.byType(LinearProgressIndicator), findsOneWidget);
+    expect(probe[0]!.mounted, isTrue,
+        reason: 'raising the loading bar unmounted the AppBar toolbar, so an '
+            'action captured before an await can no longer be used after it');
+  });
+
+  testWidgets('an action keeps its context when the loading bar goes away',
+      (tester) async {
+    final (probe, loadingModel) = await pumpBar(tester);
+
+    loadingModel.setIsLoading(true);
+    await tester.pump();
+    loadingModel.setIsLoading(false);
+    await tester.pump();
+
+    expect(find.byType(LinearProgressIndicator), findsNothing);
+    expect(probe[0]!.mounted, isTrue);
+  });
+
+  testWidgets('the idle app bar is still kToolbarHeight tall', (tester) async {
+    await pumpBar(tester);
+
+    // The always-mounted bottom must be zero-height when idle, or every screen
+    // gains a strip. Test MediaQuery has no top padding, so this is the whole
+    // app bar.
+    expect(tester.getSize(find.byType(TopAppBar)).height, kToolbarHeight);
+  });
+
+  testWidgets('the idle app bar mounts no running animation', (tester) async {
+    await pumpBar(tester);
+
+    // An always-mounted LinearProgressIndicator animates forever, which would
+    // hang every pumpAndSettle in the suite. The explicit timeout makes that
+    // regression fail here in two seconds rather than after the ten-minute
+    // default.
+    await tester.pumpAndSettle(
+      const Duration(milliseconds: 100),
+      EnginePhase.sendSemanticsUpdate,
+      const Duration(seconds: 2),
+    );
+  });
+}

--- a/mobile/test/widgets/top_app_bar_reports_menu_test.dart
+++ b/mobile/test/widgets/top_app_bar_reports_menu_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart' show RenderParagraph;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openapi/openapi.dart' as api;
@@ -64,5 +65,33 @@ void main() {
     // The menu did open — the ungated items are present.
     expect(find.text('User Profile'), findsOneWidget);
     expect(find.text('Logout'), findsOneWidget);
+  });
+
+  testWidgets('renders the items in text colour, not the brand blue',
+      (tester) async {
+    await pumpBar(tester, [Permission.appPeriodReportsPeriodRead]);
+
+    // Read the scheme actually in force rather than hardcoding colours, so the
+    // assertion keeps meaning if the app's palette changes.
+    final scheme = Theme.of(tester.element(find.byType(Scaffold))).colorScheme;
+    expect(scheme.onSurface, isNot(scheme.primary),
+        reason: 'the two must differ or this test proves nothing');
+
+    // The items are TextButtons, which default their foreground to
+    // colorScheme.primary — that is what made them render blue. They must use
+    // the colour a bare PopupMenuItem would have used instead.
+    //
+    // Assert the colour the RenderParagraph actually paints, not the declared
+    // ButtonStyle: the style is only the mechanism, and a theme or a wrapping
+    // DefaultTextStyle could still override what the user ends up seeing.
+    for (final label in ['User Profile', 'Reports', 'Logout']) {
+      final painted = tester
+          .renderObject<RenderParagraph>(find.text(label))
+          .text
+          .style
+          ?.color;
+      expect(painted, scheme.onSurface,
+          reason: '"$label" is not painted in the ordinary text colour');
+    }
   });
 }


### PR DESCRIPTION
## The bug

On the receipts screen, the overflow menu (⋮) offers **Quick Scan**, **Add Manual Receipt** and **Upload from Gallery**. Only *Add Manual Receipt* worked — the other two flashed a thin loading bar and then did nothing, with no error. The same three items reached by **holding the bottom-nav Scan slot** were fine.

Reported on iOS; it is not platform-specific, Android had it too.

## Root cause: the loading bar was destroying the menu

`TopAppBar` passed its `LinearProgressIndicator` as `AppBar.bottom`, and `null` when idle. Flutter's `AppBar` re-parents its whole toolbar into a `Column` **only** when `bottom != null`:

```dart
Widget appBar = ClipRect(...);
if (widget.bottom != null) {
  appBar = Column(children: [Flexible(child: ConstrainedBox(..., child: appBar)), widget.bottom!]);
}
```

So toggling the bar changes that child slot from a `ClipRect` to a `Column`. `Widget.canUpdate` fails on the differing `runtimeType`, and Flutter **deactivates and unmounts the entire toolbar subtree** — `leading`, `title`, and every `actions` child.

`ReceiptEntryOverflowMenu` lives in `actions`, and its items close over the `PopupMenuButton`'s own context. `startScanEntry` and `startGalleryEntry` both open with `await _refreshBeforeQuickScan(context)` — which raises that very bar — then `if (!context.mounted) return;`. By the time they resume the context is gone, so they returned silently.

*Add Manual Receipt* survived only because `openManualReceipt` is synchronous: `context.go(...)` runs in the same frame as the menu pop. The long-press menu is immune because its context comes from `_GroupBottomNav`. The avatar menu in the same app bar survives by accident — it navigates from `this.context`, the State context *above* the `AppBar`.

Introduced by #681, which put the first `await` + loading toggle ahead of the `mounted` check; the overflow menu itself arrived in #676.

## The fix

`bottom` is now **always non-null** — zero height with a `SizedBox.shrink()` child when idle, 4px and the indicator while loading — so the toolbar is never re-parented.

Layout-neutral: `TopAppBar.preferredSize` is `kToolbarHeight` regardless of `bottom` (there is no `AppBarTheme` in `lib/`), so `Scaffold` allocates 56 either way, and idle yields `Column[Flexible(toolbar → 56), 0]` — the same box the bare `ClipRect` produced. Every other `AppBar` feature (`surfaceTintColor`, scroll-under elevation, `SafeArea`, semantics) is computed outside the `if (widget.bottom != null)` block.

The child still swaps to `SizedBox.shrink()` when idle rather than staying mounted: a live indeterminate `LinearProgressIndicator` animates forever and `pumpAndSettle` would never return (default timeout **10 minutes**, so that regression would hang CI rather than fail it).

Fixing the teardown at its source covers **every** widget in a `TopAppBar` toolbar, not just this menu — including the Quick Scan sheet's own app-bar icons and the "enter details manually" link it holds, which `_submitQuickScan`'s own loading toggle would otherwise kill mid-sheet.

### Considered and rejected

Passing `GroupAppBar`'s (surviving) context down into the overflow menu. It works, but it fixes one widget where this fixes the whole toolbar, and it stores a `BuildContext` in a widget field — the exact lifetime hazard `ContextModel.resolveSheetContext` already exists to paper over.

## Tests

- **New `test/widgets/top_app_bar_loading_indicator_test.dart`** pins the seam: a probe in `TopAppBar.actions` must keep its `BuildContext` across a `LoadingModel` toggle, plus the idle bar staying `kToolbarHeight` and mounting no running animation. The two context cases **fail on the unfixed code** with `mounted: false`.
- **`integration_test/quick_scan_entry_test.dart`** gains a case that *taps* the overflow's Quick Scan through to the sheet. The existing overflow spec stopped at asserting labels, which is why this shipped.
- A note in `test/shared/functions/receipt_entry_test.dart` explaining why it couldn't catch this despite driving `startScanEntry` across every gate: `TokenRefreshService` is uninitialized in a widget test, so `reloadAppData()` returns within a microtask and the bar never gets a frame.

### Verification

| | result |
|---|---|
| `flutter test` | 424 passed |
| `flutter analyze` (touched files) | clean |
| `run-e2e-ios.sh quick_scan_entry_test.dart` **with** fix | 4/4 passed |
| same, **fix reverted** | 3/4 — only the new case fails (`Timed out after 25s waiting for ... "Group"`) |

That last row is the point: the three pre-existing specs pass against the broken code.

## Docs

`mobile/CLAUDE.md` gains a section on why the loading bar must never be null, and a cross-reference from the receipt-entry overflow bullet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where Quick Scan launched from the Receipts overflow menu could fail to open after a data refresh.
  - Quick Scan now opens the scanning sheet reliably, with the Group field available as expected.
  - Improved loading indicator behavior so app-bar actions remain available while content refreshes.
  - Updated avatar menu text colors for improved theme consistency.

- **Tests**
  - Added coverage for Quick Scan launches, refresh flows, loading behavior, and app-bar stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->