### PR TITLE
Add quick date filter to receipts table with month stepper

### DIFF
--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -1209,6 +1209,84 @@ helpers `withAdminApi` + `apiDeleteUserByName` / `apiDeleteGroupById` / `apiDele
   spec rather than an extension of `group-viewer-visibility.spec.ts`, whose serial block has a known
   pre-existing failure — a Legacy User can't load `/groups` — that would skip any test appended to it.)
 
+## Receipts table filtering
+
+The receipts table (`src/receipts/receipts-table/`) offers three ways into **one** filter —
+`ReceiptTableState.filter`, which is persisted to localStorage. The advanced dialog
+(`app-receipt-filter`), the month stepper and the filter chips all read and write that single slice,
+so they can never disagree.
+
+- **Field metadata is shared.** `RECEIPT_FILTER_FIELDS` (`src/constants/receipt-filter-fields.constant.ts`)
+  is the one definition of each field's key, label and operation type. The dialog's
+  `setupAutoOperationSelection()` and the chip builder both read it, and `OperationsPipe` now reads
+  the extracted `FILTER_OPERATION_DISPLAY_VALUES`, so a chip cannot describe a condition differently
+  from the row that produced it.
+- **`isFilterEntryActive`** (`src/utils/receipt-filter-entry.ts`) is the shared "does this field
+  narrow anything" predicate: a non-empty stringified value that isn't `"0"`, **or** the operation
+  `WITHIN_CURRENT_MONTH` (the one operation that carries no value). `ReceiptTableState.numFiltersApplied`
+  and the chip builder both call it, so the Filter badge and the chip set always agree.
+- **Single-field writes go through `SetReceiptFilterField`**, whose handler spreads a new filter
+  object and rebuilds a cleared field from a **fresh** `buildDefaultReceiptFilter()`. That factory
+  replaced the shared `defaultReceiptFilter` constant inside `@State` defaults and `ResetReceiptFilter`
+  for the same reason: the old code wrote the module-level object straight into state, where a later
+  in-place edit would have corrupted the default for the rest of the session.
+  `ReceiptsTableComponent.applyFilterField()` is the only caller — it dispatches the action, then
+  `SetPage(1)`, then refetches, so narrowing a filter from page 7 can never land on an empty page.
+
+### The month stepper is the Date filter
+
+`app-month-stepper` (`src/shared-ui/month-stepper/`, standalone, deliberately presentational) emits
+months; `receipts-table` translates them with `src/utils/receipt-date-filter.ts`. A month is written
+as `BETWEEN [startOfMonth, endOfMonth]` — the one operation that can express *any* month, which is
+why this feature needed no API change. Picking a month **overwrites** whatever the Date filter held.
+
+- **The stepper and the chips never show the same condition twice.** While `monthFromFilterEntry`
+  resolves the Date filter to a month, the label names it and the chip row omits `date`. When it
+  cannot (a partial range, a `GREATER_THAN`, `WITHIN_CURRENT_MONTH`) the label reads **"Custom"** and
+  the Date chip renders, so the filter stays visible and clearable.
+- **`monthFromFilterEntry` must accept ISO strings, not just `Date`s.** The filter is persisted and
+  NGXS serializes through JSON, so after a reload `filter.date.value` is two ISO strings. It matches
+  on calendar fields (day 1, same year+month, `getDaysInMonth` on the end) rather than on the
+  serialized text, which also makes it tolerate the local-midnight pair the dialog's datepickers
+  write. Get this wrong and the label silently degrades to "Custom" after every refresh —
+  `e2e/receipt-quick-date-filter.spec.ts` covers it because the Jest specs cannot.
+- **`WITHIN_CURRENT_MONTH` is a no-op on the backend for `date` today.** `BuildGormFilterQuery` guards
+  every field with `if Filter.Date.Value != nil` and the dialog stores `value: null` for that
+  operation, so it never reaches the query builder — the badge counts it and nothing is filtered.
+  Pre-existing; the chip just surfaces it for the first time.
+- **Arrow steps from "All time"/"Custom" seed the current month** and then apply the delta, so `‹`
+  and `›` never do the same thing.
+
+### The overflow menu
+
+Quick Scan, Export all receipts, Configure Columns, Poll email(s) and the selection actions live in a
+`⋮` `mat-menu` (`data-testid="receipts-overflow-menu"`), always collapsed — not breakpoint-driven.
+
+**Every entry is a plain `<button mat-menu-item>` in `receipts-table.component.html`, never a shared
+component that renders one.** `MatMenu` collects items with a **content** query
+(`@ContentChildren(MatMenuItem, { descendants: true })`), which does not cross a child component's
+**view** boundary — so a `mat-menu-item` rendered inside `app-quick-scan-button`'s own template would
+be invisible to the menu and silently skipped by its `FocusKeyManager` (no arrow-key navigation, no
+typeahead, no open-focus). `display: contents` does not help. The behaviour still lives in one place:
+export calls `ReceiptExportService` directly, and Quick Scan calls the shared
+`openQuickScanDialog(matDialog)` (`src/receipts/quick-scan-dialog/open-quick-scan-dialog.ts`), which
+`app-quick-scan-button` uses too.
+
+Two consequences for tests and styles:
+- **A `mat-menu-item`'s role is `menuitem`, not `button`.** A `getByRole('button', { name: 'Quick Scan' })`
+  negative would pass whether or not the entry rendered, so `receipt-feature-gating.spec.ts` asserts
+  those absences by `data-testid` **with the menu open** (`openReceiptsOverflowMenu` in
+  `e2e/helpers/receipts-table.ts`). Any new negative assertion about a menu entry must do the same.
+- **Menu content renders in a CDK overlay**, outside `app-receipts-table`, so the
+  `ViewEncapsulation.None` + `app-receipts-table { … }` nesting in the component's SCSS cannot reach
+  it — the `N selected` section label is styled at the top level of that file instead.
+
+The chips row is inline markup (`mat-chip-set` / `matChipRemove`) with every label built by the pure
+`buildReceiptFilterChips` util, so `ReceiptsModule` must import **`MatChipsModule`** — `SharedUiModule`
+imports it but does not export it. An id the caller cannot resolve (a category outside their grants,
+a group they have left) renders as the raw id rather than dropping the chip, so a filter that is
+actively removing rows is never invisible.
+
 ## Quick Scan Configuration
 
 - **Group receipt settings** (`src/group/group-receipt-settings/`) has a **Quick Scan** section: per

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -1222,8 +1222,10 @@ so they can never disagree.
   the extracted `FILTER_OPERATION_DISPLAY_VALUES`, so a chip cannot describe a condition differently
   from the row that produced it.
 - **`isFilterEntryActive`** (`src/utils/receipt-filter-entry.ts`) is the shared "does this field
-  narrow anything" predicate: a non-empty stringified value that isn't `"0"`, **or** the operation
-  `WITHIN_CURRENT_MONTH` (the one operation that carries no value). `ReceiptTableState.numFiltersApplied`
+  narrow anything" predicate: any non-empty stringified value, **or** the operation
+  `WITHIN_CURRENT_MONTH` (the one operation that carries no value). **Zero counts** — no field
+  defaults to `0` (they default to `null`/`[]`), and the API applies an `amount EQUALS 0`, so
+  excluding it would leave a filter that narrows the table with no badge and no clearable chip. `ReceiptTableState.numFiltersApplied`
   and the chip builder both call it, so the Filter badge and the chip set always agree.
 - **Single-field writes go through `SetReceiptFilterField`**, whose handler spreads a new filter
   object and rebuilds a cleared field from a **fresh** `buildDefaultReceiptFilter()`. That factory
@@ -1232,11 +1234,36 @@ so they can never disagree.
   in-place edit would have corrupted the default for the rest of the session.
   `ReceiptsTableComponent.applyFilterField()` is the only caller — it dispatches the action, then
   `SetPage(1)`, then refetches, so narrowing a filter from page 7 can never land on an empty page.
+- **Refreshes go through one `switchMap`** (`listenForRefreshRequests()`, wired in the constructor;
+  `getFilteredReceipts()` just pushes onto its `Subject`). Each refresh used to be its own
+  subscription, so the last *response* won rather than the last *request* — and the quick date
+  arrows put those one click apart, so a slow earlier page could repaint the table with a month the
+  user had already stepped past. The inner observable carries a `catchError(() => EMPTY)`: an error
+  surfacing *through* `switchMap` would complete the outer subscription and silently kill every
+  later refresh. `getInitialData()` deliberately stays on its own one-shot subscription, because it
+  owns the single `setColumns()` call and that reads `viewChild.required` template refs.
 
 ### The month stepper is the Date filter
 
 `app-month-stepper` (`src/shared-ui/month-stepper/`, standalone, deliberately presentational) emits
-months; `receipts-table` translates them with `src/utils/receipt-date-filter.ts`. A month is written
+months; `receipts-table` translates them with `src/utils/receipt-date-filter.ts`.
+
+**Its panel is a CDK overlay, not a `mat-menu` — do not "simplify" it back.** The panel holds a year
+pager, a month grid and three shortcuts, and **none of them is a `mat-menu-item`**. Inside a menu
+that makes the `FocusKeyManager`'s item list empty, so arrow keys are no-ops, and
+`ListKeyManager.onKeydown` turns **Tab** into `tabOut`, which `MatMenu` wires to `closed.emit('tab')`
+— so Tab *dismissed* the panel instead of entering it, leaving the whole picker mouse-only
+(verified in a browser: the grid is gone after one Tab). It is now
+`cdkConnectedOverlay` + `cdkTrapFocus [cdkTrapFocusAutoCapture]` with `role="dialog"`, an
+`aria-label`, `(keydown.escape)` and a transparent backdrop; the trap restores focus to the trigger
+when the overlay is destroyed. The year pager's old `$event.stopPropagation()` is gone with it — it
+only existed because a menu closes on any click inside itself.
+
+The same rule applies to the two house alternatives, which is why neither was used: `cdkMenu` (the
+`filtered-stateful-menu` precedent) has the identical empty-key-manager problem, and `ngbPopover`
+(the header notifications precedent) hard-codes `role="tooltip"` on `NgbPopoverWindow`'s host, which
+is equally wrong for interactive content and cannot be overridden. `e2e/receipt-quick-date-filter.spec.ts`
+pins the keyboard path — it fails against a `mat-menu` implementation. A month is written
 as `BETWEEN [startOfMonth, endOfMonth]` — the one operation that can express *any* month, which is
 why this feature needed no API change. Picking a month **overwrites** whatever the Date filter held.
 

--- a/desktop/e2e/column-configuration.spec.ts
+++ b/desktop/e2e/column-configuration.spec.ts
@@ -1,5 +1,6 @@
-import { expect, test, type Page } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 import { stubTokenRefresh } from './helpers/auth';
+import { gotoReceiptsTable, openReceiptsOverflowMenu } from './helpers/receipts-table';
 
 // Configuring the receipts-table columns regressed with
 // "TypeError: 0 is read-only": the dialog sorted the (frozen, dev-mode) NGXS
@@ -7,16 +8,6 @@ import { stubTokenRefresh } from './helpers/auth';
 // tests open the dialog (the core regression) and round-trip a couple of
 // configurations. The default chromium project uses e2e/.auth/user.json
 // (e2e-user = Legacy User), which can read its own group's receipts.
-
-async function gotoReceiptsTable(page: Page): Promise<void> {
-  // storageState means we're already authed; "/" redirects to the dashboard
-  // for the user's group, from which we can recover the group id.
-  await page.goto('/');
-  await page.waitForURL(/\/dashboard\/group\/\d+/);
-  const groupId = page.url().match(/\/dashboard\/group\/(\d+)/)![1];
-  await page.goto(`/receipts/group/${groupId}`);
-  await expect(page.getByTestId('configure-columns')).toBeVisible();
-}
 
 test.describe('Receipt table column configuration', () => {
   test.beforeEach(async ({ page }) => {
@@ -26,6 +17,7 @@ test.describe('Receipt table column configuration', () => {
   test('opens the dialog without crashing', async ({ page }) => {
     await gotoReceiptsTable(page);
 
+    await openReceiptsOverflowMenu(page);
     await page.getByTestId('configure-columns').click();
 
     const dialog = page.getByRole('dialog');
@@ -47,6 +39,7 @@ test.describe('Receipt table column configuration', () => {
     await expect(addedAtHeader).toBeVisible();
 
     // Open the dialog and toggle "Added At" off, then save.
+    await openReceiptsOverflowMenu(page);
     await page.getByTestId('configure-columns').click();
     const dialog = page.getByRole('dialog');
     await expect(dialog).toBeVisible();
@@ -59,6 +52,7 @@ test.describe('Receipt table column configuration', () => {
     await expect(addedAtHeader).toHaveCount(0);
 
     // Reopen and reset back to the defaults — the column returns.
+    await openReceiptsOverflowMenu(page);
     await page.getByTestId('configure-columns').click();
     await expect(dialog).toBeVisible();
     await dialog.getByTestId('reset-columns').click();

--- a/desktop/e2e/dashboard-read-redirect.spec.ts
+++ b/desktop/e2e/dashboard-read-redirect.spec.ts
@@ -81,7 +81,7 @@ test.describe('Group dashboard read gating', () => {
     await page.goto(`/dashboard/group/${groupId}`);
     // The guard redirects to the group's receipt list.
     await expect(page).toHaveURL(new RegExp(`/receipts/group/${groupId}`));
-    await expect(page.getByTestId('configure-columns')).toBeVisible();
+    await expect(page.getByTestId('receipts-overflow-menu')).toBeVisible();
   });
 
   test.describe('owner with group.dashboards.read', () => {

--- a/desktop/e2e/helpers/provisioning.ts
+++ b/desktop/e2e/helpers/provisioning.ts
@@ -357,6 +357,8 @@ export async function apiCreateReceipt(
     groupId: number | string;
     paidByUserId: number;
     name: string;
+    /** Receipt date as an ISO string. Defaults to a fixed date in 2024. */
+    date?: string;
     customFields?: ReceiptCustomFieldValue[];
   },
 ): Promise<number> {
@@ -364,7 +366,7 @@ export async function apiCreateReceipt(
     data: {
       name: opts.name,
       amount: '10.00',
-      date: '2024-01-01T00:00:00Z',
+      date: opts.date ?? '2024-01-01T00:00:00Z',
       groupId: Number(opts.groupId),
       paidByUserId: opts.paidByUserId,
       status: 'OPEN',

--- a/desktop/e2e/helpers/quick-scan.ts
+++ b/desktop/e2e/helpers/quick-scan.ts
@@ -1,3 +1,4 @@
+import { openReceiptsOverflowMenu } from './receipts-table';
 import { expect, type Locator, type Page, type Route } from '@playwright/test';
 
 // Shared helpers for the Quick Scan dialog e2e specs. The dialog is only
@@ -108,7 +109,9 @@ export async function injectQuickScanAppData(
  */
 export async function openQuickScanDialog(page: Page, groupId: number): Promise<Locator> {
   await page.goto(`/receipts/group/${groupId}`);
-  await page.getByTestId('receipts-quick-scan').getByRole('button').click();
+  await openReceiptsOverflowMenu(page);
+  // A mat-menu-item is the button itself, so there is no inner button to reach.
+  await page.getByTestId('receipts-quick-scan').click();
   const dialog = page.getByRole('dialog');
   await expect(dialog).toBeVisible();
   return dialog;

--- a/desktop/e2e/helpers/receipts-table.ts
+++ b/desktop/e2e/helpers/receipts-table.ts
@@ -1,0 +1,30 @@
+import { expect, type Page } from '@playwright/test';
+
+/**
+ * Navigates to the receipts table for the user's own group and waits for the
+ * toolbar. The overflow menu is the readiness probe because it is the one
+ * toolbar control no permission or feature flag can hide.
+ */
+export async function gotoReceiptsTable(page: Page): Promise<string> {
+  // storageState means we're already authed; "/" redirects to the dashboard
+  // for the user's group, from which we can recover the group id.
+  await page.goto('/');
+  await page.waitForURL(/\/dashboard\/group\/\d+/);
+  const groupId = page.url().match(/\/dashboard\/group\/(\d+)/)![1];
+  await page.goto(`/receipts/group/${groupId}`);
+  await expect(page.getByTestId('receipts-overflow-menu')).toBeVisible();
+
+  return groupId;
+}
+
+/**
+ * Opens the receipts table's overflow menu, which holds Quick Scan, Export,
+ * Configure Columns, Poll email(s) and the selection actions.
+ *
+ * The menu closes on any click inside it, so callers that trigger more than one
+ * item have to reopen it each time.
+ */
+export async function openReceiptsOverflowMenu(page: Page): Promise<void> {
+  await page.getByTestId('receipts-overflow-menu').click();
+  await expect(page.getByRole('menu')).toBeVisible();
+}

--- a/desktop/e2e/quick-scan-dialog.spec.ts
+++ b/desktop/e2e/quick-scan-dialog.spec.ts
@@ -1,5 +1,6 @@
 import { expect, Route, test } from '@playwright/test';
 import { stubTokenRefresh } from './helpers/auth';
+import { openReceiptsOverflowMenu } from './helpers/receipts-table';
 import {
   apiCreateGroup,
   apiDeleteGroupById,
@@ -69,9 +70,10 @@ test.describe('Quick scan dialog field response', () => {
   test('shows/hides and requires fields per the selected group config', async ({ page }) => {
     await page.goto(`/receipts/group/${group.id}`);
 
-    // The feature-flag-gated Quick Scan button now renders (flag stubbed + admin owns the group). It
-    // is an icon-only button (tooltip is aria-describedby, not the a11y name), so target its testid.
-    await page.getByTestId('receipts-quick-scan').getByRole('button').click();
+    // The feature-flag-gated Quick Scan entry now renders (flag stubbed + admin owns the group).
+    // It lives in the toolbar's overflow menu, and the mat-menu-item carries the testid itself.
+    await openReceiptsOverflowMenu(page);
+    await page.getByTestId('receipts-quick-scan').click();
     const dialog = page.getByRole('dialog');
     await expect(dialog).toBeVisible();
 

--- a/desktop/e2e/receipt-feature-gating.spec.ts
+++ b/desktop/e2e/receipt-feature-gating.spec.ts
@@ -1,5 +1,6 @@
 import { BrowserContext, expect, Page, test } from '@playwright/test';
 import { creds, stubTokenRefresh } from './helpers/auth';
+import { openReceiptsOverflowMenu } from './helpers/receipts-table';
 import {
   apiCreateReceipt,
   apiDeleteGroupById,
@@ -102,24 +103,27 @@ test.describe('Receipt feature gating (quick-scan / poll-email / magic-fill)', (
     await stubTokenRefresh(page);
   });
 
-  test('the receipts header shows no Quick Scan button', async ({ page }) => {
+  // Both controls live in the toolbar's overflow menu, so the menu has to be
+  // open for their absence to mean anything. They are asserted by testid rather
+  // than by name because a mat-menu-item's role is "menuitem", so a
+  // getByRole('button', ...) negative would pass whether or not they rendered.
+  test('the receipts overflow menu shows no Quick Scan entry', async ({ page }) => {
     await page.goto(`/receipts/group/${groupId}`);
     // The table renders for a member who holds group.receipts.read.
+    await openReceiptsOverflowMenu(page);
+    // Configure Columns is ungated, so the menu is genuinely populated.
     await expect(page.getByTestId('configure-columns')).toBeVisible();
     // Quick Scan (group.receipts.quick-scan, also feature-flagged) is absent.
-    await expect(
-      page.getByRole('button', { name: 'Quick Scan' }),
-    ).toHaveCount(0);
+    await expect(page.getByTestId('receipts-quick-scan')).toHaveCount(0);
   });
 
-  test('the receipts header shows no Poll Email button', async ({ page }) => {
+  test('the receipts overflow menu shows no Poll Email entry', async ({ page }) => {
     await page.goto(`/receipts/group/${groupId}`);
+    await openReceiptsOverflowMenu(page);
     await expect(page.getByTestId('configure-columns')).toBeVisible();
     // Poll Email (group.email.poll, also feature-flagged + needs email
     // integration enabled) is absent.
-    await expect(
-      page.getByRole('button', { name: 'Poll email(s)' }),
-    ).toHaveCount(0);
+    await expect(page.getByTestId('receipts-poll-email')).toHaveCount(0);
   });
 
   test('the receipt form shows no Magic Fill button', async ({ page }) => {
@@ -142,13 +146,14 @@ test.describe('Receipt feature gating (quick-scan / poll-email / magic-fill)', (
   }) => {
     await injectQuickScanAppData(page);
 
-    // Editor group (holds quick-scan) -> the button renders.
+    // Editor group (holds quick-scan) -> the entry renders.
     await page.goto(`/receipts/group/${editorGroupId}`);
-    await expect(page.getByTestId('configure-columns')).toBeVisible();
+    await openReceiptsOverflowMenu(page);
     await expect(page.getByTestId('receipts-quick-scan')).toBeVisible();
 
-    // Viewer group (lacks quick-scan), flag still on -> the button is absent.
+    // Viewer group (lacks quick-scan), flag still on -> the entry is absent.
     await page.goto(`/receipts/group/${groupId}`);
+    await openReceiptsOverflowMenu(page);
     await expect(page.getByTestId('configure-columns')).toBeVisible();
     await expect(page.getByTestId('receipts-quick-scan')).toHaveCount(0);
   });

--- a/desktop/e2e/receipt-quick-date-filter.spec.ts
+++ b/desktop/e2e/receipt-quick-date-filter.spec.ts
@@ -1,0 +1,229 @@
+import { expect, test, type Page } from '@playwright/test';
+import { creds, stubTokenRefresh } from './helpers/auth';
+import {
+  apiCreateGroup,
+  apiCreateReceipt,
+  apiDeleteGroupById,
+  apiGetUserId,
+  uniqueName,
+  withAdminApi,
+} from './helpers/provisioning';
+import { gotoReceiptsTable } from './helpers/receipts-table';
+
+// The receipts table's quick date filter and its filter chips, end to end.
+//
+// The Jest specs cover the month<->filter translation and the chip labels
+// exhaustively, but they all run against a mocked store, so what only an e2e
+// can prove is the wire:
+//
+//   - a month written by the stepper is a BETWEEN the SERVER understands, so
+//     the table actually narrows to that month;
+//   - the filter survives a reload. ReceiptTableState is persisted to
+//     localStorage, which serializes every Date to an ISO string, so the
+//     stepper has to read a month back out of strings it never wrote. Get that
+//     wrong and the label silently degrades to "Custom" after every refresh —
+//     the single most likely bug in this feature;
+//   - the dialog and the chips share one filter, so a condition added in the
+//     dialog is clearable from a chip without disturbing the month.
+//
+// Runs as admin and seeds its own group so the month buckets contain exactly
+// this spec's receipts, whatever else the shared backend holds.
+
+test.use({ storageState: 'e2e/.auth/admin.json' });
+
+test.describe('Receipts quick date filter', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  const thisMonthReceipt = uniqueName('qdf-this');
+  const lastMonthReceipt = uniqueName('qdf-last');
+  const olderReceipt = uniqueName('qdf-older');
+
+  let group: { id: number; name: string };
+
+  /** An ISO date in the middle of the month [delta] months from now. */
+  function isoInMonth(delta: number): string {
+    const now = new Date();
+    return new Date(Date.UTC(now.getFullYear(), now.getMonth() + delta, 15)).toISOString();
+  }
+
+  function monthLabel(delta: number): string {
+    const now = new Date();
+    return new Date(now.getFullYear(), now.getMonth() + delta, 1).toLocaleString('en-US', {
+      month: 'long',
+      year: 'numeric',
+    });
+  }
+
+  const stepperLabel = (page: Page) => page.getByTestId('receipts-month-label');
+  const rowLink = (page: Page, name: string) => page.getByRole('link', { name });
+
+  test.beforeAll(async () => {
+    await withAdminApi(async (api) => {
+      const adminId = await apiGetUserId(api, creds('admin').username);
+      group = await apiCreateGroup(api, uniqueName('qdf-group'));
+
+      for (const [name, delta] of [
+        [thisMonthReceipt, 0],
+        [lastMonthReceipt, -1],
+        [olderReceipt, -2],
+      ] as const) {
+        await apiCreateReceipt(api, {
+          groupId: group.id,
+          paidByUserId: adminId,
+          name,
+          date: isoInMonth(delta),
+        });
+      }
+    });
+  });
+
+  test.afterAll(async () => {
+    await withAdminApi(async (api) => {
+      try {
+        await apiDeleteGroupById(api, String(group.id));
+      } catch {
+        // Best effort — a cleanup failure must not mask a real result.
+      }
+    });
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await stubTokenRefresh(page);
+  });
+
+  async function gotoSeededGroup(page: Page): Promise<void> {
+    await gotoReceiptsTable(page);
+    await page.goto(`/receipts/group/${group.id}`);
+    await expect(page.getByTestId('receipts-overflow-menu')).toBeVisible();
+  }
+
+  test('starts on All time with every receipt and no chips', async ({ page }) => {
+    await gotoSeededGroup(page);
+
+    await expect(stepperLabel(page)).toContainText('All time');
+    await expect(page.locator('[data-testid^="receipt-filter-chip-"]')).toHaveCount(0);
+
+    await expect(rowLink(page, thisMonthReceipt)).toBeVisible();
+    await expect(rowLink(page, lastMonthReceipt)).toBeVisible();
+    await expect(rowLink(page, olderReceipt)).toBeVisible();
+  });
+
+  test('narrows the table to a month and shows no duplicate date chip', async ({ page }) => {
+    await gotoSeededGroup(page);
+
+    await stepperLabel(page).click();
+    await page.getByTestId('month-stepper-this-month').click();
+
+    await expect(stepperLabel(page)).toContainText(monthLabel(0));
+    await expect(rowLink(page, thisMonthReceipt)).toBeVisible();
+    await expect(rowLink(page, lastMonthReceipt)).toHaveCount(0);
+    await expect(rowLink(page, olderReceipt)).toHaveCount(0);
+
+    // The stepper already names the month, so the Date chip stays suppressed…
+    await expect(page.getByTestId('receipt-filter-chip-date')).toHaveCount(0);
+    // …but it is still a filter, so the badge and the reset control show it.
+    await expect(page.getByTestId('receipts-filter-reset')).toBeVisible();
+  });
+
+  test('steps a month at a time', async ({ page }) => {
+    await gotoSeededGroup(page);
+
+    await stepperLabel(page).click();
+    await page.getByTestId('month-stepper-this-month').click();
+    await expect(stepperLabel(page)).toContainText(monthLabel(0));
+
+    await page.getByTestId('receipts-month-prev').click();
+
+    await expect(stepperLabel(page)).toContainText(monthLabel(-1));
+    await expect(rowLink(page, lastMonthReceipt)).toBeVisible();
+    await expect(rowLink(page, thisMonthReceipt)).toHaveCount(0);
+
+    await page.getByTestId('receipts-month-next').click();
+    await expect(stepperLabel(page)).toContainText(monthLabel(0));
+    await expect(rowLink(page, thisMonthReceipt)).toBeVisible();
+  });
+
+  // The filter is persisted, and JSON turns both Dates into ISO strings. If the
+  // month is only recognised on Date instances this reads "Custom" after the
+  // reload and the table silently keeps filtering by a month nothing names.
+  test('keeps the month across a reload', async ({ page }) => {
+    await gotoSeededGroup(page);
+
+    await stepperLabel(page).click();
+    await page.getByTestId('month-stepper-last-month').click();
+    await expect(stepperLabel(page)).toContainText(monthLabel(-1));
+
+    await page.reload();
+
+    await expect(stepperLabel(page)).toContainText(monthLabel(-1));
+    await expect(rowLink(page, lastMonthReceipt)).toBeVisible();
+    await expect(rowLink(page, thisMonthReceipt)).toHaveCount(0);
+  });
+
+  test('clears one dialog-set condition from its chip without losing the month', async ({
+    page,
+  }) => {
+    await gotoSeededGroup(page);
+
+    await stepperLabel(page).click();
+    await page.getByTestId('month-stepper-this-month').click();
+    await expect(stepperLabel(page)).toContainText(monthLabel(0));
+
+    // Add a second condition through the real filter dialog.
+    await page.getByTestId('receipts-filter').click();
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+    await dialog.getByLabel('Name').fill(thisMonthReceipt);
+    await dialog.getByTestId('dialog-submit-button').click();
+    await expect(dialog).toBeHidden();
+
+    const nameChip = page.getByTestId('receipt-filter-chip-name');
+    await expect(nameChip).toContainText(`Name contains ${thisMonthReceipt}`);
+    // Still only the one chip — the month is the stepper's to show.
+    await expect(page.getByTestId('receipt-filter-chip-date')).toHaveCount(0);
+
+    await page.getByTestId('receipt-filter-chip-clear-name').click();
+
+    await expect(nameChip).toHaveCount(0);
+    await expect(stepperLabel(page)).toContainText(monthLabel(0));
+    await expect(rowLink(page, thisMonthReceipt)).toBeVisible();
+  });
+
+  // A Date filter the stepper cannot express has to stay visible and clearable.
+  test('falls back to Custom with a date chip for a range that is not a month', async ({
+    page,
+  }) => {
+    await gotoSeededGroup(page);
+
+    await page.getByTestId('receipts-filter').click();
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+    await dialog.getByLabel('Operation').first().click();
+    await page.getByRole('option', { name: 'Within current month' }).click();
+    await dialog.getByTestId('dialog-submit-button').click();
+    await expect(dialog).toBeHidden();
+
+    await expect(stepperLabel(page)).toContainText('Custom');
+    await expect(page.getByTestId('receipt-filter-chip-date')).toContainText(
+      'Date within current month',
+    );
+
+    await page.getByTestId('receipt-filter-chip-clear-date').click();
+    await expect(stepperLabel(page)).toContainText('All time');
+  });
+
+  test('returns to all time from the panel', async ({ page }) => {
+    await gotoSeededGroup(page);
+
+    await stepperLabel(page).click();
+    await page.getByTestId('month-stepper-this-month').click();
+    await expect(rowLink(page, olderReceipt)).toHaveCount(0);
+
+    await stepperLabel(page).click();
+    await page.getByTestId('month-stepper-all-time').click();
+
+    await expect(stepperLabel(page)).toContainText('All time');
+    await expect(page.locator('[data-testid^="receipt-filter-chip-"]')).toHaveCount(0);
+    await expect(rowLink(page, olderReceipt)).toBeVisible();
+  });
+});

--- a/desktop/e2e/receipt-quick-date-filter.spec.ts
+++ b/desktop/e2e/receipt-quick-date-filter.spec.ts
@@ -40,18 +40,26 @@ test.describe('Receipts quick date filter', () => {
 
   let group: { id: number; name: string };
 
-  /** An ISO date in the middle of the month [delta] months from now. */
+  /**
+   * One instant for the whole suite. The seeded receipt dates, the expected
+   * labels and the browser's own clock all derive from it, so a run that
+   * crosses a month boundary cannot leave the app a month ahead of its fixture.
+   */
+  const REFERENCE_TIME = new Date();
+
+  /** An ISO date in the middle of the month [delta] months from the reference. */
   function isoInMonth(delta: number): string {
-    const now = new Date();
-    return new Date(Date.UTC(now.getFullYear(), now.getMonth() + delta, 15)).toISOString();
+    return new Date(
+      Date.UTC(REFERENCE_TIME.getFullYear(), REFERENCE_TIME.getMonth() + delta, 15),
+    ).toISOString();
   }
 
   function monthLabel(delta: number): string {
-    const now = new Date();
-    return new Date(now.getFullYear(), now.getMonth() + delta, 1).toLocaleString('en-US', {
-      month: 'long',
-      year: 'numeric',
-    });
+    return new Date(
+      REFERENCE_TIME.getFullYear(),
+      REFERENCE_TIME.getMonth() + delta,
+      1,
+    ).toLocaleString('en-US', { month: 'long', year: 'numeric' });
   }
 
   const stepperLabel = (page: Page) => page.getByTestId('receipts-month-label');
@@ -89,6 +97,12 @@ test.describe('Receipts quick date filter', () => {
 
   test.beforeEach(async ({ page }) => {
     await stubTokenRefresh(page);
+    // Pin the app's clock to the same instant. The component reads its own
+    // new Date() for This month / Last month and for an arrow press with
+    // nothing selected, so a spec-side reference alone would still disagree
+    // with it across a month boundary. setFixedTime only changes what Date
+    // returns — timers keep running, so animations are unaffected.
+    await page.clock.setFixedTime(REFERENCE_TIME);
   });
 
   async function gotoSeededGroup(page: Page): Promise<void> {
@@ -209,6 +223,69 @@ test.describe('Receipts quick date filter', () => {
     );
 
     await page.getByTestId('receipt-filter-chip-clear-date').click();
+    await expect(stepperLabel(page)).toContainText('All time');
+  });
+
+  // The panel is a dialog, not a menu. Under the mat-menu it was mouse-only:
+  // with no mat-menu-items the key manager was empty so arrows did nothing, and
+  // ListKeyManager turns Tab into tabOut, which MatMenu wires to close — so Tab
+  // dismissed the panel instead of entering it.
+  test('is operable by keyboard and returns focus to the trigger', async ({ page }) => {
+    await gotoSeededGroup(page);
+
+    await stepperLabel(page).locator('button').focus();
+    await page.keyboard.press('Enter');
+    await expect(page.getByRole('dialog', { name: 'Filter by month' })).toBeVisible();
+
+    // Tab must move INTO the panel, not close it.
+    await page.keyboard.press('Tab');
+    await expect(page.getByRole('dialog', { name: 'Filter by month' })).toBeVisible();
+    expect(
+      await page.evaluate(() => !!document.activeElement?.closest('[role="dialog"]')),
+    ).toBe(true);
+
+    // Reach a month button by keyboard and pick it.
+    await page.getByTestId('month-stepper-month-0').focus();
+    await page.keyboard.press('Enter');
+
+    await expect(page.getByRole('dialog', { name: 'Filter by month' })).toBeHidden();
+    await expect(stepperLabel(page)).toContainText('January');
+
+    // The focus trap hands focus back to the control that opened it.
+    expect(
+      await page.evaluate(
+        () => document.activeElement?.closest('[data-testid]')?.getAttribute('data-testid'),
+      ),
+    ).toEqual('receipts-month-label');
+  });
+
+  test('closes on Escape without changing the filter', async ({ page }) => {
+    await gotoSeededGroup(page);
+
+    await stepperLabel(page).click();
+    await expect(page.getByRole('dialog', { name: 'Filter by month' })).toBeVisible();
+
+    await page.keyboard.press('Escape');
+
+    await expect(page.getByRole('dialog', { name: 'Filter by month' })).toBeHidden();
+    await expect(stepperLabel(page)).toContainText('All time');
+  });
+
+  // Paging the year used to need a stopPropagation hack, because a mat-menu
+  // closes on any click inside it.
+  test('stays open while paging the year', async ({ page }) => {
+    await gotoSeededGroup(page);
+
+    await stepperLabel(page).click();
+    const year = await page.getByTestId('month-stepper-year').textContent();
+
+    await page.getByTestId('month-stepper-year-prev').click();
+
+    await expect(page.getByRole('dialog', { name: 'Filter by month' })).toBeVisible();
+    await expect(page.getByTestId('month-stepper-year')).toHaveText(
+      String(Number(year) - 1),
+    );
+    // Paging is a view concern — it must not have written a filter.
     await expect(stepperLabel(page)).toContainText('All time');
   });
 

--- a/desktop/src/constants/filter-operations-options.constant.ts
+++ b/desktop/src/constants/filter-operations-options.constant.ts
@@ -19,3 +19,17 @@ export const textOperationOptions = Object.values(FilterOperation).filter(
 export const usersOperationOptions = Object.values(FilterOperation).filter(
   (k) => k === "CONTAINS" && k !== FilterOperation.WithinCurrentMonth && !!k
 );
+
+/**
+ * Human-readable label per operation. Shared by the filter dialog's Operation
+ * select (via `OperationsPipe`) and the filter chips, so both read a condition
+ * the same way.
+ */
+export const FILTER_OPERATION_DISPLAY_VALUES: { [key: string]: string } = {
+  [FilterOperation.Contains]: "Contains",
+  [FilterOperation.Equals]: "Equals",
+  [FilterOperation.GreaterThan]: "Greater than",
+  [FilterOperation.LessThan]: "Less than",
+  [FilterOperation.Between]: "Between",
+  [FilterOperation.WithinCurrentMonth]: "Within current month",
+};

--- a/desktop/src/constants/index.ts
+++ b/desktop/src/constants/index.ts
@@ -2,5 +2,6 @@ export * from './components.constant';
 export * from './dialog.constant';
 export * from './filter-operations-options.constant';
 export * from './keyboard-shortcuts.constant';
+export * from './receipt-filter-fields.constant';
 export * from './receipt-status-options';
 export * from './snackbar.constant';

--- a/desktop/src/constants/receipt-filter-fields.constant.ts
+++ b/desktop/src/constants/receipt-filter-fields.constant.ts
@@ -1,0 +1,35 @@
+import { ReceiptPagedRequestFilter } from "../open-api";
+
+export type ReceiptFilterFieldKey = keyof ReceiptPagedRequestFilter;
+
+/**
+ * The operation-option bucket a field belongs to. Matches the `type` argument
+ * `OperationsPipe` switches on, so a field's operations and its label come from
+ * the same place.
+ */
+export type ReceiptFilterFieldType = "date" | "text" | "number" | "list" | "users";
+
+export interface ReceiptFilterField {
+  key: ReceiptFilterFieldKey;
+  label: string;
+  type: ReceiptFilterFieldType;
+}
+
+/**
+ * The ten filterable receipt fields, in the order the filter dialog renders
+ * them. This is the single definition of a field's label and type — the dialog's
+ * auto-operation wiring and the filter chips both read it, so a chip can never
+ * disagree with the row that produced it.
+ */
+export const RECEIPT_FILTER_FIELDS: readonly ReceiptFilterField[] = [
+  { key: "date", label: "Date", type: "date" },
+  { key: "name", label: "Name", type: "text" },
+  { key: "paidBy", label: "Paid by", type: "users" },
+  { key: "group", label: "Group", type: "list" },
+  { key: "amount", label: "Amount", type: "number" },
+  { key: "categories", label: "Categories", type: "list" },
+  { key: "tags", label: "Tags", type: "list" },
+  { key: "status", label: "Status", type: "list" },
+  { key: "resolvedDate", label: "Resolved Date", type: "date" },
+  { key: "createdAt", label: "Added At", type: "date" },
+];

--- a/desktop/src/receipts/quick-scan-dialog/open-quick-scan-dialog.spec.ts
+++ b/desktop/src/receipts/quick-scan-dialog/open-quick-scan-dialog.spec.ts
@@ -1,0 +1,42 @@
+import { MatDialog } from "@angular/material/dialog";
+import { of } from "rxjs";
+import { DEFAULT_DIALOG_CONFIG } from "../../constants";
+import { openQuickScanDialog } from "./open-quick-scan-dialog";
+import { QuickScanDialogComponent } from "./quick-scan-dialog.component";
+
+describe("openQuickScanDialog", () => {
+  // A plain function over MatDialog — no TestBed needed, and a double keeps the
+  // real dialog (and its whole component tree) out of the test.
+  function dialogDouble(afterClosed = of(undefined)) {
+    return {
+      open: jest.fn().mockReturnValue({ afterClosed: () => afterClosed }),
+    } as unknown as MatDialog;
+  }
+
+  it("opens the quick scan dialog with the shared dialog config", () => {
+    const matDialog = dialogDouble();
+
+    openQuickScanDialog(matDialog);
+
+    expect(matDialog.open).toHaveBeenCalledTimes(1);
+    expect(matDialog.open).toHaveBeenCalledWith(
+      QuickScanDialogComponent,
+      DEFAULT_DIALOG_CONFIG
+    );
+  });
+
+  // Both call sites (the icon button and the receipts-table overflow item)
+  // refetch off this observable, so it has to be the dialog's own afterClosed.
+  it("returns the dialog's afterClosed observable", (done) => {
+    const afterClosed = of("closed");
+    const matDialog = dialogDouble(afterClosed as any);
+
+    const result = openQuickScanDialog(matDialog);
+
+    expect(result).toBe(afterClosed);
+    result.subscribe((value) => {
+      expect(value).toEqual("closed");
+      done();
+    });
+  });
+});

--- a/desktop/src/receipts/quick-scan-dialog/open-quick-scan-dialog.ts
+++ b/desktop/src/receipts/quick-scan-dialog/open-quick-scan-dialog.ts
@@ -1,0 +1,17 @@
+import { MatDialog } from "@angular/material/dialog";
+import { Observable } from "rxjs";
+import { DEFAULT_DIALOG_CONFIG } from "../../constants";
+import { QuickScanDialogComponent } from "./quick-scan-dialog.component";
+
+/**
+ * Opens the Quick Scan dialog and emits once it closes.
+ *
+ * Shared by the `app-quick-scan-button` icon button and the receipts table's
+ * overflow-menu item, which cannot reuse that component: `MatMenu` collects its
+ * items with a **content** query, and a `mat-menu-item` rendered inside another
+ * component's template is a view child of that component, so the menu would
+ * never see it and keyboard navigation would skip the entry.
+ */
+export function openQuickScanDialog(matDialog: MatDialog): Observable<unknown> {
+  return matDialog.open(QuickScanDialogComponent, DEFAULT_DIALOG_CONFIG).afterClosed();
+}

--- a/desktop/src/receipts/receipts-table/receipts-table.component.html
+++ b/desktop/src/receipts/receipts-table/receipts-table.component.html
@@ -2,7 +2,7 @@
   [headerText]="headerText"
   subtitle="View, filter, and manage this group's receipts."
 >
-  <div class="d-flex align-items-center">
+  <div class="d-flex align-items-center receipts-toolbar">
     <app-add-button
       *ngIf="canCreate"
       class="me-2"
@@ -11,21 +11,18 @@
       tooltip="Add Receipt"
       [buttonRouterLink]="['/receipts/add']"
     ></app-add-button>
-    <app-quick-scan-button
-      *ngIf="canQuickScan"
-      data-testid="receipts-quick-scan"
+
+    <app-month-stepper
       class="me-2"
-      (afterClosed)="getFilteredReceipts()"
-    >
-    </app-quick-scan-button>
-    @if (dataSource().data.length > 0) {
-      <app-export-button
-        [groupId]="groupId"
-        [filter]="filter() ?? undefined"
-      ></app-export-button>
-    }
+      [value]="stepperMonth()"
+      [label]="stepperLabel()"
+      (monthSelected)="monthSelected($event)"
+      (allTimeSelected)="allTimeSelected()"
+    ></app-month-stepper>
+
     <app-button
       class="me-2 filter-button"
+      data-testid="receipts-filter"
       icon="filter_alt"
       matButtonType="iconButton"
       tooltip="Filter Receipts"
@@ -35,61 +32,113 @@
       (clicked)="filterButtonClicked()"
     ></app-button>
     <app-button
-      class="me-2"
-      data-testid="configure-columns"
-      icon="view_column"
-      matButtonType="iconButton"
-      tooltip="Configure Columns"
-      color="accent"
-      (clicked)="configureColumnsButtonClicked()"
-    ></app-button>
-    <app-button
       *ngIf="(numFiltersApplied() ?? 0) > 0"
       @fadeInOut
       class="me-2"
+      data-testid="receipts-filter-reset"
       icon="restart_alt"
       matButtonType="iconButton"
       tooltip="Reset filter"
       color="accent"
       (clicked)="resetFilterButtonClicked()"
     ></app-button>
-    <ng-container *ngIf="canPollEmail && group?.groupSettings?.emailIntegrationEnabled">
-      <app-button
-        *appFeature="'aiPoweredReceipts'"
-        class="me-2"
-        icon="mail"
-        matButtonType="iconButton"
-        tooltip="Poll email(s)"
-        color="accent"
-        matBadgeColor="accent"
-        (clicked)="pollEmail()"
-      ></app-button>
-    </ng-container>
 
     @if (selectedReceiptIds().length > 1) {
       <app-queue-start-menu
+        class="me-2"
         buttonText="Start Queue"
         color="accent"
         [receiptIds]="selectedReceiptIds()"
       ></app-queue-start-menu>
     }
 
-    @if (selectedReceiptIds().length > 0) {
-      <app-button
-        matButtonType="iconButton"
-        icon="more_vert"
-        color="accent"
-        [matMenuTriggerFor]="menu"
-      ></app-button>
+    <app-button
+      data-testid="receipts-overflow-menu"
+      matButtonType="iconButton"
+      icon="more_vert"
+      tooltip="More actions"
+      color="accent"
+      [matMenuTriggerFor]="overflowMenu"
+    ></app-button>
 
-      <mat-menu #menu="matMenu">
-        <button mat-menu-item (click)="exportSelectedReceipts()">Export Selected Receipts</button>
+    <!--
+      Every item here is a plain button: MatMenu collects its items with a
+      content query, so a mat-menu-item rendered inside a child component's
+      template (app-quick-scan-button, app-export-button) would be invisible to
+      the menu and skipped by keyboard navigation. The behaviour behind each one
+      still lives in a shared place — openQuickScanDialog and
+      ReceiptExportService.
+    -->
+    <mat-menu #overflowMenu="matMenu">
+      @if (canQuickScan) {
+        <button
+          *appFeature="'aiPoweredReceipts'"
+          mat-menu-item
+          data-testid="receipts-quick-scan"
+          (click)="quickScanClicked()"
+        >
+          <mat-icon>receipt_long</mat-icon>
+          <span>Quick Scan</span>
+        </button>
+      }
+
+      @if (dataSource().data.length > 0) {
+        <button
+          mat-menu-item
+          data-testid="receipts-export-all"
+          (click)="exportAllReceipts()"
+        >
+          <mat-icon>download</mat-icon>
+          <span>Export all receipts</span>
+        </button>
+      }
+
+      <button
+        mat-menu-item
+        data-testid="configure-columns"
+        (click)="configureColumnsButtonClicked()"
+      >
+        <mat-icon>view_column</mat-icon>
+        <span>Configure Columns</span>
+      </button>
+
+      <ng-container *ngIf="canPollEmail && group?.groupSettings?.emailIntegrationEnabled">
+        <button
+          *appFeature="'aiPoweredReceipts'"
+          mat-menu-item
+          data-testid="receipts-poll-email"
+          (click)="pollEmail()"
+        >
+          <mat-icon>mail</mat-icon>
+          <span>Poll email(s)</span>
+        </button>
+      </ng-container>
+
+      @if (selectedReceiptIds().length > 0) {
+        <div class="receipts-overflow-menu__label" role="presentation">
+          {{ selectedReceiptIds().length }} selected
+        </div>
+        <button
+          mat-menu-item
+          data-testid="receipts-export-selected"
+          (click)="exportSelectedReceipts()"
+        >
+          <mat-icon>file_upload</mat-icon>
+          <span>Export Selected Receipts</span>
+        </button>
 
         @if (canEdit) {
-          <button mat-menu-item (click)="showStatusUpdateDialog()">Bulk Status Update</button>
+          <button
+            mat-menu-item
+            data-testid="receipts-bulk-status"
+            (click)="showStatusUpdateDialog()"
+          >
+            <mat-icon>fact_check</mat-icon>
+            <span>Bulk Status Update</span>
+          </button>
         }
-      </mat-menu>
-    }
+      }
+    </mat-menu>
   </div>
 </app-table-header>
 <app-summary-card
@@ -99,6 +148,27 @@
   [receiptIds]="selectedReceiptIds()"
   [groupId]="selectedGroupId() ?? ''"
 ></app-summary-card>
+
+@if (filterChips().length > 0) {
+  <mat-chip-set class="receipt-filter-chips" aria-label="Applied filters">
+    @for (chip of filterChips(); track chip.key) {
+      <mat-chip
+        [attr.data-testid]="'receipt-filter-chip-' + chip.key"
+        (removed)="filterChipCleared(chip.key)"
+      >
+        {{ chip.label }}
+        <button
+          matChipRemove
+          [attr.data-testid]="'receipt-filter-chip-clear-' + chip.key"
+          [attr.aria-label]="'Remove ' + chip.label + ' filter'"
+        >
+          <mat-icon>cancel</mat-icon>
+        </button>
+      </mat-chip>
+    }
+  </mat-chip-set>
+}
+
 <div class="table-container">
   <app-table
     [columns]="columns()"

--- a/desktop/src/receipts/receipts-table/receipts-table.component.scss
+++ b/desktop/src/receipts/receipts-table/receipts-table.component.scss
@@ -16,6 +16,8 @@ app-receipts-table {
 
   .receipt-filter-chips {
     display: block;
+    // app-table-header owns the gap below itself, so only close the gap to the
+    // table here.
     margin-bottom: variables.$spacing-md;
   }
 }

--- a/desktop/src/receipts/receipts-table/receipts-table.component.scss
+++ b/desktop/src/receipts/receipts-table/receipts-table.component.scss
@@ -1,5 +1,34 @@
+@use "sass:map";
+@use "../../variables.scss" as variables;
+
 app-receipts-table {
   .filter-button button .mat-badge-content {
     color: white;
   }
+
+  // The toolbar now carries the month stepper as well, so let it wrap on narrow
+  // viewports rather than pushing the header out of the page.
+  .receipts-toolbar {
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    row-gap: variables.$spacing-xs;
+  }
+
+  .receipt-filter-chips {
+    display: block;
+    margin-bottom: variables.$spacing-md;
+  }
+}
+
+// The overflow menu renders in a CDK overlay, outside app-receipts-table, so
+// this rule cannot live inside the host block above.
+.receipts-overflow-menu__label {
+  padding: variables.$spacing-sm variables.$spacing-md variables.$spacing-xs;
+  margin-top: variables.$spacing-xs;
+  border-top: 1px solid map.get(variables.$accent-palette, 200);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: map.get(variables.$accent-palette, 400);
 }

--- a/desktop/src/receipts/receipts-table/receipts-table.component.spec.ts
+++ b/desktop/src/receipts/receipts-table/receipts-table.component.spec.ts
@@ -1,18 +1,23 @@
 import { provideHttpClientTesting } from "@angular/common/http/testing";
-import { CUSTOM_ELEMENTS_SCHEMA } from "@angular/core";
+import { CUSTOM_ELEMENTS_SCHEMA, provideZonelessChangeDetection } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { ReactiveFormsModule } from "@angular/forms";
+import { MatChipsModule } from "@angular/material/chips";
 import { MatDialogModule } from "@angular/material/dialog";
+import { MatMenuModule } from "@angular/material/menu";
 import { MatSnackBarModule } from "@angular/material/snack-bar";
 import { MatTooltipModule } from "@angular/material/tooltip";
-import { ActivatedRoute } from "@angular/router";
+import { ActivatedRoute, provideRouter } from "@angular/router";
 import { NgxsModule, Store } from "@ngxs/store";
 import { of } from "rxjs";
 import { PipesModule } from "src/pipes/pipes.module";
 import { ReceiptTableState } from "src/store/receipt-table.state";
-import { ApiModule, Permission, Receipt } from "../../open-api";
-import { AuthState } from "../../store";
+import { MonthStepperComponent } from "../../shared-ui/month-stepper/month-stepper.component";
+import { ApiModule, FilterOperation, Permission, Receipt, ReceiptStatus } from "../../open-api";
+import { ReceiptFilterService } from "../../services/receipt-filter.service";
+import { AuthState, GroupState, UserState } from "../../store";
 import { SetPermissions } from "../../store/auth.state.actions";
+import { SetReceiptFilter } from "../../store/receipt-table.actions";
 import { ReceiptsTableComponent } from "./receipts-table.component";
 import { provideHttpClient, withInterceptorsFromDi } from "@angular/common/http";
 
@@ -26,11 +31,14 @@ describe("ReceiptsTableComponent", () => {
     declarations: [ReceiptsTableComponent],
     schemas: [CUSTOM_ELEMENTS_SCHEMA],
     imports: [ApiModule,
-        NgxsModule.forRoot([ReceiptTableState, AuthState]),
+        NgxsModule.forRoot([ReceiptTableState, AuthState, GroupState, UserState]),
         ReactiveFormsModule,
         MatSnackBarModule,
         MatTooltipModule,
         MatDialogModule,
+        MatMenuModule,
+        MatChipsModule,
+        MonthStepperComponent,
         PipesModule],
     providers: [
         {
@@ -46,6 +54,8 @@ describe("ReceiptsTableComponent", () => {
         },
         provideHttpClient(withInterceptorsFromDi()),
         provideHttpClientTesting(),
+        provideZonelessChangeDetection(),
+        provideRouter([]),
     ]
 }).compileComponents();
 
@@ -122,5 +132,104 @@ describe("ReceiptsTableComponent", () => {
     component.ngAfterViewInit();
 
     expect(component.selectedReceiptIds()).toEqual([1, 2]);
+  });
+  describe("quick date filtering and filter chips", () => {
+    let refetch: jest.SpyInstance;
+
+    const setFilter = (filter: Record<string, unknown>) =>
+      store.dispatch(new SetReceiptFilter(filter as any));
+
+    beforeEach(() => {
+      refetch = jest
+        .spyOn(TestBed.inject(ReceiptFilterService), "getPagedReceiptsForGroups")
+        .mockReturnValue(of({ data: [], totalCount: 0 } as any));
+    });
+
+    it("reads All time with no date filter", () => {
+      expect(component.stepperMonth()).toBeNull();
+      expect(component.stepperLabel()).toEqual("All time");
+    });
+
+    it("writes the picked month as a BETWEEN over the whole month", () => {
+      component.monthSelected({ year: 2026, month: 8 });
+
+      const date = (store.selectSnapshot(ReceiptTableState.filterData).filter as any).date;
+      const [start, end] = date.value as Date[];
+      expect(date.operation).toEqual(FilterOperation.Between);
+      expect(start.getMonth()).toEqual(8);
+      expect(start.getDate()).toEqual(1);
+      expect(end.getDate()).toEqual(30);
+
+      expect(component.stepperLabel()).toEqual("September 2026");
+      expect(store.selectSnapshot(ReceiptTableState.page)).toEqual(1);
+      expect(refetch).toHaveBeenCalled();
+    });
+
+    // The quick control IS the date filter, so it replaces whatever was there.
+    it("overrides an existing date filter rather than sitting beside it", () => {
+      setFilter({ date: { operation: FilterOperation.GreaterThan, value: new Date(2020, 0, 1) } });
+
+      component.monthSelected({ year: 2026, month: 8 });
+
+      const date = (store.selectSnapshot(ReceiptTableState.filterData).filter as any).date;
+      expect(date.operation).toEqual(FilterOperation.Between);
+    });
+
+    it("clears the date filter for all time", () => {
+      component.monthSelected({ year: 2026, month: 8 });
+      component.allTimeSelected();
+
+      expect(component.stepperLabel()).toEqual("All time");
+      expect(component.filterChips()).toEqual([]);
+    });
+
+    // A date filter the stepper cannot express stays visible as a chip so it can
+    // still be seen and cleared.
+    it("reads Custom and shows a date chip for a filter it cannot express", () => {
+      setFilter({ date: { operation: FilterOperation.WithinCurrentMonth, value: null } });
+
+      expect(component.stepperMonth()).toBeNull();
+      expect(component.stepperLabel()).toEqual("Custom");
+      expect(component.filterChips()).toEqual([
+        { key: "date", label: "Date within current month" },
+      ]);
+    });
+
+    it("never shows a date chip for the month the stepper is already showing", () => {
+      component.monthSelected({ year: 2026, month: 8 });
+
+      expect(component.filterChips()).toEqual([]);
+    });
+
+    it("builds a chip per active field, resolving ids to names", () => {
+      component.categories.set([{ id: 3, name: "Groceries" }] as any);
+      setFilter({
+        name: { operation: FilterOperation.Contains, value: "whole" },
+        categories: { operation: FilterOperation.Contains, value: [3] },
+        status: { operation: FilterOperation.Contains, value: [ReceiptStatus.Open] },
+      });
+
+      expect(component.filterChips()).toEqual([
+        { key: "name", label: "Name contains whole" },
+        { key: "categories", label: "Categories contains Groceries" },
+        { key: "status", label: "Status contains Open" },
+      ]);
+    });
+
+    it("clears exactly the field whose chip was dismissed", () => {
+      setFilter({
+        name: { operation: FilterOperation.Contains, value: "whole" },
+        status: { operation: FilterOperation.Contains, value: [ReceiptStatus.Open] },
+      });
+
+      component.filterChipCleared("status");
+
+      const filter = store.selectSnapshot(ReceiptTableState.filterData).filter as any;
+      expect(filter.status).toEqual({ operation: null, value: [] });
+      expect(filter.name).toEqual({ operation: FilterOperation.Contains, value: "whole" });
+      expect(component.filterChips().map((chip) => chip.key)).toEqual(["name"]);
+      expect(store.selectSnapshot(ReceiptTableState.page)).toEqual(1);
+      expect(refetch).toHaveBeenCalled();
+    });
   });
 });

--- a/desktop/src/receipts/receipts-table/receipts-table.component.spec.ts
+++ b/desktop/src/receipts/receipts-table/receipts-table.component.spec.ts
@@ -9,7 +9,7 @@ import { MatSnackBarModule } from "@angular/material/snack-bar";
 import { MatTooltipModule } from "@angular/material/tooltip";
 import { ActivatedRoute, provideRouter } from "@angular/router";
 import { NgxsModule, Store } from "@ngxs/store";
-import { of } from "rxjs";
+import { of, Subject, throwError } from "rxjs";
 import { PipesModule } from "src/pipes/pipes.module";
 import { ReceiptTableState } from "src/store/receipt-table.state";
 import { MonthStepperComponent } from "../../shared-ui/month-stepper/month-stepper.component";
@@ -214,6 +214,39 @@ describe("ReceiptsTableComponent", () => {
         { key: "categories", label: "Categories contains Groceries" },
         { key: "status", label: "Status contains Open" },
       ]);
+    });
+
+    // Each refresh used to be its own subscription, so the last RESPONSE won
+    // rather than the last REQUEST — and the quick date arrows are one click
+    // apart, which is what makes this reachable.
+    it("lets a newer refresh supersede an in-flight one", () => {
+      const superseded = new Subject<any>();
+      const latest = new Subject<any>();
+      refetch.mockReturnValueOnce(superseded).mockReturnValueOnce(latest);
+
+      component.monthSelected({ year: 2026, month: 8 });
+      component.monthSelected({ year: 2026, month: 9 });
+
+      // The first request resolving late must not repaint the table.
+      superseded.next({ data: [{ id: 1 }], totalCount: 1 });
+      expect(component.totalCount()).toEqual(0);
+
+      latest.next({ data: [{ id: 2 }], totalCount: 2 });
+      expect(component.totalCount()).toEqual(2);
+    });
+
+    // switchMap completes the outer stream on an error unless the inner one
+    // swallows it, which would silently kill every refresh after the first
+    // failure.
+    it("keeps refreshing after a failed request", () => {
+      refetch.mockReturnValueOnce(throwError(() => new Error("boom")));
+
+      component.monthSelected({ year: 2026, month: 8 });
+
+      refetch.mockReturnValue(of({ data: [{ id: 3 }], totalCount: 3 }));
+      component.monthSelected({ year: 2026, month: 9 });
+
+      expect(component.totalCount()).toEqual(3);
     });
 
     it("clears exactly the field whose chip was dismissed", () => {

--- a/desktop/src/receipts/receipts-table/receipts-table.component.ts
+++ b/desktop/src/receipts/receipts-table/receipts-table.component.ts
@@ -1,3 +1,4 @@
+import { CurrencyPipe, DatePipe } from "@angular/common";
 import { AfterViewInit, Component, computed, OnInit, signal, TemplateRef, ViewEncapsulation, viewChild } from "@angular/core";
 import { MatDialog } from "@angular/material/dialog";
 import { PageEvent } from "@angular/material/paginator";
@@ -10,7 +11,7 @@ import { map, take, tap } from "rxjs";
 import { fadeInOut } from "src/animations";
 import { ReceiptFilterService } from "src/services/receipt-filter.service";
 import { ConfirmationDialogComponent } from "src/shared-ui/confirmation-dialog/confirmation-dialog.component";
-import { ResetReceiptFilter, SetColumnConfig, SetPage, SetPageSize, SetReceiptFilterData, } from "src/store/receipt-table.actions";
+import { ResetReceiptFilter, SetColumnConfig, SetPage, SetPageSize, SetReceiptFilterData, SetReceiptFilterField, } from "src/store/receipt-table.actions";
 import { ReceiptTableState } from "src/store/receipt-table.state";
 import { TableColumn } from "src/table/table-column.interface";
 import { TableComponent } from "src/table/table/table.component";
@@ -19,11 +20,13 @@ import { ReceiptTableColumnConfig } from "../../interfaces";
 import {
   BulkStatusUpdateCommand,
   Category,
+  FilterOperation,
   Group,
   GroupsService,
   PagedDataDataInner,
   Permission,
   Receipt,
+  ReceiptPagedRequestFilter,
   ReceiptService,
   ReceiptStatus,
   Tag,
@@ -31,9 +34,14 @@ import {
 import { SnackbarService } from "../../services";
 import { ReceiptExportService } from "../../services/receipt-export.service";
 import { ReceiptFilterComponent } from "../../shared-ui/receipt-filter/receipt-filter.component";
-import { AuthState, GroupState } from "../../store";
+import { AuthState, GroupState, UserState } from "../../store";
+import { CustomCurrencyPipe } from "../../pipes/custom-currency.pipe";
 import { applyFormCommand } from "../../utils/index";
+import { FilterMonth, monthFilterEntry, monthFromFilterEntry } from "../../utils/receipt-date-filter";
 import { buildReceiptFilterForm } from "../../utils/receipt-filter";
+import { buildReceiptFilterChips, ReceiptFilterChip } from "../../utils/receipt-filter-chips";
+import { isFilterEntryActive } from "../../utils/receipt-filter-entry";
+import { openQuickScanDialog } from "../quick-scan-dialog/open-quick-scan-dialog";
 import { BulkStatusUpdateComponent } from "../bulk-resolve-dialog/bulk-status-update-dialog.component";
 import { ColumnConfigurationDialogComponent } from "../column-configuration-dialog/column-configuration-dialog.component";
 
@@ -45,6 +53,10 @@ import { ColumnConfigurationDialogComponent } from "../column-configuration-dial
   animations: [fadeInOut],
   encapsulation: ViewEncapsulation.None,
   host: DEFAULT_HOST_CLASS,
+  // The chip labels are built in TS rather than the template, so the formatting
+  // pipes are injected. CustomCurrencyPipe is declared in PipesModule and needs
+  // CurrencyPipe, neither of which is providedIn: "root".
+  providers: [CurrencyPipe, CustomCurrencyPipe, DatePipe],
   standalone: false
 })
 export class ReceiptsTableComponent implements OnInit, AfterViewInit {
@@ -58,6 +70,8 @@ export class ReceiptsTableComponent implements OnInit, AfterViewInit {
     private router: Router,
     private snackbarService: SnackbarService,
     private store: Store,
+    private customCurrencyPipe: CustomCurrencyPipe,
+    private datePipe: DatePipe,
   ) {}
 
   readonly createdAtCell = viewChild.required<TemplateRef<any>>("createdAtCell");
@@ -92,6 +106,55 @@ export class ReceiptsTableComponent implements OnInit, AfterViewInit {
 
   public selectedGroupId = this.store.selectSignal(GroupState.selectedGroupId);
 
+  private groups = this.store.selectSignal(GroupState.groups);
+
+  private users = this.store.selectSignal(UserState.users);
+
+  private receiptFilter = computed(
+    () => this.filter()?.filter as ReceiptPagedRequestFilter | undefined
+  );
+
+  /**
+   * The month the quick date control is showing, or null when the Date filter
+   * is unset or is something a month cannot express.
+   */
+  public stepperMonth = computed(() => monthFromFilterEntry(this.receiptFilter()?.date));
+
+  public stepperLabel = computed(() => {
+    const month = this.stepperMonth();
+    if (month) {
+      return this.datePipe.transform(new Date(month.year, month.month, 1), "LLLL y") ?? "";
+    }
+
+    // A Date filter the stepper cannot describe still has to be visible as a
+    // filter — the chip beside it spells out what it actually is.
+    return isFilterEntryActive(this.receiptFilter()?.date) ? "Custom" : "All time";
+  });
+
+  public filterChips = computed<ReceiptFilterChip[]>(() => {
+    const categories = this.categories();
+    const tags = this.tags();
+    const groups = this.groups();
+    const users = this.users();
+
+    return buildReceiptFilterChips(
+      this.receiptFilter(),
+      {
+        categories,
+        tags,
+        // Not groupsWithoutAll: a group filter set on the All Groups view is
+        // persisted, so it can outlive the view that offers the control and
+        // still has to name itself here.
+        groups,
+        users,
+        formatDate: (value) => this.datePipe.transform(value as string) ?? "",
+        formatCurrency: (value) => this.customCurrencyPipe.transform(value as number),
+      },
+      // The stepper already says "September 2026", so don't say it twice.
+      this.stepperMonth() ? ["date"] : []
+    );
+  });
+
   private numFiltersAppliedRaw = this.store.selectSignal(ReceiptTableState.numFiltersApplied);
 
   public numFiltersApplied = computed(() => {
@@ -99,9 +162,9 @@ export class ReceiptsTableComponent implements OnInit, AfterViewInit {
     return num > 0 ? num : undefined;
   });
 
-  public categories: Category[] = [];
+  public categories = signal<Category[]>([]);
 
-  public tags: Tag[] = [];
+  public tags = signal<Tag[]>([]);
 
   public groupId: string = "0";
 
@@ -143,12 +206,16 @@ export class ReceiptsTableComponent implements OnInit, AfterViewInit {
     // Filter options come from the selected group's AppData catalog (filtered to
     // the user's grants), so a restricted user can't filter by a hidden one.
     const numericGroupId = Number(this.groupId);
-    this.categories = Number.isNaN(numericGroupId)
-      ? []
-      : this.store.selectSnapshot(AuthState.groupCategories(numericGroupId));
-    this.tags = Number.isNaN(numericGroupId)
-      ? []
-      : this.store.selectSnapshot(AuthState.groupTags(numericGroupId));
+    this.categories.set(
+      Number.isNaN(numericGroupId)
+        ? []
+        : this.store.selectSnapshot(AuthState.groupCategories(numericGroupId))
+    );
+    this.tags.set(
+      Number.isNaN(numericGroupId)
+        ? []
+        : this.store.selectSnapshot(AuthState.groupTags(numericGroupId))
+    );
     this.getInitialData();
   }
 
@@ -338,8 +405,8 @@ export class ReceiptsTableComponent implements OnInit, AfterViewInit {
       maxWidth: "100%",
     });
 
-    dialogRef.componentInstance.categories = this.categories;
-    dialogRef.componentInstance.tags = this.tags;
+    dialogRef.componentInstance.categories = this.categories();
+    dialogRef.componentInstance.tags = this.tags();
     dialogRef.componentInstance.parentForm = buildReceiptFilterForm(filter, this);
     dialogRef.componentInstance.headerText = "Filter Receipts";
     // The group filter is only meaningful on the "All groups" view; a
@@ -363,6 +430,46 @@ export class ReceiptsTableComponent implements OnInit, AfterViewInit {
         })
       )
       .subscribe();
+  }
+
+  public monthSelected(month: FilterMonth): void {
+    // The quick control IS the Date filter, so it overwrites whatever was there.
+    this.applyFilterField("date", monthFilterEntry(month) as any);
+  }
+
+  public allTimeSelected(): void {
+    this.applyFilterField("date", null);
+  }
+
+  public filterChipCleared(field: keyof ReceiptPagedRequestFilter): void {
+    this.applyFilterField(field, null);
+  }
+
+  /**
+   * The one write path for a single-field filter change, so the page reset and
+   * the refetch can never be forgotten — narrowing a filter while on page 7
+   * would otherwise land on an empty page.
+   */
+  private applyFilterField(
+    field: keyof ReceiptPagedRequestFilter,
+    entry: { operation: FilterOperation | null; value: unknown } | null
+  ): void {
+    this.store.dispatch(new SetReceiptFilterField(field, entry));
+    this.store.dispatch(new SetPage(1));
+    this.getFilteredReceipts();
+  }
+
+  public quickScanClicked(): void {
+    openQuickScanDialog(this.matDialog)
+      .pipe(
+        take(1),
+        tap(() => this.getFilteredReceipts())
+      )
+      .subscribe();
+  }
+
+  public exportAllReceipts(): void {
+    this.receiptExportService.exportReceiptsFromFilter(this.groupId, this.filter());
   }
 
   public resetFilterButtonClicked(): void {

--- a/desktop/src/receipts/receipts-table/receipts-table.component.ts
+++ b/desktop/src/receipts/receipts-table/receipts-table.component.ts
@@ -7,7 +7,7 @@ import { MatTableDataSource } from "@angular/material/table";
 import { ActivatedRoute, Router } from "@angular/router";
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 import { Store } from "@ngxs/store";
-import { map, take, tap } from "rxjs";
+import { catchError, EMPTY, map, Subject, switchMap, take, tap } from "rxjs";
 import { fadeInOut } from "src/animations";
 import { ReceiptFilterService } from "src/services/receipt-filter.service";
 import { ConfirmationDialogComponent } from "src/shared-ui/confirmation-dialog/confirmation-dialog.component";
@@ -72,7 +72,9 @@ export class ReceiptsTableComponent implements OnInit, AfterViewInit {
     private store: Store,
     private customCurrencyPipe: CustomCurrencyPipe,
     private datePipe: DatePipe,
-  ) {}
+  ) {
+    this.listenForRefreshRequests();
+  }
 
   readonly createdAtCell = viewChild.required<TemplateRef<any>>("createdAtCell");
 
@@ -105,6 +107,8 @@ export class ReceiptsTableComponent implements OnInit, AfterViewInit {
   public columnConfig = this.store.selectSignal(ReceiptTableState.columnConfig);
 
   public selectedGroupId = this.store.selectSignal(GroupState.selectedGroupId);
+
+  private readonly refreshRequested = new Subject<void>();
 
   private groups = this.store.selectSignal(GroupState.groups);
 
@@ -500,10 +504,28 @@ export class ReceiptsTableComponent implements OnInit, AfterViewInit {
   }
 
   public getFilteredReceipts(): void {
-    this.receiptFilterService
-      .getPagedReceiptsForGroups(this.groupId.toString())
+    this.refreshRequested.next();
+  }
+
+  /**
+   * Every refresh goes through one switchMap, so a newer request supersedes
+   * whatever is in flight (and aborts its XHR) instead of racing it. Without
+   * this the last *response* wins rather than the last *request* — and the
+   * quick date arrows put those one click apart, so a slow earlier page could
+   * repaint the table with a month the user has already stepped past.
+   */
+  private listenForRefreshRequests(): void {
+    this.refreshRequested
       .pipe(
-        take(1),
+        untilDestroyed(this),
+        switchMap(() =>
+          this.receiptFilterService.getPagedReceiptsForGroups(this.groupId.toString()).pipe(
+            // Keeps the outer subscription alive. An error surfacing through
+            // switchMap would complete it and silently kill every later
+            // refresh; the HTTP interceptor already reports the failure.
+            catchError(() => EMPTY)
+          )
+        ),
         tap((pagedData) => {
           this.dataSource.set(new MatTableDataSource(pagedData.data));
           this.totalCount.set(pagedData.totalCount);

--- a/desktop/src/receipts/receipts.module.ts
+++ b/desktop/src/receipts/receipts.module.ts
@@ -7,6 +7,7 @@ import { MatCheckboxModule } from "@angular/material/checkbox";
 import { MatDialogModule } from "@angular/material/dialog";
 import { MatExpansionModule } from "@angular/material/expansion";
 import { MatIconModule } from "@angular/material/icon";
+import { MatChipsModule } from "@angular/material/chips";
 import { MatMenuModule } from "@angular/material/menu";
 import { MatProgressSpinnerModule } from "@angular/material/progress-spinner";
 import { MatTableModule } from "@angular/material/table";
@@ -28,6 +29,7 @@ import { CategoryAutocompleteComponent } from "../category-autocomplete/category
 import { CheckboxModule } from "../checkbox/checkbox.module";
 import { DirectivesModule } from "../directives";
 import { InputModule } from "../input";
+import { MonthStepperComponent } from "../shared-ui/month-stepper/month-stepper.component";
 import { ExportButtonComponent } from "../standalone/components/export-button/export-button.component";
 import { FilteredStatefulMenuComponent } from "../standalone/components/filtered-stateful-menu/filtered-stateful-menu.component";
 import { TagAutocompleteComponent } from "../tag-autocomplete/tag-autocomplete.component";
@@ -80,6 +82,7 @@ import { UserTotalWithPercentagePipe } from "./user-total-with-percentage.pipe";
     InputModule,
     MatCardModule,
     MatCheckboxModule,
+    MatChipsModule,
     MatDialogModule,
     MatExpansionModule,
     MatIconModule,
@@ -100,6 +103,7 @@ import { UserTotalWithPercentagePipe } from "./user-total-with-percentage.pipe";
     UserAutocompleteModule,
     FilteredStatefulMenuComponent,
     CheckboxModule,
+    MonthStepperComponent,
   ],
   exports: [
     UploadImageComponent

--- a/desktop/src/receipts/receipts.module.ts
+++ b/desktop/src/receipts/receipts.module.ts
@@ -30,7 +30,6 @@ import { CheckboxModule } from "../checkbox/checkbox.module";
 import { DirectivesModule } from "../directives";
 import { InputModule } from "../input";
 import { MonthStepperComponent } from "../shared-ui/month-stepper/month-stepper.component";
-import { ExportButtonComponent } from "../standalone/components/export-button/export-button.component";
 import { FilteredStatefulMenuComponent } from "../standalone/components/filtered-stateful-menu/filtered-stateful-menu.component";
 import { TagAutocompleteComponent } from "../tag-autocomplete/tag-autocomplete.component";
 import { BulkStatusUpdateComponent } from "./bulk-resolve-dialog/bulk-status-update-dialog.component";
@@ -78,7 +77,6 @@ import { UserTotalWithPercentagePipe } from "./user-total-with-percentage.pipe";
     DatepickerModule,
     DirectivesModule,
     DragDropModule,
-    ExportButtonComponent,
     InputModule,
     MatCardModule,
     MatCheckboxModule,

--- a/desktop/src/shared-ui/month-stepper/month-stepper.component.html
+++ b/desktop/src/shared-ui/month-stepper/month-stepper.component.html
@@ -8,13 +8,17 @@
     (clicked)="step(-1)"
   ></app-button>
   <app-button
+    cdkOverlayOrigin
+    #trigger="cdkOverlayOrigin"
     data-testid="receipts-month-label"
     matButtonType="basic"
     icon="calendar_month"
     color="accent"
     tooltip="Filter by month"
+    aria-haspopup="dialog"
+    [attr.aria-expanded]="panelOpen()"
     [buttonText]="label()"
-    [matMenuTriggerFor]="panel"
+    (clicked)="togglePanel()"
   ></app-button>
   <app-button
     data-testid="receipts-month-next"
@@ -26,11 +30,30 @@
   ></app-button>
 </div>
 
-<mat-menu #panel="matMenu">
-  <ng-template matMenuContent>
-    <!-- Material closes the panel on any click inside it, so the year pager has
-         to stop its clicks from reaching the panel or paging would dismiss it. -->
-    <div class="month-stepper__year" (click)="$event.stopPropagation()">
+<!--
+  A dialog, not a menu: the panel holds a pager, a grid and shortcuts rather
+  than menu items, so it owns its own focus trap and Escape handling. The trap's
+  autoCapture also restores focus to the trigger when the overlay is destroyed.
+-->
+<ng-template
+  cdkConnectedOverlay
+  cdkConnectedOverlayBackdropClass="cdk-overlay-transparent-backdrop"
+  [cdkConnectedOverlayOrigin]="trigger"
+  [cdkConnectedOverlayOpen]="panelOpen()"
+  [cdkConnectedOverlayPositions]="panelPositions"
+  [cdkConnectedOverlayHasBackdrop]="true"
+  (backdropClick)="closePanel()"
+  (detach)="closePanel()"
+>
+  <div
+    class="month-stepper__panel"
+    role="dialog"
+    aria-label="Filter by month"
+    cdkTrapFocus
+    [cdkTrapFocusAutoCapture]="true"
+    (keydown.escape)="closePanel()"
+  >
+    <div class="month-stepper__year">
       <app-button
         data-testid="month-stepper-year-prev"
         matButtonType="iconButton"
@@ -79,10 +102,10 @@
         type="button"
         class="month-stepper__shortcut--muted"
         data-testid="month-stepper-all-time"
-        (click)="allTimeSelected.emit()"
+        (click)="pickAllTime()"
       >
         All time
       </button>
     </div>
-  </ng-template>
-</mat-menu>
+  </div>
+</ng-template>

--- a/desktop/src/shared-ui/month-stepper/month-stepper.component.html
+++ b/desktop/src/shared-ui/month-stepper/month-stepper.component.html
@@ -1,0 +1,88 @@
+<div class="month-stepper">
+  <app-button
+    data-testid="receipts-month-prev"
+    matButtonType="iconButton"
+    icon="chevron_left"
+    color="accent"
+    tooltip="Previous month"
+    (clicked)="step(-1)"
+  ></app-button>
+  <app-button
+    data-testid="receipts-month-label"
+    matButtonType="basic"
+    icon="calendar_month"
+    color="accent"
+    tooltip="Filter by month"
+    [buttonText]="label()"
+    [matMenuTriggerFor]="panel"
+  ></app-button>
+  <app-button
+    data-testid="receipts-month-next"
+    matButtonType="iconButton"
+    icon="chevron_right"
+    color="accent"
+    tooltip="Next month"
+    (clicked)="step(1)"
+  ></app-button>
+</div>
+
+<mat-menu #panel="matMenu">
+  <ng-template matMenuContent>
+    <!-- Material closes the panel on any click inside it, so the year pager has
+         to stop its clicks from reaching the panel or paging would dismiss it. -->
+    <div class="month-stepper__year" (click)="$event.stopPropagation()">
+      <app-button
+        data-testid="month-stepper-year-prev"
+        matButtonType="iconButton"
+        icon="chevron_left"
+        color="accent"
+        tooltip="Previous year"
+        [disabled]="!canPageBack()"
+        (clicked)="pageYear(-1)"
+      ></app-button>
+      <span class="month-stepper__year-value" data-testid="month-stepper-year">{{ pagedYear() }}</span>
+      <app-button
+        data-testid="month-stepper-year-next"
+        matButtonType="iconButton"
+        icon="chevron_right"
+        color="accent"
+        tooltip="Next year"
+        [disabled]="!canPageForward()"
+        (clicked)="pageYear(1)"
+      ></app-button>
+    </div>
+
+    <div class="month-stepper__months">
+      @for (short of shortMonthLabels; track $index) {
+        <button
+          type="button"
+          class="month-stepper__month"
+          [class.month-stepper__month--selected]="isSelected($index)"
+          [attr.data-testid]="'month-stepper-month-' + $index"
+          [attr.aria-label]="monthLabel($index) + ' ' + pagedYear()"
+          [attr.aria-pressed]="isSelected($index)"
+          (click)="pickMonth($index)"
+        >
+          {{ short }}
+        </button>
+      }
+    </div>
+
+    <div class="month-stepper__shortcuts">
+      <button type="button" data-testid="month-stepper-this-month" (click)="pickRelativeMonth(0)">
+        This month
+      </button>
+      <button type="button" data-testid="month-stepper-last-month" (click)="pickRelativeMonth(-1)">
+        Last month
+      </button>
+      <button
+        type="button"
+        class="month-stepper__shortcut--muted"
+        data-testid="month-stepper-all-time"
+        (click)="allTimeSelected.emit()"
+      >
+        All time
+      </button>
+    </div>
+  </ng-template>
+</mat-menu>

--- a/desktop/src/shared-ui/month-stepper/month-stepper.component.scss
+++ b/desktop/src/shared-ui/month-stepper/month-stepper.component.scss
@@ -16,6 +16,17 @@
   }
 }
 
+// mat-menu used to supply the surface; a bare overlay does not.
+.month-stepper__panel {
+  padding: variables.$spacing-sm 0;
+  border-radius: 0.25rem;
+  background: white;
+  box-shadow:
+    0 3px 1px -2px rgba(0, 0, 0, 0.2),
+    0 2px 2px 0 rgba(0, 0, 0, 0.14),
+    0 1px 5px 0 rgba(0, 0, 0, 0.12);
+}
+
 .month-stepper__year {
   display: flex;
   align-items: center;

--- a/desktop/src/shared-ui/month-stepper/month-stepper.component.scss
+++ b/desktop/src/shared-ui/month-stepper/month-stepper.component.scss
@@ -1,0 +1,98 @@
+@use "sass:map";
+@use "../../variables.scss" as variables;
+
+:host {
+  display: inline-block;
+}
+
+.month-stepper {
+  display: inline-flex;
+  align-items: center;
+
+  // The label is a text button, so pin a width or the control jitters as the
+  // month name changes length.
+  [data-testid="receipts-month-label"] button {
+    min-width: 10.5rem;
+  }
+}
+
+.month-stepper__year {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 variables.$spacing-sm variables.$spacing-xs;
+}
+
+.month-stepper__year-value {
+  font-weight: 600;
+}
+
+.month-stepper__months {
+  display: grid;
+  grid-template-columns: repeat(3, 4.75rem);
+  gap: variables.$spacing-xs;
+  padding: 0 variables.$spacing-sm;
+}
+
+.month-stepper__month {
+  height: 2.25rem;
+  border: 1px solid map.get(variables.$accent-palette, 200);
+  border-radius: 0.375rem;
+  background: transparent;
+  color: map.get(variables.$accent-palette, 700);
+  font: inherit;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  cursor: pointer;
+
+  &:hover {
+    background: map.get(variables.$primary-palette, 50);
+    border-color: map.get(variables.$primary-palette, 100);
+  }
+}
+
+.month-stepper__month--selected {
+  border-color: transparent;
+  background: map.get(variables.$primary-palette, 500);
+  color: white;
+  font-weight: 600;
+
+  &:hover {
+    background: map.get(variables.$primary-palette, 600);
+    border-color: transparent;
+  }
+}
+
+.month-stepper__shortcuts {
+  display: flex;
+  align-items: center;
+  gap: variables.$spacing-xs;
+  margin-top: variables.$spacing-sm;
+  padding: variables.$spacing-sm variables.$spacing-sm 0;
+  border-top: 1px solid map.get(variables.$accent-palette, 200);
+
+  button {
+    border: 0;
+    border-radius: 0.25rem;
+    background: transparent;
+    padding: variables.$spacing-xs variables.$spacing-sm;
+    font: inherit;
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: map.get(variables.$primary-palette, 700);
+    cursor: pointer;
+
+    &:hover {
+      background: map.get(variables.$primary-palette, 50);
+    }
+  }
+}
+
+.month-stepper__shortcut--muted {
+  margin-left: auto;
+  color: map.get(variables.$accent-palette, 500);
+
+  &:hover {
+    background: map.get(variables.$accent-palette, 100);
+  }
+}

--- a/desktop/src/shared-ui/month-stepper/month-stepper.component.scss
+++ b/desktop/src/shared-ui/month-stepper/month-stepper.component.scss
@@ -88,7 +88,7 @@
   }
 }
 
-.month-stepper__shortcut--muted {
+.month-stepper__shortcuts .month-stepper__shortcut--muted {
   margin-left: auto;
   color: map.get(variables.$accent-palette, 500);
 

--- a/desktop/src/shared-ui/month-stepper/month-stepper.component.spec.ts
+++ b/desktop/src/shared-ui/month-stepper/month-stepper.component.spec.ts
@@ -1,0 +1,159 @@
+import { provideZonelessChangeDetection } from "@angular/core";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { NoopAnimationsModule } from "@angular/platform-browser/animations";
+import { provideRouter } from "@angular/router";
+import { FilterMonth } from "../../utils/receipt-date-filter";
+import { MonthStepperComponent } from "./month-stepper.component";
+
+/**
+ * Expectations are derived from the real clock rather than a frozen one: jest's
+ * fake timers stall `fixture.whenStable()` under zoneless change detection.
+ */
+function monthRelativeToToday(delta: number): FilterMonth {
+  const today = new Date();
+  const shifted = new Date(today.getFullYear(), today.getMonth() + delta, 1);
+
+  return { year: shifted.getFullYear(), month: shifted.getMonth() };
+}
+
+describe("MonthStepperComponent", () => {
+  let component: MonthStepperComponent;
+  let fixture: ComponentFixture<MonthStepperComponent>;
+  let emitted: FilterMonth[];
+  let allTimeEmissions: number;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MonthStepperComponent, NoopAnimationsModule],
+      // app-button binds [routerLink], so it needs a router context.
+      providers: [provideZonelessChangeDetection(), provideRouter([])],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(MonthStepperComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput("label", "All time");
+
+    emitted = [];
+    allTimeEmissions = 0;
+    component.monthSelected.subscribe((month) => emitted.push(month));
+    component.allTimeSelected.subscribe(() => (allTimeEmissions += 1));
+
+    await fixture.whenStable();
+  });
+
+  const setMonth = async (month: FilterMonth | null) => {
+    fixture.componentRef.setInput("value", month);
+    await fixture.whenStable();
+  };
+
+  it("renders the label it is given", async () => {
+    fixture.componentRef.setInput("label", "September 2026");
+    await fixture.whenStable();
+
+    expect(
+      fixture.nativeElement.querySelector('[data-testid="receipts-month-label"]').textContent
+    ).toContain("September 2026");
+  });
+
+  describe("stepping", () => {
+    it("steps from the bound month", async () => {
+      await setMonth({ year: 2026, month: 8 });
+
+      component.step(1);
+      component.step(-1);
+
+      expect(emitted).toEqual([
+        { year: 2026, month: 9 },
+        { year: 2026, month: 7 },
+      ]);
+    });
+
+    // Without a month the arrows would otherwise no-op, so they step from today
+    // and the first press always lands somewhere useful.
+    it("steps from the current month when nothing is selected", () => {
+      component.step(-1);
+      component.step(1);
+
+      expect(emitted).toEqual([monthRelativeToToday(-1), monthRelativeToToday(1)]);
+    });
+
+    it("rolls the year at both boundaries", async () => {
+      await setMonth({ year: 2026, month: 11 });
+      component.step(1);
+
+      await setMonth({ year: 2026, month: 0 });
+      component.step(-1);
+
+      expect(emitted).toEqual([
+        { year: 2027, month: 0 },
+        { year: 2025, month: 11 },
+      ]);
+    });
+  });
+
+  describe("the panel", () => {
+    it("seeds its year from the bound month and falls back to this year", async () => {
+      expect(component.pagedYear()).toBe(new Date().getFullYear());
+
+      await setMonth({ year: 2023, month: 4 });
+
+      expect(component.pagedYear()).toBe(2023);
+    });
+
+    // Paging is a view concern — it must not write a filter.
+    it("pages the year without emitting", async () => {
+      await setMonth({ year: 2026, month: 8 });
+
+      component.pageYear(-1);
+
+      expect(component.pagedYear()).toBe(2025);
+      expect(emitted).toEqual([]);
+    });
+
+    it("picks a month out of the paged year", async () => {
+      await setMonth({ year: 2026, month: 8 });
+
+      component.pageYear(1);
+      component.pickMonth(0);
+
+      expect(emitted).toEqual([{ year: 2027, month: 0 }]);
+    });
+
+    it("marks only the bound month as selected, and only in its own year", async () => {
+      await setMonth({ year: 2026, month: 8 });
+
+      expect(component.isSelected(8)).toBe(true);
+      expect(component.isSelected(7)).toBe(false);
+
+      component.pageYear(1);
+
+      expect(component.isSelected(8)).toBe(false);
+    });
+
+    it("emits the right months for the shortcuts", () => {
+      component.pickRelativeMonth(0);
+      component.pickRelativeMonth(-1);
+
+      expect(emitted).toEqual([monthRelativeToToday(0), monthRelativeToToday(-1)]);
+    });
+
+    it("emits all time separately", () => {
+      component.allTimeSelected.emit();
+
+      expect(allTimeEmissions).toBe(1);
+      expect(emitted).toEqual([]);
+    });
+
+    it("bounds the year pager", async () => {
+      await setMonth({ year: 1970, month: 0 });
+      expect(component.canPageBack()).toBe(false);
+
+      await setMonth({ year: new Date().getFullYear() + 5, month: 0 });
+      expect(component.canPageForward()).toBe(false);
+
+      await setMonth({ year: new Date().getFullYear(), month: 0 });
+      expect(component.canPageBack()).toBe(true);
+      expect(component.canPageForward()).toBe(true);
+    });
+  });
+});

--- a/desktop/src/shared-ui/month-stepper/month-stepper.component.spec.ts
+++ b/desktop/src/shared-ui/month-stepper/month-stepper.component.spec.ts
@@ -138,9 +138,42 @@ describe("MonthStepperComponent", () => {
     });
 
     it("emits all time separately", () => {
-      component.allTimeSelected.emit();
+      component.pickAllTime();
 
       expect(allTimeEmissions).toBe(1);
+      expect(emitted).toEqual([]);
+    });
+
+    it("opens and closes", () => {
+      expect(component.panelOpen()).toBe(false);
+
+      component.togglePanel();
+      expect(component.panelOpen()).toBe(true);
+
+      component.togglePanel();
+      expect(component.panelOpen()).toBe(false);
+    });
+
+    it("closes once a month or a shortcut is picked", () => {
+      for (const pick of [
+        () => component.pickMonth(3),
+        () => component.pickRelativeMonth(0),
+        () => component.pickAllTime(),
+      ]) {
+        component.togglePanel();
+        pick();
+        expect(component.panelOpen()).toBe(false);
+      }
+    });
+
+    // Paging is a view concern. Under the old mat-menu this needed a
+    // stopPropagation hack because the menu closed on any click inside it.
+    it("stays open while paging the year", () => {
+      component.togglePanel();
+
+      component.pageYear(-1);
+
+      expect(component.panelOpen()).toBe(true);
       expect(emitted).toEqual([]);
     });
 

--- a/desktop/src/shared-ui/month-stepper/month-stepper.component.ts
+++ b/desktop/src/shared-ui/month-stepper/month-stepper.component.ts
@@ -1,5 +1,6 @@
-import { Component, computed, input, linkedSignal, output } from "@angular/core";
-import { MatMenuModule } from "@angular/material/menu";
+import { A11yModule } from "@angular/cdk/a11y";
+import { ConnectedPosition, OverlayModule } from "@angular/cdk/overlay";
+import { Component, computed, input, linkedSignal, output, signal } from "@angular/core";
 import { ButtonModule } from "../../button";
 import { FilterMonth, monthOfDate, shiftMonth } from "../../utils/receipt-date-filter";
 
@@ -24,13 +25,19 @@ const MAX_YEAR_OFFSET = 5;
  *
  * Deliberately presentational — it emits months and knows nothing about what a
  * caller does with them.
+ *
+ * The panel is a CDK overlay rather than a `mat-menu`. A menu's key manager
+ * only tracks `mat-menu-item`s, and this panel has none — so arrow keys did
+ * nothing and, worse, `ListKeyManager` turns Tab into `tabOut`, which `MatMenu`
+ * wires to close. That left the grid, the pager and the shortcuts reachable by
+ * mouse only. An overlay lets this be what it actually is: a small dialog.
  */
 @Component({
   selector: "app-month-stepper",
   templateUrl: "./month-stepper.component.html",
   styleUrls: ["./month-stepper.component.scss"],
   standalone: true,
-  imports: [ButtonModule, MatMenuModule],
+  imports: [A11yModule, ButtonModule, OverlayModule],
 })
 export class MonthStepperComponent {
   /** The month currently shown, or null when the caller is showing something else. */
@@ -48,6 +55,14 @@ export class MonthStepperComponent {
 
   public readonly shortMonthLabels = SHORT_MONTH_LABELS;
 
+  public readonly panelOpen = signal(false);
+
+  /** Anchored under the label, flipping above it when there is no room below. */
+  public readonly panelPositions: ConnectedPosition[] = [
+    { originX: "end", originY: "bottom", overlayX: "end", overlayY: "top", offsetY: 4 },
+    { originX: "end", originY: "top", overlayX: "end", overlayY: "bottom", offsetY: -4 },
+  ];
+
   /**
    * The year the grid is paging through. Follows the bound month but stays
    * overridable, so paging the year does not change the filter and a reset
@@ -62,6 +77,18 @@ export class MonthStepperComponent {
   public readonly canPageForward = computed(
     () => this.pagedYear() < new Date().getFullYear() + MAX_YEAR_OFFSET
   );
+
+  public togglePanel(): void {
+    this.panelOpen.update((open) => !open);
+  }
+
+  /**
+   * Focus returns to the trigger on its own: the focus trap captures the
+   * previously focused element and restores it when the overlay is destroyed.
+   */
+  public closePanel(): void {
+    this.panelOpen.set(false);
+  }
 
   public monthLabel(month: number): string {
     return MONTH_LABELS[month];
@@ -82,16 +109,24 @@ export class MonthStepperComponent {
     this.monthSelected.emit(shiftMonth(this.value() ?? monthOfDate(new Date()), delta));
   }
 
+  /** Leaves the panel open — paging is a view concern, not a selection. */
   public pageYear(delta: number): void {
     this.pagedYear.update((year) => year + delta);
   }
 
   public pickMonth(month: number): void {
     this.monthSelected.emit({ year: this.pagedYear(), month });
+    this.closePanel();
   }
 
   /** `0` is this month, `-1` last month. */
   public pickRelativeMonth(delta: number): void {
     this.monthSelected.emit(shiftMonth(monthOfDate(new Date()), delta));
+    this.closePanel();
+  }
+
+  public pickAllTime(): void {
+    this.allTimeSelected.emit();
+    this.closePanel();
   }
 }

--- a/desktop/src/shared-ui/month-stepper/month-stepper.component.ts
+++ b/desktop/src/shared-ui/month-stepper/month-stepper.component.ts
@@ -1,0 +1,97 @@
+import { Component, computed, input, linkedSignal, output } from "@angular/core";
+import { MatMenuModule } from "@angular/material/menu";
+import { ButtonModule } from "../../button";
+import { FilterMonth, monthOfDate, shiftMonth } from "../../utils/receipt-date-filter";
+
+const MONTH_LABELS = [
+  "January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December",
+];
+
+const SHORT_MONTH_LABELS = [
+  "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+  "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+];
+
+// Arbitrary, purely so the year pager is not an infinite hole.
+const MIN_YEAR = 1970;
+const MAX_YEAR_OFFSET = 5;
+
+/**
+ * A month picker shaped as a stepper: previous / next arrows either side of a
+ * label that opens a year pager and a month grid, plus This month / Last month
+ * / All time shortcuts.
+ *
+ * Deliberately presentational — it emits months and knows nothing about what a
+ * caller does with them.
+ */
+@Component({
+  selector: "app-month-stepper",
+  templateUrl: "./month-stepper.component.html",
+  styleUrls: ["./month-stepper.component.scss"],
+  standalone: true,
+  imports: [ButtonModule, MatMenuModule],
+})
+export class MonthStepperComponent {
+  /** The month currently shown, or null when the caller is showing something else. */
+  public readonly value = input<FilterMonth | null>(null);
+
+  /**
+   * Rendered on the label. The caller owns the wording because only it knows
+   * whether "no month" means nothing is set or something it cannot express.
+   */
+  public readonly label = input.required<string>();
+
+  public readonly monthSelected = output<FilterMonth>();
+
+  public readonly allTimeSelected = output<void>();
+
+  public readonly shortMonthLabels = SHORT_MONTH_LABELS;
+
+  /**
+   * The year the grid is paging through. Follows the bound month but stays
+   * overridable, so paging the year does not change the filter and a reset
+   * underneath the open panel still re-seeds it.
+   */
+  public readonly pagedYear = linkedSignal(
+    () => this.value()?.year ?? new Date().getFullYear()
+  );
+
+  public readonly canPageBack = computed(() => this.pagedYear() > MIN_YEAR);
+
+  public readonly canPageForward = computed(
+    () => this.pagedYear() < new Date().getFullYear() + MAX_YEAR_OFFSET
+  );
+
+  public monthLabel(month: number): string {
+    return MONTH_LABELS[month];
+  }
+
+  public isSelected(month: number): boolean {
+    const value = this.value();
+
+    return !!value && value.year === this.pagedYear() && value.month === month;
+  }
+
+  /**
+   * Steps by whole months. With nothing selected it steps from the current
+   * month, so the first press always lands somewhere useful rather than
+   * no-oping.
+   */
+  public step(delta: number): void {
+    this.monthSelected.emit(shiftMonth(this.value() ?? monthOfDate(new Date()), delta));
+  }
+
+  public pageYear(delta: number): void {
+    this.pagedYear.update((year) => year + delta);
+  }
+
+  public pickMonth(month: number): void {
+    this.monthSelected.emit({ year: this.pagedYear(), month });
+  }
+
+  /** `0` is this month, `-1` last month. */
+  public pickRelativeMonth(delta: number): void {
+    this.monthSelected.emit(shiftMonth(monthOfDate(new Date()), delta));
+  }
+}

--- a/desktop/src/shared-ui/quick-scan-button/quick-scan-button.component.ts
+++ b/desktop/src/shared-ui/quick-scan-button/quick-scan-button.component.ts
@@ -1,8 +1,7 @@
 import { Component, output } from "@angular/core";
 import { MatDialog } from "@angular/material/dialog";
 import { take, tap } from "rxjs";
-import { DEFAULT_DIALOG_CONFIG } from "../../constants";
-import { QuickScanDialogComponent } from "../../receipts/quick-scan-dialog/quick-scan-dialog.component";
+import { openQuickScanDialog } from "../../receipts/quick-scan-dialog/open-quick-scan-dialog";
 
 @Component({
     selector: "app-quick-scan-button",
@@ -16,13 +15,7 @@ export class QuickScanButtonComponent {
   constructor(private matDialog: MatDialog) {}
 
   public showQuickScanDialog(): void {
-    const ref = this.matDialog.open(
-      QuickScanDialogComponent,
-      DEFAULT_DIALOG_CONFIG
-    );
-
-    ref
-      .afterClosed()
+    openQuickScanDialog(this.matDialog)
       .pipe(
         take(1),
         tap(() => {

--- a/desktop/src/shared-ui/receipt-filter/operations.pipe.ts
+++ b/desktop/src/shared-ui/receipt-filter/operations.pipe.ts
@@ -1,6 +1,7 @@
 import { Pipe, PipeTransform } from "@angular/core";
 import {
   dateOperationOptions,
+  FILTER_OPERATION_DISPLAY_VALUES,
   listOperationOptions,
   numberOperationOptions,
   textOperationOptions,
@@ -13,15 +14,6 @@ import { FilterOperation } from "src/open-api";
     standalone: false
 })
 export class OperationsPipe implements PipeTransform {
-  private displayValues: { [key: string]: string } = {
-    [FilterOperation.Contains]: "Contains",
-    [FilterOperation.Equals]: "Equals",
-    [FilterOperation.GreaterThan]: "Greater than",
-    [FilterOperation.LessThan]: "Less than",
-    [FilterOperation.Between]: "Between",
-    [FilterOperation.WithinCurrentMonth]: "Within current month"
-  };
-
   public transform(type: string, display: boolean): string[] {
     let operationOptions: FilterOperation[] = [];
 
@@ -48,7 +40,7 @@ export class OperationsPipe implements PipeTransform {
 
   private getDisplayValue(option: FilterOperation | null, display: boolean): string {
     if (display) {
-      return this.displayValues?.[option ?? ""] ?? "";
+      return FILTER_OPERATION_DISPLAY_VALUES?.[option ?? ""] ?? "";
     } else {
       return option ?? "";
     }

--- a/desktop/src/shared-ui/receipt-filter/receipt-filter.component.ts
+++ b/desktop/src/shared-ui/receipt-filter/receipt-filter.component.ts
@@ -4,7 +4,7 @@ import { MatDialogRef } from "@angular/material/dialog";
 import { Store } from "@ngxs/store";
 import { endOfDay, startOfMonth } from "date-fns";
 import { take, tap } from "rxjs";
-import { RECEIPT_STATUS_OPTIONS } from "src/constants";
+import { RECEIPT_FILTER_FIELDS, RECEIPT_STATUS_OPTIONS } from "src/constants";
 import { SetReceiptFilter } from "src/store/receipt-table.actions";
 import { FormCommand } from "../../form/index";
 import { Category, FilterOperation, Tag } from "../../open-api";
@@ -124,23 +124,12 @@ export class ReceiptFilterComponent implements OnInit {
   }
 
   private setupAutoOperationSelection(): void {
-    // List of all filter fields
-    const fieldsToWatch = [
-      { fieldName: "date", type: "date" },
-      { fieldName: "name", type: "text" },
-      { fieldName: "paidBy", type: "users" },
-      { fieldName: "amount", type: "number" },
-      { fieldName: "categories", type: "list" },
-      { fieldName: "tags", type: "list" },
-      { fieldName: "status", type: "list" },
-      { fieldName: "group", type: "list" },
-      { fieldName: "resolvedDate", type: "date" },
-      { fieldName: "createdAt", type: "date" }
-    ];
-
-    fieldsToWatch.forEach(({ fieldName, type }) => {
-      const valueControl = this.parentForm.get(`${this.basePath}${fieldName}.value`);
-      const operationControl = this.parentForm.get(`${this.basePath}${fieldName}.operation`);
+    // RECEIPT_FILTER_FIELDS is the shared definition of every filter field's
+    // label and operation type, so these rows and the filter chips that describe
+    // them cannot drift apart.
+    RECEIPT_FILTER_FIELDS.forEach(({ key, type }) => {
+      const valueControl = this.parentForm.get(`${this.basePath}${key}.value`);
+      const operationControl = this.parentForm.get(`${this.basePath}${key}.operation`);
 
       if (valueControl && operationControl) {
         valueControl.valueChanges.subscribe(value => {

--- a/desktop/src/store/receipt-table.actions.ts
+++ b/desktop/src/store/receipt-table.actions.ts
@@ -1,4 +1,4 @@
-import { ReceiptPagedRequestFilter } from "../open-api";
+import { FilterOperation, ReceiptPagedRequestFilter } from "../open-api";
 import { ReceiptTableInterface } from "../interfaces";
 import { ReceiptTableColumnConfig } from "../interfaces/receipt-table-column-config.interface";
 
@@ -24,6 +24,16 @@ export class SetReceiptFilter {
   static readonly type = "[ReceiptTable] Set Filter";
 
   constructor(public data: ReceiptPagedRequestFilter) {}
+}
+
+export class SetReceiptFilterField {
+  static readonly type = "[ReceiptTable] Set Filter Field";
+
+  constructor(
+    public field: keyof ReceiptPagedRequestFilter,
+    /** `null` clears the field back to its default empty shape. */
+    public entry: { operation: FilterOperation | null; value: unknown } | null,
+  ) {}
 }
 
 export class ResetReceiptFilter {

--- a/desktop/src/store/receipt-table.state.spec.ts
+++ b/desktop/src/store/receipt-table.state.spec.ts
@@ -159,14 +159,14 @@ describe("ReceiptTableState", () => {
     const result = store.selectSnapshot(ReceiptTableState.filterData).filter;
     expect(result).toEqual(defaultReceiptFilter);
   });
-  it("should not count a zero-valued filter field", () => {
+  it("should count a zero-valued filter field", () => {
     store.reset({
       receiptTable: {
         filter: { ...defaultReceiptFilter, amount: { operation: FilterOperation.Equals, value: 0 } },
       },
     });
 
-    expect(store.selectSnapshot(ReceiptTableState.numFiltersApplied)).toEqual(0);
+    expect(store.selectSnapshot(ReceiptTableState.numFiltersApplied)).toEqual(1);
   });
 
   it("should set a single filter field, leaving the others alone", () => {

--- a/desktop/src/store/receipt-table.state.spec.ts
+++ b/desktop/src/store/receipt-table.state.spec.ts
@@ -2,8 +2,8 @@ import { TestBed } from "@angular/core/testing";
 import { NgxsModule, Store } from "@ngxs/store";
 import { DEFAULT_RECEIPT_TABLE_COLUMNS, ReceiptTableInterface } from "src/interfaces";
 import { FilterOperation, ReceiptPagedRequestFilter, ReceiptStatus } from "../open-api";
-import { ResetReceiptFilter, SetPage, SetPageSize, SetReceiptFilter, SetReceiptFilterData, } from "./receipt-table.actions";
-import { defaultReceiptFilter, ReceiptTableState } from "./receipt-table.state";
+import { ResetReceiptFilter, SetPage, SetPageSize, SetReceiptFilter, SetReceiptFilterData, SetReceiptFilterField, } from "./receipt-table.actions";
+import { buildDefaultReceiptFilter, defaultReceiptFilter, ReceiptTableState } from "./receipt-table.state";
 
 describe("ReceiptTableState", () => {
   let store: Store;
@@ -158,5 +158,57 @@ describe("ReceiptTableState", () => {
 
     const result = store.selectSnapshot(ReceiptTableState.filterData).filter;
     expect(result).toEqual(defaultReceiptFilter);
+  });
+  it("should not count a zero-valued filter field", () => {
+    store.reset({
+      receiptTable: {
+        filter: { ...defaultReceiptFilter, amount: { operation: FilterOperation.Equals, value: 0 } },
+      },
+    });
+
+    expect(store.selectSnapshot(ReceiptTableState.numFiltersApplied)).toEqual(0);
+  });
+
+  it("should set a single filter field, leaving the others alone", () => {
+    store.dispatch(
+      new SetReceiptFilterField("status", {
+        operation: FilterOperation.Contains,
+        value: [ReceiptStatus.Open],
+      })
+    );
+
+    const result = store.selectSnapshot(ReceiptTableState.filterData).filter as any;
+    expect(result.status).toEqual({
+      operation: FilterOperation.Contains,
+      value: [ReceiptStatus.Open],
+    });
+    expect(result.categories).toEqual({ operation: null, value: [] });
+    expect(result.date).toEqual({ operation: null, value: null });
+  });
+
+  it("should clear a single filter field back to its default empty shape", () => {
+    store.reset({ receiptTable: { filter: filledFilter } });
+
+    store.dispatch(new SetReceiptFilterField("categories", null));
+    store.dispatch(new SetReceiptFilterField("date", null));
+
+    const result = store.selectSnapshot(ReceiptTableState.filterData).filter as any;
+    // A list field clears to [], a scalar to null.
+    expect(result.categories).toEqual({ operation: null, value: [] });
+    expect(result.date).toEqual({ operation: null, value: null });
+    expect(result.name).toEqual(filledFilter.name);
+  });
+
+  // ResetReceiptFilter writes a default filter straight into state, so without a
+  // fresh object per write a later field update would corrupt the module-level
+  // default for the rest of the session.
+  it("should never mutate the exported default filter", () => {
+    store.dispatch(new ResetReceiptFilter());
+    store.dispatch(
+      new SetReceiptFilterField("name", { operation: FilterOperation.Contains, value: "whole" })
+    );
+
+    expect(defaultReceiptFilter).toEqual(buildDefaultReceiptFilter());
+    expect((defaultReceiptFilter as any).name).toEqual({ operation: null, value: null });
   });
 });

--- a/desktop/src/store/receipt-table.state.ts
+++ b/desktop/src/store/receipt-table.state.ts
@@ -2,51 +2,62 @@ import { Injectable } from "@angular/core";
 import { Action, Selector, State, StateContext } from "@ngxs/store";
 import { ReceiptTableInterface } from "../interfaces";
 import { DEFAULT_RECEIPT_TABLE_COLUMNS, ReceiptTableColumnConfig } from "../interfaces/receipt-table-column-config.interface";
-import { FilterOperation, ReceiptPagedRequestFilter } from "../open-api";
-import { ResetReceiptFilter, SetColumnConfig, SetPage, SetPageSize, SetReceiptFilter, SetReceiptFilterData } from "./receipt-table.actions";
+import { ReceiptPagedRequestFilter } from "../open-api";
+import { isFilterEntryActive } from "../utils/receipt-filter-entry";
+import { ResetReceiptFilter, SetColumnConfig, SetPage, SetPageSize, SetReceiptFilter, SetReceiptFilterData, SetReceiptFilterField } from "./receipt-table.actions";
 
-export const defaultReceiptFilter = {
-  date: {
-    operation: null,
-    value: null
-  },
-  amount: {
-    operation: null,
-    value: null,
-  },
-  name: {
-    operation: null,
-    value: null,
-  },
-  paidBy: {
-    operation: null,
-    value: [],
-  },
-  categories: {
-    operation: null,
-    value: [],
-  },
-  tags: {
-    operation: null,
-    value: [],
-  },
-  status: {
-    operation: null,
-    value: [],
-  },
-  group: {
-    operation: null,
-    value: [],
-  },
-  resolvedDate: {
-    operation: null,
-    value: null,
-  },
-  createdAt: {
-    operation: null,
-    value: null,
-  },
-} as ReceiptPagedRequestFilter;
+/**
+ * A pristine filter. This is a factory rather than a shared constant because
+ * the value is written straight into state on reset — handing out the same
+ * object every time would let a later in-place edit corrupt the default for the
+ * rest of the session.
+ */
+export function buildDefaultReceiptFilter(): ReceiptPagedRequestFilter {
+  return {
+    date: {
+      operation: null,
+      value: null
+    },
+    amount: {
+      operation: null,
+      value: null,
+    },
+    name: {
+      operation: null,
+      value: null,
+    },
+    paidBy: {
+      operation: null,
+      value: [],
+    },
+    categories: {
+      operation: null,
+      value: [],
+    },
+    tags: {
+      operation: null,
+      value: [],
+    },
+    status: {
+      operation: null,
+      value: [],
+    },
+    group: {
+      operation: null,
+      value: [],
+    },
+    resolvedDate: {
+      operation: null,
+      value: null,
+    },
+    createdAt: {
+      operation: null,
+      value: null,
+    },
+  } as ReceiptPagedRequestFilter;
+}
+
+export const defaultReceiptFilter = buildDefaultReceiptFilter();
 
 // TODO: look into fixing date equals
 @State<ReceiptTableInterface>({
@@ -56,7 +67,7 @@ export const defaultReceiptFilter = {
     pageSize: 50,
     orderBy: "created_at",
     sortDirection: "desc",
-    filter: defaultReceiptFilter,
+    filter: buildDefaultReceiptFilter(),
     columnConfig: DEFAULT_RECEIPT_TABLE_COLUMNS,
   },
 })
@@ -79,20 +90,11 @@ export class ReceiptTableState {
 
   @Selector()
   static numFiltersApplied(state: ReceiptTableInterface): number {
-    let filtersApplied = 0;
     const filter: any = state.filter;
 
-    Object.keys(filter).forEach((key) => {
-      const stringValue = filter[key]?.value?.toString();
-      const operationValue = filter[key]?.operation?.toString();
-      if (stringValue?.length > 0 && stringValue !== "0") {
-        filtersApplied += 1;
-      } else if (operationValue === FilterOperation.WithinCurrentMonth) {
-        filtersApplied += 1;
-      }
-    });
-
-    return filtersApplied;
+    // Shares isFilterEntryActive with the filter chips, so the badge count and
+    // the chips can never disagree about what counts as a condition.
+    return Object.keys(filter).filter((key) => isFilterEntryActive(filter[key])).length;
   }
 
   @Selector()
@@ -138,10 +140,29 @@ export class ReceiptTableState {
     });
   }
 
+  @Action(SetReceiptFilterField)
+  setReceiptFilterField(
+    { getState, patchState }: StateContext<ReceiptTableInterface>,
+    payload: SetReceiptFilterField
+  ) {
+    // A cleared field is rebuilt from a fresh default so the empty shape (list
+    // fields go back to [], scalars to null) has one source of truth, and the
+    // spread allocates a new container rather than writing through the current
+    // filter — which may be shared with another reference.
+    const clearedEntry = (buildDefaultReceiptFilter() as any)[payload.field];
+
+    patchState({
+      filter: {
+        ...getState().filter,
+        [payload.field]: payload.entry ?? clearedEntry,
+      },
+    });
+  }
+
   @Action(ResetReceiptFilter)
   resetFilter({ patchState }: StateContext<ReceiptTableInterface>) {
     patchState({
-      filter: defaultReceiptFilter,
+      filter: buildDefaultReceiptFilter(),
     });
   }
 

--- a/desktop/src/utils/receipt-date-filter.spec.ts
+++ b/desktop/src/utils/receipt-date-filter.spec.ts
@@ -1,0 +1,90 @@
+import { FilterOperation } from "../open-api";
+import { monthFilterEntry, monthFromFilterEntry, monthOfDate, shiftMonth } from "./receipt-date-filter";
+
+describe("receipt-date-filter", () => {
+  describe("monthFilterEntry", () => {
+    it("expresses a month as a BETWEEN over its first and last day", () => {
+      const entry = monthFilterEntry({ year: 2026, month: 8 });
+      const [start, end] = entry.value as Date[];
+
+      expect(entry.operation).toBe(FilterOperation.Between);
+      expect(start.getFullYear()).toBe(2026);
+      expect(start.getMonth()).toBe(8);
+      expect(start.getDate()).toBe(1);
+      expect(end.getMonth()).toBe(8);
+      expect(end.getDate()).toBe(30);
+    });
+
+    it("handles a 28-day February", () => {
+      const [, end] = monthFilterEntry({ year: 2026, month: 1 }).value as Date[];
+
+      expect(end.getDate()).toBe(28);
+    });
+  });
+
+  describe("monthFromFilterEntry", () => {
+    it("round-trips a month", () => {
+      expect(monthFromFilterEntry(monthFilterEntry({ year: 2026, month: 8 }))).toEqual({
+        year: 2026,
+        month: 8,
+      });
+    });
+
+    // The filter is persisted to localStorage, so every Date comes back as an
+    // ISO string. Without this the stepper would silently read "Custom" after
+    // every page reload.
+    it("round-trips a month that has been through JSON serialization", () => {
+      const persisted = JSON.parse(JSON.stringify(monthFilterEntry({ year: 2026, month: 11 })));
+
+      expect(monthFromFilterEntry(persisted)).toEqual({ year: 2026, month: 11 });
+    });
+
+    // The dialog's datepickers write local midnight for both ends, with no
+    // end-of-day component — that is still September.
+    it("matches on calendar days, not on the exact instant", () => {
+      expect(
+        monthFromFilterEntry({
+          operation: FilterOperation.Between,
+          value: [new Date(2026, 8, 1), new Date(2026, 8, 30)],
+        })
+      ).toEqual({ year: 2026, month: 8 });
+    });
+
+    it("returns null for a range that is not exactly one whole month", () => {
+      const partial = { operation: FilterOperation.Between, value: [new Date(2026, 8, 1), new Date(2026, 8, 15)] };
+      const spanning = { operation: FilterOperation.Between, value: [new Date(2026, 8, 1), new Date(2026, 9, 31)] };
+      const lateStart = { operation: FilterOperation.Between, value: [new Date(2026, 8, 2), new Date(2026, 8, 30)] };
+
+      expect(monthFromFilterEntry(partial)).toBeNull();
+      expect(monthFromFilterEntry(spanning)).toBeNull();
+      expect(monthFromFilterEntry(lateStart)).toBeNull();
+    });
+
+    it("returns null for any other operation or a malformed value", () => {
+      expect(monthFromFilterEntry({ operation: FilterOperation.GreaterThan, value: new Date(2026, 8, 1) })).toBeNull();
+      expect(monthFromFilterEntry({ operation: FilterOperation.WithinCurrentMonth, value: null })).toBeNull();
+      expect(monthFromFilterEntry({ operation: FilterOperation.Between, value: [new Date(2026, 8, 1)] })).toBeNull();
+      expect(monthFromFilterEntry({ operation: FilterOperation.Between, value: ["nonsense", "junk"] })).toBeNull();
+      expect(monthFromFilterEntry({ operation: null, value: null })).toBeNull();
+      expect(monthFromFilterEntry(undefined)).toBeNull();
+    });
+  });
+
+  describe("shiftMonth", () => {
+    it("steps within a year", () => {
+      expect(shiftMonth({ year: 2026, month: 8 }, 1)).toEqual({ year: 2026, month: 9 });
+      expect(shiftMonth({ year: 2026, month: 8 }, -1)).toEqual({ year: 2026, month: 7 });
+    });
+
+    it("rolls the year at both boundaries", () => {
+      expect(shiftMonth({ year: 2026, month: 11 }, 1)).toEqual({ year: 2027, month: 0 });
+      expect(shiftMonth({ year: 2026, month: 0 }, -1)).toEqual({ year: 2025, month: 11 });
+    });
+  });
+
+  describe("monthOfDate", () => {
+    it("reads the calendar month off a date", () => {
+      expect(monthOfDate(new Date(2026, 8, 11))).toEqual({ year: 2026, month: 8 });
+    });
+  });
+});

--- a/desktop/src/utils/receipt-date-filter.ts
+++ b/desktop/src/utils/receipt-date-filter.ts
@@ -1,0 +1,90 @@
+import { endOfMonth, getDaysInMonth, isValid, startOfMonth } from "date-fns";
+import { FilterOperation } from "../open-api";
+import { ReceiptFilterEntry } from "./receipt-filter-entry";
+
+/** A calendar month. `month` is zero-based, matching `Date.getMonth()`. */
+export interface FilterMonth {
+  year: number;
+  month: number;
+}
+
+/**
+ * The filter entry for a whole calendar month.
+ *
+ * A month is expressed as `BETWEEN [first day, last day]` — the one operation
+ * that can describe *any* month, so the quick date control needs no API change.
+ * (`WITHIN_CURRENT_MONTH` is not equivalent: the server pins it to
+ * month-start through *today*, so it can only ever mean the current month.)
+ */
+export function monthFilterEntry(month: FilterMonth): ReceiptFilterEntry {
+  const start = startOfMonth(new Date(month.year, month.month, 1));
+
+  return {
+    operation: FilterOperation.Between,
+    value: [start, endOfMonth(start)],
+  };
+}
+
+/**
+ * The month a filter entry describes, or `null` when it describes anything else
+ * (a partial range, a `GREATER_THAN`, `WITHIN_CURRENT_MONTH`, nothing at all).
+ *
+ * Values arrive as `Date`s from the datepickers but as ISO **strings** once the
+ * filter has been through the persisted NGXS state, so both are accepted.
+ * Comparison is on calendar fields rather than on the serialized text, which
+ * differs between the two forms.
+ */
+export function monthFromFilterEntry(entry: unknown): FilterMonth | null {
+  const typedEntry = entry as ReceiptFilterEntry | undefined | null;
+
+  if (typedEntry?.operation?.toString() !== FilterOperation.Between) {
+    return null;
+  }
+
+  const value = typedEntry.value;
+  if (!Array.isArray(value) || value.length !== 2) {
+    return null;
+  }
+
+  const start = toDate(value[0]);
+  const end = toDate(value[1]);
+
+  if (!start || !end) {
+    return null;
+  }
+
+  const spansWholeMonth =
+    start.getDate() === 1 &&
+    start.getFullYear() === end.getFullYear() &&
+    start.getMonth() === end.getMonth() &&
+    end.getDate() === getDaysInMonth(start);
+
+  return spansWholeMonth
+    ? { year: start.getFullYear(), month: start.getMonth() }
+    : null;
+}
+
+/** Steps a month by `delta` months, rolling the year at the boundaries. */
+export function shiftMonth(month: FilterMonth, delta: number): FilterMonth {
+  const shifted = new Date(month.year, month.month + delta, 1);
+
+  return { year: shifted.getFullYear(), month: shifted.getMonth() };
+}
+
+/** The calendar month a date falls in. */
+export function monthOfDate(date: Date): FilterMonth {
+  return { year: date.getFullYear(), month: date.getMonth() };
+}
+
+function toDate(value: unknown): Date | null {
+  if (value instanceof Date) {
+    return isValid(value) ? value : null;
+  }
+
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = new Date(value);
+    return isValid(parsed) ? parsed : null;
+  }
+
+  return null;
+}

--- a/desktop/src/utils/receipt-filter-chips.spec.ts
+++ b/desktop/src/utils/receipt-filter-chips.spec.ts
@@ -1,0 +1,107 @@
+import { Category, FilterOperation, Group, ReceiptPagedRequestFilter, Tag, User } from "../open-api";
+import { buildReceiptFilterChips, ReceiptFilterChipLookups } from "./receipt-filter-chips";
+
+const lookups: ReceiptFilterChipLookups = {
+  categories: [{ id: 3, name: "Groceries" }, { id: 7, name: "Dining" }] as Category[],
+  tags: [{ id: 1, name: "Reimbursable" }] as Tag[],
+  groups: [{ id: 4, name: "Household" }] as Group[],
+  users: [{ id: 2, displayName: "Dana Kim" }] as User[],
+  formatDate: (value) => (value ? new Date(value as string).toDateString() : ""),
+  formatCurrency: (value) => `$${Number(value).toFixed(2)}`,
+};
+
+function filterWith(partial: Record<string, unknown>): ReceiptPagedRequestFilter {
+  return partial as ReceiptPagedRequestFilter;
+}
+
+describe("buildReceiptFilterChips", () => {
+  it("returns nothing for an empty or missing filter", () => {
+    expect(buildReceiptFilterChips(undefined, lookups)).toEqual([]);
+    expect(buildReceiptFilterChips(filterWith({ name: { operation: null, value: "" } }), lookups)).toEqual([]);
+  });
+
+  it("emits one chip per active field, in dialog order", () => {
+    const chips = buildReceiptFilterChips(
+      filterWith({
+        status: { operation: FilterOperation.Contains, value: ["OPEN"] },
+        name: { operation: FilterOperation.Contains, value: "whole" },
+        tags: { operation: FilterOperation.Contains, value: [] },
+      }),
+      lookups
+    );
+
+    expect(chips.map((chip) => chip.key)).toEqual(["name", "status"]);
+  });
+
+  it("labels a BETWEEN date range", () => {
+    const [chip] = buildReceiptFilterChips(
+      filterWith({
+        date: {
+          operation: FilterOperation.Between,
+          value: [new Date(2026, 8, 1), new Date(2026, 8, 30)],
+        },
+      }),
+      lookups
+    );
+
+    expect(chip.label).toBe("Date between Tue Sep 01 2026 – Wed Sep 30 2026");
+  });
+
+  it("labels a currency comparison", () => {
+    const [chip] = buildReceiptFilterChips(
+      filterWith({ amount: { operation: FilterOperation.GreaterThan, value: 25 } }),
+      lookups
+    );
+
+    expect(chip.label).toBe("Amount greater than $25.00");
+  });
+
+  it("resolves ids to names for every list-shaped field", () => {
+    const chips = buildReceiptFilterChips(
+      filterWith({
+        paidBy: { operation: FilterOperation.Contains, value: [2] },
+        group: { operation: FilterOperation.Contains, value: [4] },
+        categories: { operation: FilterOperation.Contains, value: [3, 7] },
+        status: { operation: FilterOperation.Contains, value: ["OPEN"] },
+      }),
+      lookups
+    );
+
+    expect(chips.map((chip) => chip.label)).toEqual([
+      "Paid by contains Dana Kim",
+      "Group contains Household",
+      "Categories contains Groceries, Dining",
+      "Status contains Open",
+    ]);
+  });
+
+  // A category outside the user's grants, or a group they have left, still has
+  // to be visible so it can be cleared.
+  it("falls back to the raw id when a lookup misses", () => {
+    const [chip] = buildReceiptFilterChips(
+      filterWith({ categories: { operation: FilterOperation.Contains, value: [99] } }),
+      lookups
+    );
+
+    expect(chip.label).toBe("Categories contains 99");
+  });
+
+  // WITHIN_CURRENT_MONTH carries no value, so the label stops at the operation.
+  it("labels WITHIN_CURRENT_MONTH without a value segment", () => {
+    const [chip] = buildReceiptFilterChips(
+      filterWith({ date: { operation: FilterOperation.WithinCurrentMonth, value: null } }),
+      lookups
+    );
+
+    expect(chip.label).toBe("Date within current month");
+  });
+
+  it("omits the keys the caller already renders elsewhere", () => {
+    const filter = filterWith({
+      date: { operation: FilterOperation.Between, value: [new Date(2026, 8, 1), new Date(2026, 8, 30)] },
+      name: { operation: FilterOperation.Contains, value: "whole" },
+    });
+
+    expect(buildReceiptFilterChips(filter, lookups, ["date"]).map((chip) => chip.key)).toEqual(["name"]);
+  });
+});

--- a/desktop/src/utils/receipt-filter-chips.ts
+++ b/desktop/src/utils/receipt-filter-chips.ts
@@ -1,0 +1,134 @@
+import { FILTER_OPERATION_DISPLAY_VALUES } from "../constants/filter-operations-options.constant";
+import {
+  RECEIPT_FILTER_FIELDS,
+  ReceiptFilterField,
+  ReceiptFilterFieldKey,
+} from "../constants/receipt-filter-fields.constant";
+import { RECEIPT_STATUS_OPTIONS } from "../constants/receipt-status-options";
+import { Category, FilterOperation, Group, ReceiptPagedRequestFilter, Tag, User } from "../open-api";
+import { isFilterEntryActive, ReceiptFilterEntry } from "./receipt-filter-entry";
+
+export interface ReceiptFilterChip {
+  key: ReceiptFilterFieldKey;
+  label: string;
+}
+
+/**
+ * Everything needed to turn stored ids into names. Passed in rather than looked
+ * up here so the builder stays pure and testable — the same shape
+ * `report-template-summary.ts` uses.
+ */
+export interface ReceiptFilterChipLookups {
+  categories: readonly Category[];
+  tags: readonly Tag[];
+  groups: readonly Group[];
+  users: readonly User[];
+  formatDate: (value: unknown) => string;
+  formatCurrency: (value: unknown) => string;
+}
+
+const BETWEEN_SEPARATOR = " – ";
+
+/**
+ * One chip per filter field that actually narrows the result set, labelled
+ * `"<Field> <operation> <value>"`.
+ *
+ * `omitKeys` lets a caller suppress a field it already renders another way —
+ * the receipts table passes `["date"]` while the month stepper is displaying
+ * that exact month, so the same condition never appears twice.
+ */
+export function buildReceiptFilterChips(
+  filter: ReceiptPagedRequestFilter | undefined | null,
+  lookups: ReceiptFilterChipLookups,
+  omitKeys: readonly string[] = [],
+): ReceiptFilterChip[] {
+  if (!filter) {
+    return [];
+  }
+
+  return RECEIPT_FILTER_FIELDS.filter(
+    (field) =>
+      !omitKeys.includes(field.key) &&
+      isFilterEntryActive((filter as Record<string, unknown>)[field.key]),
+  ).map((field) => ({
+    key: field.key,
+    label: buildLabel(field, (filter as Record<string, unknown>)[field.key] as ReceiptFilterEntry, lookups),
+  }));
+}
+
+function buildLabel(
+  field: ReceiptFilterField,
+  entry: ReceiptFilterEntry,
+  lookups: ReceiptFilterChipLookups,
+): string {
+  const operation = entry?.operation?.toString() ?? "";
+  const operationLabel = (FILTER_OPERATION_DISPLAY_VALUES[operation] ?? "").toLowerCase();
+
+  // WITHIN_CURRENT_MONTH carries no value, so the label stops at the operation.
+  const valueLabel =
+    operation === FilterOperation.WithinCurrentMonth
+      ? ""
+      : buildValueLabel(field, entry, operation, lookups);
+
+  return [field.label, operationLabel, valueLabel].filter((part) => !!part).join(" ");
+}
+
+function buildValueLabel(
+  field: ReceiptFilterField,
+  entry: ReceiptFilterEntry,
+  operation: string,
+  lookups: ReceiptFilterChipLookups,
+): string {
+  const value = entry?.value;
+
+  if (field.type === "date" || field.type === "number") {
+    const format = field.type === "date" ? lookups.formatDate : lookups.formatCurrency;
+
+    if (operation === FilterOperation.Between && Array.isArray(value)) {
+      return [format(value[0]), format(value[1])].join(BETWEEN_SEPARATOR);
+    }
+
+    return format(value);
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((id) => resolveOptionName(field.key, id, lookups)).join(", ");
+  }
+
+  return value?.toString() ?? "";
+}
+
+/**
+ * An id the caller can no longer resolve — a category outside their grants, a
+ * group they have left — falls back to the raw id rather than vanishing, so the
+ * condition stays visible and clearable.
+ */
+function resolveOptionName(
+  key: ReceiptFilterFieldKey,
+  id: unknown,
+  lookups: ReceiptFilterChipLookups,
+): string {
+  const rawId = String(id);
+
+  switch (key) {
+    case "categories":
+      return findName(lookups.categories, rawId) ?? rawId;
+    case "tags":
+      return findName(lookups.tags, rawId) ?? rawId;
+    case "group":
+      return findName(lookups.groups, rawId) ?? rawId;
+    case "paidBy":
+      return lookups.users.find((user) => String(user.id) === rawId)?.displayName ?? rawId;
+    case "status":
+      return RECEIPT_STATUS_OPTIONS.find((option) => option.value === rawId)?.displayValue ?? rawId;
+    default:
+      return rawId;
+  }
+}
+
+function findName(
+  options: readonly { id?: number; name?: string }[],
+  rawId: string,
+): string | undefined {
+  return options.find((option) => String(option.id) === rawId)?.name;
+}

--- a/desktop/src/utils/receipt-filter-entry.spec.ts
+++ b/desktop/src/utils/receipt-filter-entry.spec.ts
@@ -16,10 +16,11 @@ describe("isFilterEntryActive", () => {
     expect(isFilterEntryActive(null)).toBe(false);
   });
 
-  // An untouched numeric field stringifies to "0", which must not read as a
-  // condition — this is the rule the filter-count badge has always applied.
-  it("treats a zero value as inactive", () => {
-    expect(isFilterEntryActive({ operation: FilterOperation.Equals, value: 0 })).toBe(false);
+  // No field defaults to 0 — they default to null or [] — so a zero was typed,
+  // and the API applies it. Hiding its badge and chip would leave a filter that
+  // narrows the table with no way to see or clear it.
+  it("treats a zero value as active", () => {
+    expect(isFilterEntryActive({ operation: FilterOperation.Equals, value: 0 })).toBe(true);
   });
 
   // The one operation that carries no value: the API pins the range itself.

--- a/desktop/src/utils/receipt-filter-entry.spec.ts
+++ b/desktop/src/utils/receipt-filter-entry.spec.ts
@@ -1,0 +1,31 @@
+import { FilterOperation } from "../open-api";
+import { isFilterEntryActive } from "./receipt-filter-entry";
+
+describe("isFilterEntryActive", () => {
+  it("treats a populated value as active", () => {
+    expect(isFilterEntryActive({ operation: FilterOperation.Contains, value: "whole" })).toBe(true);
+    expect(isFilterEntryActive({ operation: FilterOperation.Contains, value: [1, 2] })).toBe(true);
+    expect(isFilterEntryActive({ operation: FilterOperation.Equals, value: 12.5 })).toBe(true);
+  });
+
+  it("treats an empty value as inactive", () => {
+    expect(isFilterEntryActive({ operation: null, value: null })).toBe(false);
+    expect(isFilterEntryActive({ operation: null, value: [] })).toBe(false);
+    expect(isFilterEntryActive({ operation: null, value: "" })).toBe(false);
+    expect(isFilterEntryActive(undefined)).toBe(false);
+    expect(isFilterEntryActive(null)).toBe(false);
+  });
+
+  // An untouched numeric field stringifies to "0", which must not read as a
+  // condition — this is the rule the filter-count badge has always applied.
+  it("treats a zero value as inactive", () => {
+    expect(isFilterEntryActive({ operation: FilterOperation.Equals, value: 0 })).toBe(false);
+  });
+
+  // The one operation that carries no value: the API pins the range itself.
+  it("treats WITHIN_CURRENT_MONTH as active despite having no value", () => {
+    expect(
+      isFilterEntryActive({ operation: FilterOperation.WithinCurrentMonth, value: null })
+    ).toBe(true);
+  });
+});

--- a/desktop/src/utils/receipt-filter-entry.ts
+++ b/desktop/src/utils/receipt-filter-entry.ts
@@ -14,14 +14,18 @@ export interface ReceiptFilterEntry {
  *
  * `WITHIN_CURRENT_MONTH` is the one operation that carries no value — the API
  * pins the range to the current month itself — so it counts on the operation
- * alone. Everything else needs a non-empty value, and `"0"` is excluded so an
- * untouched numeric field doesn't read as a condition.
+ * alone. Everything else needs a non-empty value.
+ *
+ * Zero counts. Every field defaults to `null` or `[]`, never `0`, so a zero can
+ * only have been typed — and the API applies it (`Filter.Amount.Value != nil`
+ * is satisfied by a JSON `0`), so an `amount EQUALS 0` filter really does
+ * narrow the table and has to be visible and clearable like any other.
  */
 export function isFilterEntryActive(entry: unknown): boolean {
   const typedEntry = entry as ReceiptFilterEntry | undefined | null;
   const stringValue = typedEntry?.value?.toString();
 
-  if (stringValue !== undefined && stringValue.length > 0 && stringValue !== "0") {
+  if (stringValue !== undefined && stringValue.length > 0) {
     return true;
   }
 

--- a/desktop/src/utils/receipt-filter-entry.ts
+++ b/desktop/src/utils/receipt-filter-entry.ts
@@ -1,0 +1,29 @@
+import { FilterOperation } from "../open-api";
+
+/**
+ * A single `{ operation, value }` pair out of a `ReceiptPagedRequestFilter`.
+ * The generated model types every field as `object`, so callers hand us this.
+ */
+export interface ReceiptFilterEntry {
+  operation?: FilterOperation | null;
+  value?: unknown;
+}
+
+/**
+ * Whether a filter field actually narrows the result set.
+ *
+ * `WITHIN_CURRENT_MONTH` is the one operation that carries no value — the API
+ * pins the range to the current month itself — so it counts on the operation
+ * alone. Everything else needs a non-empty value, and `"0"` is excluded so an
+ * untouched numeric field doesn't read as a condition.
+ */
+export function isFilterEntryActive(entry: unknown): boolean {
+  const typedEntry = entry as ReceiptFilterEntry | undefined | null;
+  const stringValue = typedEntry?.value?.toString();
+
+  if (stringValue !== undefined && stringValue.length > 0 && stringValue !== "0") {
+    return true;
+  }
+
+  return typedEntry?.operation?.toString() === FilterOperation.WithinCurrentMonth;
+}


### PR DESCRIPTION
## Summary
Adds a month-based quick date filter to the receipts table, replacing the quick-scan button in the toolbar with a new month stepper component. The filter integrates with the existing advanced filter dialog and persists to localStorage, allowing users to quickly narrow receipts by calendar month.

## Key Changes

- **Month Stepper Component** (`app-month-stepper`): A new presentational component that provides previous/next arrows, a label button opening a year pager and month grid, and shortcuts for "This month", "Last month", and "All time". Emits `FilterMonth` objects or an "all time" signal.

- **Date Filter Utilities** (`receipt-date-filter.ts`): Bidirectional conversion between `FilterMonth` objects and `BETWEEN` filter entries. Handles round-tripping through JSON serialization (localStorage persistence) and calendar-day matching rather than exact timestamps.

- **Filter Entry Abstraction** (`receipt-filter-entry.ts`): Shared predicate `isFilterEntryActive()` determines whether a filter field narrows results. Recognizes `WITHIN_CURRENT_MONTH` as active despite carrying no value, and treats zero-valued fields as inactive.

- **Filter Chip Builder** (`receipt-filter-chips.ts`): Generates one chip per active filter field with labels like "Date between Sep 1 – Sep 30". Resolves category/tag/group/user IDs to names and formats dates/currency. Supports omitting fields already rendered elsewhere (e.g., date when the month stepper is visible).

- **Receipts Table Refactor**:
  - Toolbar reorganized: month stepper added, quick-scan and export buttons moved to overflow menu
  - Filter chips now render below the toolbar
  - Month stepper and chips both read/write `ReceiptTableState.filter`, ensuring they never disagree
  - `SetReceiptFilterField` action added for single-field updates with automatic reset to defaults

- **State Management**:
  - `defaultReceiptFilter` converted to `buildDefaultReceiptFilter()` factory to prevent shared-object mutations
  - `numFiltersApplied()` selector now uses `isFilterEntryActive()` for consistency with chip builder
  - New `SetReceiptFilterField` action for targeted filter updates

- **Field Metadata** (`receipt-filter-fields.constant.ts`): Centralized definition of filterable fields (key, label, type) used by dialog, chip builder, and operations pipe.

- **E2E Test** (`receipt-quick-date-filter.spec.ts`): Comprehensive test suite verifying month selection narrows the table, filter survives page reload, and chips/dialog share one filter without duplication.

- **Helper Updates**: `gotoReceiptsTable()` and `openReceiptsOverflowMenu()` helpers added for e2e tests; existing specs updated to use overflow menu for quick-scan and other toolbar actions.

## Implementation Details

- The month stepper is deliberately presentational—it knows nothing about filtering, only emits months. The receipts table component handles the store integration.
- Filter persistence to localStorage serializes `Date` objects as ISO strings; `monthFromFilterEntry()` reconstructs the month from strings without requiring the original `Date` objects.
- The chip builder is pure and testable, accepting a lookups object for ID-to-name resolution rather than performing service lookups.
- The overflow menu consolidates secondary toolbar actions (quick-scan, export, column config, poll email) to reduce toolbar clutter on narrow viewports.

https://claude.ai/code/session_017PoCksgW3b6zeKkLxYfV3Q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added month-based receipt filtering with previous/next navigation, month selection, relative-month shortcuts, and an all-time option.
  - Added filter chips showing active receipt filters, with individual removal controls and reset behavior.
  - Consolidated receipt actions—including Quick Scan, exports, column settings, and bulk actions—into an overflow menu.

- **Bug Fixes**
  - Improved filter persistence, pagination reset, date handling, and filter-state reset behavior.
  - Updated navigation and feature-access checks to use the receipts overflow menu consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->