### PR TITLE
Apply group default custom fields on load in every form state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -266,6 +266,12 @@ A group can declare custom fields that are **always pre-added** to its receipts,
     both clients already submit one per attached field because the backend replaces the whole
     association on update. And **a default applied on load stays auto-managed**, so changing the
     group on that form drops it again while it is still empty.
+  - **Each client tracks that "the form added this, the user didn't" differently**, because their
+    form lifecycles differ. Desktop re-derives it every `initForm()`, which rebuilds the custom-field
+    `FormArray` from the saved receipt, so an unsaved manual edit never survives a navigation.
+    Mobile's `ReceiptModel` *does* outlive its screen, so the provenance set lives on the model
+    (`ReceiptModel.autoAppliedCustomFieldIds`) — see `mobile/CLAUDE.md`. Inferring it from the saved
+    receipt instead reclaims a field the user removed and re-added by hand, and then drops it.
 - **Both clients gate on `app.custom-fields.read`.** The server's
   `enforceReceiptCustomFieldSelection` **403s** any save that changes the set of attached custom
   field ids for a caller without it, so auto-adding fields for such a user would make their receipts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,12 +253,19 @@ A group can declare custom fields that are **always pre-added** to its receipts,
   `applyDefaultCustomFieldsOnIngest`, which attaches the set to receipts the **server** creates
   (quick scan, email). Deleting a custom field removes it from every group's set. See
   `api/CLAUDE.md` → "Group Default Custom Fields".
-- **Both clients apply the set on the receipt form**, on create and whenever the group changes, with
-  the same "smart swap" rule: an auto-added field that is still **empty** is dropped when you switch
-  away, anything you typed into or added by hand is kept, and the new group's missing defaults are
-  added. A field the user adds or removes by hand stops being auto-managed. See
-  `desktop/CLAUDE.md` → "Per-group default custom fields" and `mobile/CLAUDE.md` → "Group default
-  custom fields".
+- **Both clients apply the set on the receipt form**, on load in **every** mode — create, edit and
+  read-only view — and whenever the group changes, with the same "smart swap" rule: an auto-added
+  field that is still **empty** is dropped when you switch away, anything you typed into or added by
+  hand is kept, and the new group's missing defaults are added. A field the user adds or removes by
+  hand stops being auto-managed. See `desktop/CLAUDE.md` → "Per-group default custom fields" and
+  `mobile/CLAUDE.md` → "Group default custom fields".
+  - **Applying on load is what makes a default read as a built-in field.** A receipt saved before the
+    group was configured shows the field too: blank and read-only in view, editable in edit. Two
+    consequences worth knowing. **Saving an edited receipt persists the defaults as empty attached
+    values** — an empty value is meaningful, it records that the field belongs on the receipt, and
+    both clients already submit one per attached field because the backend replaces the whole
+    association on update. And **a default applied on load stays auto-managed**, so changing the
+    group on that form drops it again while it is still empty.
 - **Both clients gate on `app.custom-fields.read`.** The server's
   `enforceReceiptCustomFieldSelection` **403s** any save that changes the set of attached custom
   field ids for a caller without it, so auto-adding fields for such a user would make their receipts

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -692,12 +692,17 @@ Custom Fields** `app-form-section` on `src/group/group-receipt-settings/` (betwe
 - **Receipt form "smart swap".** `applyGroupDefaultCustomFields(groupId)` runs **inside**
   `listenForGroupChanges()`'s `tap`, **after** the `selectedGroup.set(group)` write — under zoneless
   CD that signal write is the only change-detection trigger; a FormArray mutation has none of its own.
-  It returns early in view mode, without `canManageCustomFields()`, on a falsy group id, and — via
-  `groupChangeIsInitialEmission` — on the listener's `startWith()` replay unless the mode is `add`.
-  That guard is the **only** thing keeping an edit-mode receipt untouched on load, since `startWith`
-  fires at init in every mode. Both it and `autoAppliedCustomFieldIds` are reset at the **top** of
-  `initForm()` (which re-runs on every route-data emission) so a stale auto set can never strip a
-  saved receipt's own fields.
+  It returns early only without `canManageCustomFields()` and on a falsy group id.
+- **It applies on load in every mode**, via that listener's `startWith()` replay, which fires at init
+  in `add`, `edit` **and** `view`. A group's defaults are meant to read as its built-in receipt
+  fields, so a receipt saved before the group was configured picks them up too — blank and read-only
+  in view (the template's `@for` already binds `[readonly]="mode | inputReadonly"`), editable in edit,
+  and persisted as empty attached values once that edit is saved. `addCustomFieldControl` skips a
+  field the form already carries, so a receipt that already has the default is untouched.
+  `autoAppliedCustomFieldIds` is reset at the **top** of `initForm()` (which re-runs on every
+  route-data emission), which is what makes the removal pass inert on load — a stale auto set could
+  otherwise strip a saved receipt's own fields — and it is also why a default applied on load is
+  still the swap's to take back on a later group change.
 - The swap drops a previously auto-added default only while it is still **empty**
   (`isCustomFieldControlEmpty`: every typed column null-or-`""` **and** `booleanValue` falsy — so a
   BOOLEAN deliberately left `false` counts as empty and is swapped out); anything with a value stays
@@ -716,6 +721,10 @@ delivery paths, which the Jest specs cannot — they inject settings into a mock
   the proof the client sent every attached field (an id set that doesn't match the stored one is a
   403 from `enforceReceiptCustomFieldSelection`). Verified to FAIL with the empty-check inverted.
 - Deleting a custom field prunes it from the group's stored set.
+- A receipt created while its group declared **nothing** shows the field once the group gains it:
+  blank on `/receipts/:id/view`, editable on `/edit`, and the value survives a save + re-navigation.
+  Reaching the view page after that save is the proof `enforceReceiptCustomFieldSelection` accepted
+  the newly attached id.
 
 Three `data-testid`s were added for it, none of them pre-existing: **`autocomplete-clear`** on the
 shared `app-autocomlete`'s clear button, **`receipt-group`** on the receipt form's group picker, and

--- a/desktop/e2e/group-default-custom-fields.spec.ts
+++ b/desktop/e2e/group-default-custom-fields.spec.ts
@@ -1,10 +1,12 @@
 import { expect, test, type Page } from '@playwright/test';
-import { stubTokenRefresh } from './helpers/auth';
+import { creds, stubTokenRefresh } from './helpers/auth';
 import {
   apiCreateCustomField,
   apiCreateGroup,
+  apiCreateReceipt,
   apiDeleteCustomFieldById,
   apiDeleteGroupById,
+  apiGetUserId,
   apiSetGroupDefaultCustomFields,
   uniqueName,
   withAdminApi,
@@ -17,7 +19,9 @@ import {
 //   - the settings page reads GET /group/{id} through groupResolverFn, so test 1 is a real
 //     persistence round-trip;
 //   - the receipt form reads GroupState, hydrated from AppData on every navigation, so test 2
-//     proves the ids reach a different consumer over a different endpoint.
+//     proves the ids reach a different consumer over a different endpoint;
+//   - a saved receipt picks its group's defaults up on load, so test 4 proves the retro-fit
+//     survives a real save (enforceReceiptCustomFieldSelection would 403 a mismatched id set).
 //
 // Runs as admin: the section needs group.update + app.custom-fields.read, and seeding custom
 // fields needs app.custom-fields.create/delete.
@@ -106,6 +110,15 @@ test.describe('Group default custom fields', () => {
     await page.waitForURL(/\/receipt-settings\/view/);
   }
 
+  /** Asserts the receipt form's mounted custom-field set is exactly [names] — count included, so
+   *  a duplicated field fails as loudly as a missing one. */
+  async function expectFields(page: Page, names: string[]) {
+    await expect(page.locator('app-custom-field')).toHaveCount(names.length);
+    for (const name of names) {
+      await expect(page.getByLabel(name)).toBeVisible();
+    }
+  }
+
   test('the picker persists a group default set and its ingest toggle', async ({ page }) => {
     await page.goto(`/groups/${alpha.id}/receipt-settings/edit`);
     await expect(defaultFieldsPicker(page)).toBeVisible();
@@ -192,15 +205,6 @@ test.describe('Group default custom fields', () => {
       await expect(page.getByLabel(name)).toBeVisible();
     }
 
-    /** Asserts the mounted custom-field set is exactly [names] — count included, so a duplicated
-     *  field fails as loudly as a missing one. */
-    async function expectFields(names: string[]) {
-      await expect(page.locator('app-custom-field')).toHaveCount(names.length);
-      for (const name of names) {
-        await expect(page.getByLabel(name)).toBeVisible();
-      }
-    }
-
     const receiptName = uniqueName('dcf-receipt');
     await page.goto('/receipts/add');
     await expect(page.getByLabel('Name')).toBeVisible();
@@ -209,23 +213,23 @@ test.describe('Group default custom fields', () => {
 
     // Alpha declares A + B, so both are pre-added on the create form.
     await selectGroup(alpha.name);
-    await expectFields([nameA, nameB]);
+    await expectFields(page, [nameA, nameB]);
 
     // Typing into A makes it the user's data; C is added by hand, so it is never auto-managed.
     await page.getByLabel(nameA).fill('kept-A');
     await addFieldByHand(nameC);
-    await expectFields([nameA, nameB, nameC]);
+    await expectFields(page, [nameA, nameB, nameC]);
 
     // Beta declares only C. B is the only field the swap owns AND is still empty, so it is the
     // only one dropped; C is already attached and must not be added a second time.
     await selectGroup(beta.name);
-    await expectFields([nameA, nameC]);
+    await expectFields(page, [nameA, nameC]);
     await expect(page.getByLabel(nameA)).toHaveValue('kept-A');
 
     // Back to Alpha: B returns as a default and must come back BLANK (the form drops an
     // auto-applied field's stored value on removal), C stays because the user added it.
     await selectGroup(alpha.name);
-    await expectFields([nameA, nameB, nameC]);
+    await expectFields(page, [nameA, nameB, nameC]);
     await expect(page.getByLabel(nameA)).toHaveValue('kept-A');
     await expect(page.getByLabel(nameB)).toHaveValue('');
 
@@ -243,5 +247,40 @@ test.describe('Group default custom fields', () => {
     await expect(page.getByLabel(nameA)).toHaveValue('kept-A');
     await expect(page.getByLabel(nameB)).toHaveValue('typed-B');
     await expect(page.getByLabel(nameC)).toBeVisible();
+  });
+
+  test('a saved receipt picks up a default its group gained afterwards', async ({ page }) => {
+    // The receipt is created while beta declares nothing, so the field can only be on the form
+    // because the form put it there on load.
+    let receiptId: number;
+    const receiptName = uniqueName('dcf-existing');
+    await withAdminApi(async (api) => {
+      await apiSetGroupDefaultCustomFields(api, beta.id, []);
+      receiptId = await apiCreateReceipt(api, {
+        groupId: beta.id,
+        paidByUserId: await apiGetUserId(api, creds('admin').username),
+        name: receiptName,
+      });
+      await apiSetGroupDefaultCustomFields(api, beta.id, [fieldA.id]);
+    });
+
+    // View mode: blank and read-only, exactly like a built-in field with no value.
+    await page.goto(`/receipts/${receiptId!}/view`);
+    await expect(page.getByLabel('Name')).toHaveValue(receiptName);
+    await expectFields(page, [nameA]);
+    await expect(page.getByLabel(nameA)).toHaveValue('');
+
+    await page.goto(`/receipts/${receiptId!}/edit`);
+    await expect(page.getByLabel('Name')).toHaveValue(receiptName);
+    await expectFields(page, [nameA]);
+
+    await page.getByLabel(nameA).fill('retro-fitted');
+    await page.getByRole('button', { name: 'Save', exact: true }).first().click({ force: true });
+    await page.waitForURL(/\/receipts\/\d+\/view/);
+
+    // Reaching /view proves enforceReceiptCustomFieldSelection accepted the newly attached id;
+    // re-navigating proves the value came back out of the server rather than the live form.
+    await page.goto(`/receipts/${receiptId!}/view`);
+    await expect(page.getByLabel(nameA)).toHaveValue('retro-fitted');
   });
 });

--- a/desktop/src/receipts/receipt-form/receipt-form.component.spec.ts
+++ b/desktop/src/receipts/receipt-form/receipt-form.component.spec.ts
@@ -822,6 +822,22 @@ describe("ReceiptFormComponent", () => {
       routeDataSubject.next({ mode: FormMode.add, customFields });
     };
 
+    const savedReceipt = (groupId: number, customFields: any[] = []): any => ({
+      id: 9,
+      name: "R",
+      amount: "1.00",
+      groupId,
+      customFields,
+    });
+
+    const openSavedForm = (
+      mode: FormMode,
+      receipt: any,
+      customFields: any[] = catalog
+    ): void => {
+      routeDataSubject.next({ mode, customFields, receipt });
+    };
+
     beforeEach(() => {
       store = TestBed.inject(Store);
       store.dispatch(new SetPermissions([Permission.AppCustomFieldsRead], {}));
@@ -900,38 +916,60 @@ describe("ReceiptFormComponent", () => {
       expect(attachedIds()).toEqual([2]);
     });
 
-    it("applies nothing to an edit-mode receipt on load", () => {
-      routeDataSubject.next({
-        mode: FormMode.edit,
-        customFields: catalog,
-        receipt: { id: 9, name: "R", amount: "1.00", groupId: 1, customFields: [] } as any,
-      });
+    // A group's defaults are meant to read as its built-in receipt fields, so a
+    // saved receipt that predates the configuration picks them up too.
+    it("applies the group's missing defaults to an edit-mode receipt on load", () => {
+      openSavedForm(FormMode.edit, savedReceipt(1));
 
-      expect(attachedIds()).toEqual([]);
+      expect(attachedIds()).toEqual([1]);
+      expect(menuItemFor(1).selected).toBe(true);
     });
 
-    it("applies the new group's defaults on an active group change in edit mode", () => {
-      routeDataSubject.next({
-        mode: FormMode.edit,
-        customFields: catalog,
-        receipt: { id: 9, name: "R", amount: "1.00", groupId: 1, customFields: [] } as any,
-      });
+    it("applies the group's missing defaults in view mode", () => {
+      openSavedForm(FormMode.view, savedReceipt(1));
+
+      expect(attachedIds()).toEqual([1]);
+      expect(menuItemFor(1).selected).toBe(true);
+    });
+
+    it("keeps the receipt's own custom fields alongside the ones it adds", () => {
+      // Field 2 is the receipt's own; group 1 defaults to field 1.
+      openSavedForm(
+        FormMode.edit,
+        savedReceipt(1, [{ customFieldId: 2, stringValue: "PO-1" }])
+      );
+
+      expect(attachedIds()).toEqual([2, 1]);
+      expect(component.customFieldsFormArray.at(0).value.stringValue).toEqual("PO-1");
+    });
+
+    it("does not duplicate a default the receipt already carries", () => {
+      openSavedForm(
+        FormMode.edit,
+        savedReceipt(1, [{ customFieldId: 1, stringValue: "R&D" }])
+      );
+
+      expect(attachedIds()).toEqual([1]);
+      expect(component.customFieldsFormArray.at(0).value.stringValue).toEqual("R&D");
+    });
+
+    it("hands a load-applied default to the swap, so a group change drops it while empty", () => {
+      openSavedForm(FormMode.edit, savedReceipt(1));
+      expect(attachedIds()).toEqual([1]);
 
       component.form.get("groupId")!.setValue(2);
 
       expect(attachedIds()).toEqual([2]);
     });
 
-    it("never applies defaults in view mode", () => {
-      routeDataSubject.next({
-        mode: FormMode.view,
-        customFields: catalog,
-        receipt: { id: 9, name: "R", amount: "1.00", groupId: 1, customFields: [] } as any,
-      });
+    it("applies the new group's defaults on an active group change in edit mode", () => {
+      // Group 3 configures none, so nothing is applied until the group changes.
+      openSavedForm(FormMode.edit, savedReceipt(3));
+      expect(attachedIds()).toEqual([]);
 
       component.form.get("groupId")!.setValue(2);
 
-      expect(attachedIds()).toEqual([]);
+      expect(attachedIds()).toEqual([2]);
     });
 
     it("never applies defaults without app.custom-fields.read", () => {
@@ -941,6 +979,12 @@ describe("ReceiptFormComponent", () => {
       expect(attachedIds()).toEqual([]);
 
       component.form.get("groupId")!.setValue(2);
+      expect(attachedIds()).toEqual([]);
+
+      // Including on a saved receipt: the backend's
+      // enforceReceiptCustomFieldSelection would 403 the save if the attached id
+      // set changed for such a caller.
+      openSavedForm(FormMode.edit, savedReceipt(1));
       expect(attachedIds()).toEqual([]);
     });
 

--- a/desktop/src/receipts/receipt-form/receipt-form.component.ts
+++ b/desktop/src/receipts/receipt-form/receipt-form.component.ts
@@ -115,11 +115,6 @@ export class ReceiptFormComponent implements OnInit {
   // user added, or typed into, is theirs and is left alone.
   private autoAppliedCustomFieldIds = new Set<number>();
 
-  // listenForGroupChanges() replays the current group id via startWith() in every
-  // mode, so the first emission is "the form just initialised", not "the user
-  // picked a group". Reset with the form in initForm().
-  private groupChangeIsInitialEmission = true;
-
   public originalReceipt?: Receipt;
 
   public images = signal<FileDataView[]>([]);
@@ -420,9 +415,9 @@ export class ReceiptFormComponent implements OnInit {
   private initForm(): void {
     // Reset BEFORE the form is built: initForm() re-runs on every route-data
     // emission and ends by calling listenForGroupChanges(), whose startWith()
-    // fires synchronously - so both must already describe the new form.
+    // fires synchronously - so it must already describe the new form. Without
+    // this, a stale auto set could strip a saved receipt's own fields.
     this.autoAppliedCustomFieldIds.clear();
-    this.groupChangeIsInitialEmission = true;
 
     // The group being browsed, or -- when that is not a receipt target (the "All"
     // group, nothing selected, or a stale persisted id) -- the user's only group.
@@ -536,7 +531,6 @@ export class ReceiptFormComponent implements OnInit {
         // CD that write is what schedules the render, and a FormArray mutation
         // on its own has no change-detection trigger.
         this.applyGroupDefaultCustomFields(groupId);
-        this.groupChangeIsInitialEmission = false;
       })
     )
       .subscribe();
@@ -547,16 +541,17 @@ export class ReceiptFormComponent implements OnInit {
   // dropped when the new group doesn't want it, anything with a value (or that
   // the user added themselves) stays, and the new group's missing defaults are
   // appended.
+  //
+  // Runs on load in EVERY mode (via listenForGroupChanges' startWith) and on
+  // every group change. A group's defaults are meant to read as that group's
+  // built-in receipt fields, so a saved receipt that predates the configuration
+  // shows them too - blank and read-only in view mode, and attached as empty
+  // values once an edit is saved. On load the removal pass is inert:
+  // autoAppliedCustomFieldIds is cleared at the top of initForm().
   private applyGroupDefaultCustomFields(groupId: number | string | null | undefined): void {
-    // Never on a read-only receipt, and never without the catalog permission -
-    // such a user's save would 403 on the backend's custom field selection check.
-    if (this.mode === FormMode.view || !this.canManageCustomFields()) {
-      return;
-    }
-
-    // The initial emission is the form loading, not a user choice: only the add
-    // form seeds defaults then, so an existing receipt opens exactly as saved.
-    if (!groupId || (this.groupChangeIsInitialEmission && this.mode !== FormMode.add)) {
+    // Never without the catalog permission - such a user's save would 403 on the
+    // backend's custom field selection check.
+    if (!groupId || !this.canManageCustomFields()) {
       return;
     }
 

--- a/mobile/CLAUDE.md
+++ b/mobile/CLAUDE.md
@@ -785,7 +785,7 @@ failing that from **the user's only group**; Quick Scan seeds each picked image 
 A group can declare custom fields that are pre-added to its receipts
 (`GroupReceiptSettings.defaultCustomFieldIds`, configured on desktop's Group Receipt Settings — see
 the root `CLAUDE.md` → "Group Default Custom Fields" for the cross-component contract). The receipt
-form (`lib/receipts/widgets/receipt_form.dart`) applies the selected group's set on **create** and on
+form (`lib/receipts/widgets/receipt_form.dart`) applies the selected group's set on **load** and on
 every **active group change**, because each group is effectively its own receipt template.
 
 - **The swap is conservative.** `_applyGroupDefaultCustomFields(newGroupId)` only takes back a field
@@ -793,10 +793,20 @@ every **active group change**, because each group is effectively its own receipt
   user typed into is kept and handed over to them (dropped from the auto set); so is anything they
   added by hand. Adding or removing a field by hand (`_addCustomField` / `_removeCustomField`) removes
   its id from the auto set, so the swap never fights a decision the user made.
-- **It runs on an active change, never on load in edit/view.** `initState` seeds only when
-  `formState == add` and the form already knows its group; the dropdown's `onChanged` runs it **before**
-  its `setState`, because it writes to `ReceiptModel` and `notifyListeners()` must not fire from inside
-  a setState callback. View mode returns early.
+- **It runs on load in EVERY form state, and on every active group change.** A group's defaults are
+  meant to read as its built-in receipt fields, so a receipt saved before the group was configured
+  picks them up too — read-only in view (`CustomFieldWidget` gets `onRemove: null` and there is no
+  Add button), and persisted as empty attached values once an edit is saved. `initState`'s post-frame
+  callback runs `_applyGroupDefaultCustomFields(..., onLoad: true)` whenever `_resolveInitialGroupId`
+  yields a group; the dropdown's `onChanged` runs it **before** its `setState`, because it writes to
+  `ReceiptModel` and `notifyListeners()` must not fire from inside a setState callback.
+- **`onLoad` claims every default the SAVED receipt does not carry, not just the ones added on that
+  pass.** `ReceiptModel` outlives the screen — `receipt_form_screen.dart` re-hydrates only for a
+  *different* receipt id — so a view → edit navigation mounts the edit form with the view form's
+  defaults already on `modifiedReceipt`. Claiming only what this pass added would mistake them for
+  the user's own data and never swap them out on a later group change. That is why the rule reads off
+  `receipt` (pristine) rather than `modifiedReceipt` (working copy). The removal pass is inert on
+  load either way: `_autoAppliedCustomFieldIds` starts empty on a fresh `State`.
 - **One model write per swap.** `_customFieldValuesWith(add:, remove:)` is pure and every caller hands
   the whole result to a single `_setCustomFieldValues`, so a multi-field swap rebuilds the form once
   instead of once per field, with its fields half-mounted in between.
@@ -818,13 +828,17 @@ every **active group change**, because each group is effectively its own receipt
   because the backend REPLACES the whole association on update.
 
 **Tests.** `test/widgets/receipt_form_default_custom_fields_test.dart` covers the rules exhaustively
-against injected models (13 cases: seeding, each keep/drop rule, A→B→A leaving no residue, an unchecked
-BOOLEAN counting as empty, a missing/empty catalog, view mode, edit-mode-on-change-only). **E2E:**
+against injected models (17 cases: seeding, each keep/drop rule, A→B→A leaving no residue, an unchecked
+BOOLEAN counting as empty, a missing/empty catalog, the load-time apply in view and edit, no duplicate
+for a default the receipt already carries, and the view → edit carry-over staying swappable). The last
+of those uses `pumpReceiptForm`'s `modifiedReceipt:` seam, which seeds the working copy *only* —
+that split is what a view → edit navigation looks like. **E2E:**
 `integration_test/receipt_default_custom_fields_test.dart` — three specs proving the ids survive the
 wire (persisted, hydrated onto `GroupModel` via AppData at login, applied by the real form, accepted on
 save): the full swap matrix ending in an API read-back of the saved values, the stale-value guard (type
-into a default → remove it by hand → switch away and back → it returns **blank**), and view-never /
-edit-only-on-change. Every step also asserts no UI error survived it.
+into a default → remove it by hand → switch away and back → it returns **blank**), and a receipt seeded
+server-side with no custom fields showing its group's defaults in view and edit and still swapping on a
+group change. Every step also asserts no UI error survived it.
 
 Three things that spec encodes, all of which cost a debugging cycle:
 - **Do not install a `FlutterError.onError` collector to catch UI errors.** It takes the handler away

--- a/mobile/CLAUDE.md
+++ b/mobile/CLAUDE.md
@@ -797,16 +797,27 @@ every **active group change**, because each group is effectively its own receipt
   meant to read as its built-in receipt fields, so a receipt saved before the group was configured
   picks them up too — read-only in view (`CustomFieldWidget` gets `onRemove: null` and there is no
   Add button), and persisted as empty attached values once an edit is saved. `initState`'s post-frame
-  callback runs `_applyGroupDefaultCustomFields(..., onLoad: true)` whenever `_resolveInitialGroupId`
-  yields a group; the dropdown's `onChanged` runs it **before** its `setState`, because it writes to
-  `ReceiptModel` and `notifyListeners()` must not fire from inside a setState callback.
-- **`onLoad` claims every default the SAVED receipt does not carry, not just the ones added on that
-  pass.** `ReceiptModel` outlives the screen — `receipt_form_screen.dart` re-hydrates only for a
-  *different* receipt id — so a view → edit navigation mounts the edit form with the view form's
-  defaults already on `modifiedReceipt`. Claiming only what this pass added would mistake them for
-  the user's own data and never swap them out on a later group change. That is why the rule reads off
-  `receipt` (pristine) rather than `modifiedReceipt` (working copy). The removal pass is inert on
-  load either way: `_autoAppliedCustomFieldIds` starts empty on a fresh `State`.
+  callback runs `_applyGroupDefaultCustomFields` whenever `_resolveInitialGroupId` yields a group;
+  the dropdown's `onChanged` runs it **before** its `setState`, because it writes to `ReceiptModel`
+  and `notifyListeners()` must not fire from inside a setState callback.
+- **Provenance lives on `ReceiptModel`, not the form's `State`.**
+  `ReceiptModel.autoAppliedCustomFieldIds` is the set the form adds to when it attaches a default and
+  removes from when the user touches one. It has to outlive the screen: the app bar menu's Edit entry
+  is a plain `go` (`receipt_app_bar_action_builder.dart`) and `receipt_form_screen.dart` re-hydrates
+  only for a *different* receipt id, so **view → edit remounts the form against the same
+  `modifiedReceipt`** with a fresh `State`. Two sequences end with the same empty field attached and
+  absent from the saved receipt, and only the set tells them apart: one the *form* added in the view
+  mount (still the swap's, dropped on a later group change) and one the *user* removed and re-added
+  by hand (theirs, kept). An earlier attempt inferred this on load from "every default the saved
+  receipt does not carry", which reclaimed the second case and silently dropped it — see
+  [receipt-wrangler#689](https://github.com/Receipt-Wrangler/receipt-wrangler/pull/689).
+  - The set is cleared wherever the working copy is replaced — `setReceipt` (which also covers the
+    post-save re-hydration, by which point the fields really are the receipt's own data) and
+    `resetModel` (the back arrow, and the `/receipts/add` route redirect in `main.dart`) — so
+    provenance and `modifiedReceipt` can never disagree. It deliberately does **not** notify:
+    nothing renders from it.
+  - The removal pass is inert on a *first* load, since the set is empty until something attaches a
+    default.
 - **One model write per swap.** `_customFieldValuesWith(add:, remove:)` is pure and every caller hands
   the whole result to a single `_setCustomFieldValues`, so a multi-field swap rebuilds the form once
   instead of once per field, with its fields half-mounted in between.
@@ -828,11 +839,13 @@ every **active group change**, because each group is effectively its own receipt
   because the backend REPLACES the whole association on update.
 
 **Tests.** `test/widgets/receipt_form_default_custom_fields_test.dart` covers the rules exhaustively
-against injected models (17 cases: seeding, each keep/drop rule, A→B→A leaving no residue, an unchecked
+against injected models (18 cases: seeding, each keep/drop rule, A→B→A leaving no residue, an unchecked
 BOOLEAN counting as empty, a missing/empty catalog, the load-time apply in view and edit, no duplicate
-for a default the receipt already carries, and the view → edit carry-over staying swappable). The last
-of those uses `pumpReceiptForm`'s `modifiedReceipt:` seam, which seeds the working copy *only* —
-that split is what a view → edit navigation looks like. **E2E:**
+for a default the receipt already carries, and the two remount cases the provenance set exists for —
+the view → edit carry-over staying swappable, and a hand-re-added default staying the user's). Those
+last two pass `pumpReceiptForm`'s `receiptModel:` seam a model an earlier pump returned, so the
+second pump is a **real remount** (fresh `State`, same working copy and provenance) rather than a
+simulated one. **E2E:**
 `integration_test/receipt_default_custom_fields_test.dart` — three specs proving the ids survive the
 wire (persisted, hydrated onto `GroupModel` via AppData at login, applied by the real form, accepted on
 save): the full swap matrix ending in an API read-back of the saved values, the stale-value guard (type

--- a/mobile/integration_test/receipt_default_custom_fields_test.dart
+++ b/mobile/integration_test/receipt_default_custom_fields_test.dart
@@ -2,7 +2,8 @@
 //
 // A group can declare custom fields that are pre-added to its receipts
 // (`GroupReceiptSettings.defaultCustomFieldIds`), so each group is effectively
-// its own receipt template. Selecting a different group "smart swaps": a
+// its own receipt template. They are applied on load in every form state, so an
+// existing receipt shows them too. Selecting a different group "smart swaps": a
 // default this form added and the user never filled in is dropped, anything
 // they typed into or added by hand is kept, and the new group's missing
 // defaults are added.
@@ -406,7 +407,7 @@ void main() {
     _expectNoUiErrors(tester, 'switching Beta -> Alpha');
   });
 
-  testWidgets('view never applies defaults and edit applies only on a change',
+  testWidgets("an existing receipt shows its group's defaults in view and edit",
       (tester) async {
     await binding.setSurfaceSize(const Size(1280, 900));
     addTearDown(() => binding.setSurfaceSize(null));
@@ -425,7 +426,7 @@ void main() {
     );
 
     // Seeded server-side with no custom fields at all, even though its group
-    // declares two -- an existing receipt is not retro-fitted.
+    // declares two -- the form is what retro-fits them, on load.
     final receiptName = 'e2e-dcf-existing-${DateTime.now().millisecondsSinceEpoch}';
     await createReceipt(
       groupId: fixture.alphaId,
@@ -438,24 +439,27 @@ void main() {
         username: fixture.user.username, password: fixture.user.password);
     await openGroupReceipts(tester, fixture.alphaName, receiptName);
 
+    // View mode renders Alpha's two defaults, blank and read-only -- they are
+    // meant to read as that group's built-in receipt fields.
     await tester.tap(find.text(receiptName).hitTestable());
     await pumpUntilFound(tester, find.byType(ReceiptEditPopupMenu));
     await _drain(tester);
-    _expectFields(const [], [fixture.id('a'), fixture.id('b'), fixture.id('c')]);
+    await pumpUntilFound(tester, _customField(fixture.id('a')));
+    _expectFields([fixture.id('a'), fixture.id('b')], [fixture.id('c')]);
+    expect(_renderedText(tester, fixture.id('a')), '');
     _expectNoUiErrors(tester, 'opening the receipt in view mode');
 
-    // Edit mode: still nothing on load -- applying here would silently attach
-    // fields to somebody's saved receipt just by opening it.
     await tester.tap(find.byType(ReceiptEditPopupMenu));
     await pumpUntilFound(tester, find.text('Edit').hitTestable());
     await _drain(tester);
     await tester.tap(find.text('Edit').hitTestable());
     await pumpUntilFound(tester, find.byType(BottomSubmitButton));
     await pumpUntilFound(tester, find.text('Add Custom Field'));
-    _expectFields(const [], [fixture.id('a'), fixture.id('b'), fixture.id('c')]);
+    _expectFields([fixture.id('a'), fixture.id('b')], [fixture.id('c')]);
     _expectNoUiErrors(tester, 'opening the receipt in edit mode');
 
-    // An ACTIVE group change does apply, in edit mode as much as on create.
+    // The load-applied defaults are still the swap's: both are empty, so a
+    // group change takes them back and leaves only Beta's.
     await _selectGroup(tester, fixture.betaName);
     _expectFields([fixture.id('c')], [fixture.id('a'), fixture.id('b')]);
     _expectNoUiErrors(tester, 'changing the group in edit mode');

--- a/mobile/lib/models/receipt_model.dart
+++ b/mobile/lib/models/receipt_model.dart
@@ -17,6 +17,24 @@ class ReceiptModel extends ChangeNotifier {
 
   Receipt get modifiedReceipt => _modifiedReceipt;
 
+  /// Custom field ids the receipt form attached on the user's behalf from the
+  /// selected group's default set, as opposed to ones the user added by hand.
+  /// Only the former are candidates for removal when the group changes.
+  ///
+  /// Provenance lives here rather than in the form's State because this model
+  /// outlives the screen: the app bar menu's Edit entry is a plain `go`
+  /// (`receipt_app_bar_action_builder.dart`), so a view -> edit navigation
+  /// remounts the form against this same [modifiedReceipt]. A fresh State could
+  /// only guess, and would reclaim -- then silently drop on the next group
+  /// change -- a default the user had removed and re-added themselves.
+  ///
+  /// Cleared wherever the working copy is replaced ([setReceipt], [resetModel])
+  /// so the two can never disagree. Deliberately does not notify: nothing
+  /// renders from it.
+  final Set<int> _autoAppliedCustomFieldIds = {};
+
+  Set<int> get autoAppliedCustomFieldIds => _autoAppliedCustomFieldIds;
+
   List<Comment> _comments = [];
 
   List<Comment> get comments => _comments;
@@ -71,6 +89,8 @@ class ReceiptModel extends ChangeNotifier {
 
     _modifiedReceipt = receipt;
 
+    _autoAppliedCustomFieldIds.clear();
+
     _comments = (receipt.comments)?.toList() ?? [];
 
     _items = FormItem.fromItems((receipt.receiptItems)?.toList() ?? []);
@@ -111,6 +131,7 @@ class ReceiptModel extends ChangeNotifier {
   void resetModel() {
     _receipt = getDefaultReceipt();
     _modifiedReceipt = getDefaultReceipt();
+    _autoAppliedCustomFieldIds.clear();
     _comments = [];
     _items = [];
     _imageBehaviorSubject = BehaviorSubject<List<FileDataView?>>.seeded([]);

--- a/mobile/lib/receipts/widgets/receipt_form.dart
+++ b/mobile/lib/receipts/widgets/receipt_form.dart
@@ -60,7 +60,13 @@ class _ReceiptForm extends State<ReceiptForm> {
   /// selected group declares them as defaults. Only these are candidates for
   /// removal when the group changes -- anything the user added by hand, or
   /// typed a value into, is theirs (see [_applyGroupDefaultCustomFields]).
-  final Set<int> _autoAppliedCustomFieldIds = {};
+  ///
+  /// Held by [ReceiptModel], not this State: the form is remounted against the
+  /// same working copy on a view -> edit navigation, and provenance has to
+  /// survive that or a field the user removed and re-added by hand is reclaimed
+  /// as the form's and dropped on the next group change.
+  Set<int> get _autoAppliedCustomFieldIds =>
+      receiptModel.autoAppliedCustomFieldIds;
 
   @override
   void initState() {
@@ -92,7 +98,7 @@ class _ReceiptForm extends State<ReceiptForm> {
 
       // Before the setState below: it writes to ReceiptModel, and
       // notifyListeners() must not fire from inside a setState callback.
-      _applyGroupDefaultCustomFields(resolvedGroupId, onLoad: true);
+      _applyGroupDefaultCustomFields(resolvedGroupId);
 
       if (resolvedGroupId != groupId) {
         // Carry the seed into the State field the group-derived parts of the
@@ -483,7 +489,7 @@ class _ReceiptForm extends State<ReceiptForm> {
   /// Applies [newGroupId]'s default custom fields to the form, swapping out the
   /// ones the previously selected group put there. Each group is effectively
   /// its own receipt template, so this runs on every group change and once on
-  /// load, in every form state ([onLoad]).
+  /// load, in every form state.
   ///
   /// The swap is deliberately conservative. It only removes a field this form
   /// added itself ([_autoAppliedCustomFieldIds]) that is still **empty**; a
@@ -494,7 +500,7 @@ class _ReceiptForm extends State<ReceiptForm> {
   /// is empty for a caller without `app.custom-fields.read` (the 403 is
   /// swallowed into an empty list), which is exactly the gate we want here: the
   /// backend's `enforceReceiptCustomFieldSelection` would 403 their save.
-  void _applyGroupDefaultCustomFields(int newGroupId, {bool onLoad = false}) {
+  void _applyGroupDefaultCustomFields(int newGroupId) {
     var knownCustomFieldIds =
         customFieldModel.customFields.map((cf) => cf.id).toSet();
     var defaultIds = <int>[
@@ -518,16 +524,7 @@ class _ReceiptForm extends State<ReceiptForm> {
     var attachedIds =
         modifiedReceipt.customFields.map((cfv) => cfv.customFieldId).toSet();
     var toAdd = defaultIds.difference(attachedIds);
-
-    // On load the form owns every default the SAVED receipt does not carry, not
-    // just the ones added on this pass: ReceiptModel outlives the screen, so a
-    // view -> edit navigation arrives with the previous mount's defaults
-    // already attached (receipt_form_screen.dart only re-hydrates for a
-    // different receipt). Claiming only `toAdd` would mistake them for the
-    // own data and never swap them out on a later group change.
-    var savedIds = receipt.customFields.map((cfv) => cfv.customFieldId).toSet();
-    _autoAppliedCustomFieldIds
-        .addAll(onLoad ? defaultIds.difference(savedIds) : toAdd);
+    _autoAppliedCustomFieldIds.addAll(toAdd);
 
     if (toRemove.isEmpty && toAdd.isEmpty) {
       return;

--- a/mobile/lib/receipts/widgets/receipt_form.dart
+++ b/mobile/lib/receipts/widgets/receipt_form.dart
@@ -69,19 +69,22 @@ class _ReceiptForm extends State<ReceiptForm> {
 
     groupId = modifiedReceipt.groupId;
 
-    // Always scheduled, not just when the receipt already knows its group: on an
-    // add form _resolveInitialGroupId can produce one the receipt does not carry
-    // (the group being browsed, or the user's only group). Deferred to after the
-    // first frame because applying the group's defaults mutates ReceiptModel, and
-    // notifying its listeners while the tree is still building throws -- and
-    // because `formState`/`getGroupId` read the route, which needs a mounted
-    // element.
+    // Runs in every form state, not just add: a group's default custom fields
+    // are meant to read as that group's built-in receipt fields, so a saved
+    // receipt that predates the configuration shows them too (read-only in
+    // view, and attached as empty values once an edit is saved). Deferred to
+    // after the first frame because applying the group's defaults mutates
+    // ReceiptModel, and notifying its listeners while the tree is still
+    // building throws -- and because `formState`/`getGroupId` read the route,
+    // which needs a mounted element.
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted || formState != WranglerFormState.add) {
+      if (!mounted) {
         return;
       }
 
-      // Mirrors what buildGroupField seeded the dropdown with.
+      // Mirrors what buildGroupField seeded the dropdown with. On an add form
+      // this can be a group the receipt does not carry (the group being
+      // browsed, or the user's only group); otherwise it is the receipt's own.
       final resolvedGroupId = _resolveInitialGroupId();
       if (resolvedGroupId == 0) {
         return;
@@ -89,7 +92,7 @@ class _ReceiptForm extends State<ReceiptForm> {
 
       // Before the setState below: it writes to ReceiptModel, and
       // notifyListeners() must not fire from inside a setState callback.
-      _applyGroupDefaultCustomFields(resolvedGroupId);
+      _applyGroupDefaultCustomFields(resolvedGroupId, onLoad: true);
 
       if (resolvedGroupId != groupId) {
         // Carry the seed into the State field the group-derived parts of the
@@ -479,8 +482,8 @@ class _ReceiptForm extends State<ReceiptForm> {
 
   /// Applies [newGroupId]'s default custom fields to the form, swapping out the
   /// ones the previously selected group put there. Each group is effectively
-  /// its own receipt template, so this runs on every group change (and once on
-  /// load for an add form that already knows its group).
+  /// its own receipt template, so this runs on every group change and once on
+  /// load, in every form state ([onLoad]).
   ///
   /// The swap is deliberately conservative. It only removes a field this form
   /// added itself ([_autoAppliedCustomFieldIds]) that is still **empty**; a
@@ -491,11 +494,7 @@ class _ReceiptForm extends State<ReceiptForm> {
   /// is empty for a caller without `app.custom-fields.read` (the 403 is
   /// swallowed into an empty list), which is exactly the gate we want here: the
   /// backend's `enforceReceiptCustomFieldSelection` would 403 their save.
-  void _applyGroupDefaultCustomFields(int newGroupId) {
-    if (formState == WranglerFormState.view) {
-      return;
-    }
-
+  void _applyGroupDefaultCustomFields(int newGroupId, {bool onLoad = false}) {
     var knownCustomFieldIds =
         customFieldModel.customFields.map((cf) => cf.id).toSet();
     var defaultIds = <int>[
@@ -519,7 +518,16 @@ class _ReceiptForm extends State<ReceiptForm> {
     var attachedIds =
         modifiedReceipt.customFields.map((cfv) => cfv.customFieldId).toSet();
     var toAdd = defaultIds.difference(attachedIds);
-    _autoAppliedCustomFieldIds.addAll(toAdd);
+
+    // On load the form owns every default the SAVED receipt does not carry, not
+    // just the ones added on this pass: ReceiptModel outlives the screen, so a
+    // view -> edit navigation arrives with the previous mount's defaults
+    // already attached (receipt_form_screen.dart only re-hydrates for a
+    // different receipt). Claiming only `toAdd` would mistake them for the
+    // own data and never swap them out on a later group change.
+    var savedIds = receipt.customFields.map((cfv) => cfv.customFieldId).toSet();
+    _autoAppliedCustomFieldIds
+        .addAll(onLoad ? defaultIds.difference(savedIds) : toAdd);
 
     if (toRemove.isEmpty && toAdd.isEmpty) {
       return;

--- a/mobile/test/helpers/receipt_form_test_helpers.dart
+++ b/mobile/test/helpers/receipt_form_test_helpers.dart
@@ -200,10 +200,17 @@ String _locationFor(WranglerFormState formState, int receiptId) {
 ///
 /// The form derives its mode from the route (`getFormStateFromContext`), so a
 /// real [GoRouter] is mounted at the location matching [formState].
+///
+/// [modifiedReceipt] seeds the model's **working copy** only, leaving [receipt]
+/// as the saved one. That split is what a view -> edit navigation looks like:
+/// `ReceiptModel` outlives the screen, so the edit form mounts with whatever
+/// the view form attached still on `modifiedReceipt` but absent from the
+/// receipt the server stored.
 Future<ReceiptFormHarness> pumpReceiptForm(
   WidgetTester tester, {
   required List<api.Group> groups,
   api.Receipt? receipt,
+  api.Receipt? modifiedReceipt,
   List<api.CustomField> customFields = const [],
   List<api.UserView> users = const [],
   WranglerFormState formState = WranglerFormState.add,
@@ -216,6 +223,9 @@ Future<ReceiptFormHarness> pumpReceiptForm(
   // form key once (`late final`), and `setReceipt` regenerates that key
   // whenever the receipt identity changes.
   final receiptModel = ReceiptModel()..setReceipt(seededReceipt, false);
+  if (modifiedReceipt != null) {
+    receiptModel.setModifiedReceipt(modifiedReceipt);
+  }
   final groupModel = GroupModel()..setGroups(groups);
   final userModel = UserModel()..setUsers(users);
   final customFieldModel = CustomFieldModel()..setCustomFields(customFields);

--- a/mobile/test/helpers/receipt_form_test_helpers.dart
+++ b/mobile/test/helpers/receipt_form_test_helpers.dart
@@ -201,31 +201,31 @@ String _locationFor(WranglerFormState formState, int receiptId) {
 /// The form derives its mode from the route (`getFormStateFromContext`), so a
 /// real [GoRouter] is mounted at the location matching [formState].
 ///
-/// [modifiedReceipt] seeds the model's **working copy** only, leaving [receipt]
-/// as the saved one. That split is what a view -> edit navigation looks like:
-/// `ReceiptModel` outlives the screen, so the edit form mounts with whatever
-/// the view form attached still on `modifiedReceipt` but absent from the
-/// receipt the server stored.
+/// Pass [receiptModel] to pump against a model an earlier call returned: the
+/// second pump replaces the tree, so `ReceiptForm` gets a fresh `State`
+/// while the working copy and its auto-applied provenance carry over. That is
+/// what a view -> edit navigation does in the app -- the app bar menu's Edit
+/// entry is a plain `go`, and `ReceiptFormScreen` re-hydrates only for a
+/// different receipt id -- so a remount is reproduced rather than simulated.
+/// [receipt] is ignored when a model is supplied; the model already holds one.
 Future<ReceiptFormHarness> pumpReceiptForm(
   WidgetTester tester, {
   required List<api.Group> groups,
   api.Receipt? receipt,
-  api.Receipt? modifiedReceipt,
+  ReceiptModel? receiptModel,
   List<api.CustomField> customFields = const [],
   List<api.UserView> users = const [],
   WranglerFormState formState = WranglerFormState.add,
 }) async {
   registerCustomCurrencyForTests();
 
-  final seededReceipt = receipt ?? getDefaultReceipt();
+  final seededReceipt = receiptModel?.receipt ?? receipt ?? getDefaultReceipt();
 
   // Seed the receipt before the first pump: `ReceiptForm` captures the model's
   // form key once (`late final`), and `setReceipt` regenerates that key
   // whenever the receipt identity changes.
-  final receiptModel = ReceiptModel()..setReceipt(seededReceipt, false);
-  if (modifiedReceipt != null) {
-    receiptModel.setModifiedReceipt(modifiedReceipt);
-  }
+  final model =
+      receiptModel ?? (ReceiptModel()..setReceipt(seededReceipt, false));
   final groupModel = GroupModel()..setGroups(groups);
   final userModel = UserModel()..setUsers(users);
   final customFieldModel = CustomFieldModel()..setCustomFields(customFields);
@@ -250,7 +250,7 @@ Future<ReceiptFormHarness> pumpReceiptForm(
   await tester.pumpWidget(
     MultiProvider(
       providers: [
-        ChangeNotifierProvider<ReceiptModel>.value(value: receiptModel),
+        ChangeNotifierProvider<ReceiptModel>.value(value: model),
         ChangeNotifierProvider<GroupModel>.value(value: groupModel),
         ChangeNotifierProvider<UserModel>.value(value: userModel),
         ChangeNotifierProvider<CustomFieldModel>.value(value: customFieldModel),
@@ -272,7 +272,7 @@ Future<ReceiptFormHarness> pumpReceiptForm(
   await tester.pumpAndSettle();
 
   return ReceiptFormHarness(
-    receiptModel: receiptModel,
+    receiptModel: model,
     groupModel: groupModel,
     userModel: userModel,
     customFieldModel: customFieldModel,

--- a/mobile/test/widgets/receipt_form_default_custom_fields_test.dart
+++ b/mobile/test/widgets/receipt_form_default_custom_fields_test.dart
@@ -535,31 +535,80 @@ void main() {
     _expectNoUiErrors(tester);
   });
 
+  // The view -> edit navigation, for real: the app bar menu's Edit entry is a
+  // plain `go`, so the form is remounted (fresh State) against the same
+  // ReceiptModel. Provenance lives on the model precisely so these next two
+  // cases can disagree -- the form's field is still the form's, the user's is
+  // still the user's.
   testWidgets('takes back a default a previous mount of the form attached',
       (tester) async {
-    // The view -> edit navigation: ReceiptModel outlives the screen, so the
-    // edit form mounts with the view form's default on the working copy but
-    // absent from the saved receipt. It is still the form's, not the user's.
-    final saved = _receiptInGroup(_groupOneId, id: 5);
+    final viewHarness = await pumpReceiptForm(
+      tester,
+      groups: _groups(),
+      customFields: _catalog,
+      users: _users,
+      receipt: _receiptInGroup(_groupOneId, id: 5),
+      formState: WranglerFormState.view,
+    );
+    expect(_attachedIds(viewHarness), [_fieldAId]);
+
     final harness = await pumpReceiptForm(
       tester,
       groups: _groups(),
       customFields: _catalog,
       users: _users,
-      receipt: saved,
-      modifiedReceipt: saved.rebuild((b) => b
-        ..customFields = ListBuilder<api.CustomFieldValue>([
-          buildCustomFieldValue(customFieldId: _fieldAId, receiptId: 5),
-        ])),
+      receiptModel: viewHarness.receiptModel,
       formState: WranglerFormState.edit,
     );
-
     expect(_attachedIds(harness), [_fieldAId]);
+    _expectNoUiErrors(tester);
 
     await _selectGroup(tester, 'Group Two');
 
     expect(_customFieldWidget(_fieldAId), findsNothing);
     expect(_attachedIds(harness), [_fieldBId]);
+    _expectNoUiErrors(tester);
+  });
+
+  testWidgets('a default re-added by hand stays the user\'s across a remount',
+      (tester) async {
+    // Removing an auto-applied default and adding it straight back makes it the
+    // user's, and leaves it empty -- so only provenance separates it from one
+    // the form just attached. A remount must not forget that and swap it out.
+    final first = await pumpReceiptForm(
+      tester,
+      groups: _groups(),
+      customFields: _catalog,
+      users: _users,
+      receipt: _receiptInGroup(_groupOneId, id: 5),
+      formState: WranglerFormState.edit,
+    );
+    expect(_attachedIds(first), [_fieldAId]);
+
+    await _removeCustomField(tester, _fieldAId);
+    expect(_attachedIds(first), isEmpty);
+    await _addCustomFieldNamed(tester, 'Cost Centre');
+    expect(_attachedIds(first), [_fieldAId]);
+    _expectNoUiErrors(tester);
+
+    final harness = await pumpReceiptForm(
+      tester,
+      groups: _groups(),
+      customFields: _catalog,
+      users: _users,
+      receiptModel: first.receiptModel,
+      formState: WranglerFormState.edit,
+    );
+    expect(_attachedIds(harness), [_fieldAId]);
+
+    await _selectGroup(tester, 'Group Two');
+
+    expect(
+      _customFieldWidget(_fieldAId),
+      findsOneWidget,
+      reason: 'the user put this field back by hand; the swap does not own it',
+    );
+    expect(_attachedIds(harness), [_fieldAId, _fieldBId]);
     _expectNoUiErrors(tester);
   });
 }

--- a/mobile/test/widgets/receipt_form_default_custom_fields_test.dart
+++ b/mobile/test/widgets/receipt_form_default_custom_fields_test.dart
@@ -1,3 +1,4 @@
+import 'package:built_collection/built_collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -10,10 +11,11 @@ import '../helpers/receipt_form_test_helpers.dart';
 
 // A group can declare default custom fields (`GroupReceiptSettings
 // .defaultCustomFieldIds`), which the receipt form pre-adds for that group --
-// each group is effectively its own receipt template. Selecting a different
-// group therefore "smart swaps": defaults this form added and the user never
-// filled in are dropped, anything they typed into or added by hand is kept, and
-// the new group's missing defaults are added.
+// each group is effectively its own receipt template. They are applied on load
+// in EVERY form state, so a saved receipt that predates the configuration shows
+// them too. Selecting a different group "smart swaps": defaults this form added
+// and the user never filled in are dropped, anything they typed into or added
+// by hand is kept, and the new group's missing defaults are added.
 //
 // Every case asserts the swap left NO UI error behind. The path mutates the
 // receipt's custom field list while FormBuilder fields mount and unmount under
@@ -75,11 +77,16 @@ List<api.Group> _groups({
       ),
     ];
 
-api.Receipt _receiptInGroup(int groupId, {int id = 0}) =>
+api.Receipt _receiptInGroup(
+  int groupId, {
+  int id = 0,
+  List<api.CustomFieldValue> customFields = const [],
+}) =>
     getDefaultReceipt().rebuild((b) => b
       ..id = id
       ..groupId = groupId
-      ..paidByUserId = _memberId);
+      ..paidByUserId = _memberId
+      ..customFields = ListBuilder<api.CustomFieldValue>(customFields));
 
 Finder _dropdown(String name) =>
     find.byWidgetPredicate((w) => w is FormBuilderDropdown && w.name == name);
@@ -413,7 +420,11 @@ void main() {
     _expectNoUiErrors(tester);
   });
 
-  testWidgets('never applies in view mode', (tester) async {
+  // A group's defaults are meant to read as its built-in receipt fields, so a
+  // saved receipt that predates the configuration picks them up on load -- in
+  // view as well as edit.
+  testWidgets("applies the group's missing defaults in view mode",
+      (tester) async {
     final harness = await pumpReceiptForm(
       tester,
       groups: _groups(),
@@ -423,21 +434,73 @@ void main() {
       formState: WranglerFormState.view,
     );
 
-    expect(find.byType(CustomFieldWidget), findsNothing);
-    expect(_attachedIds(harness), isEmpty);
+    expect(_customFieldWidget(_fieldAId), findsOneWidget);
+    expect(_attachedIds(harness), [_fieldAId]);
+    expect(harness.customFieldValue(_fieldAId), isNull);
+    // Display only: view mode offers no way to change the set.
+    expect(
+      find.descendant(
+        of: _customFieldWidget(_fieldAId),
+        matching: find.byIcon(Icons.remove_circle_outline),
+      ),
+      findsNothing,
+    );
+    expect(_addCustomFieldButton(), findsNothing);
     _expectNoUiErrors(tester);
   });
 
-  testWidgets('edit mode applies on a group change but never on load',
+  testWidgets("applies the group's missing defaults on an edit form's load",
       (tester) async {
-    // An existing receipt is what it is; only an active group change re-templates
-    // it.
     final harness = await pumpReceiptForm(
       tester,
       groups: _groups(),
       customFields: _catalog,
       users: _users,
       receipt: _receiptInGroup(_groupOneId, id: 5),
+      formState: WranglerFormState.edit,
+    );
+
+    expect(_customFieldWidget(_fieldAId), findsOneWidget);
+    expect(_attachedIds(harness), [_fieldAId]);
+    _expectNoUiErrors(tester);
+  });
+
+  testWidgets('does not duplicate a default the receipt already carries',
+      (tester) async {
+    final harness = await pumpReceiptForm(
+      tester,
+      groups: _groups(),
+      customFields: _catalog,
+      users: _users,
+      receipt: _receiptInGroup(
+        _groupOneId,
+        id: 5,
+        customFields: [
+          buildCustomFieldValue(
+            customFieldId: _fieldAId,
+            receiptId: 5,
+            stringValue: 'CC-7',
+          ),
+        ],
+      ),
+      formState: WranglerFormState.edit,
+    );
+
+    expect(_customFieldWidget(_fieldAId), findsOneWidget);
+    expect(_attachedIds(harness), [_fieldAId]);
+    expect(harness.customFieldValue(_fieldAId), 'CC-7');
+    _expectNoUiErrors(tester);
+  });
+
+  testWidgets('edit mode applies the new group\'s defaults on a group change',
+      (tester) async {
+    // Group Three configures none, so nothing lands until the group changes.
+    final harness = await pumpReceiptForm(
+      tester,
+      groups: _groups(),
+      customFields: _catalog,
+      users: _users,
+      receipt: _receiptInGroup(_groupThreeId, id: 5),
       formState: WranglerFormState.edit,
     );
 
@@ -448,6 +511,54 @@ void main() {
     await _selectGroup(tester, 'Group Two');
 
     expect(_customFieldWidget(_fieldBId), findsOneWidget);
+    expect(_attachedIds(harness), [_fieldBId]);
+    _expectNoUiErrors(tester);
+  });
+
+  testWidgets('a default applied on load is still the swap\'s to take back',
+      (tester) async {
+    final harness = await pumpReceiptForm(
+      tester,
+      groups: _groups(),
+      customFields: _catalog,
+      users: _users,
+      receipt: _receiptInGroup(_groupOneId, id: 5),
+      formState: WranglerFormState.edit,
+    );
+
+    expect(_attachedIds(harness), [_fieldAId]);
+
+    await _selectGroup(tester, 'Group Two');
+
+    expect(_customFieldWidget(_fieldAId), findsNothing);
+    expect(_attachedIds(harness), [_fieldBId]);
+    _expectNoUiErrors(tester);
+  });
+
+  testWidgets('takes back a default a previous mount of the form attached',
+      (tester) async {
+    // The view -> edit navigation: ReceiptModel outlives the screen, so the
+    // edit form mounts with the view form's default on the working copy but
+    // absent from the saved receipt. It is still the form's, not the user's.
+    final saved = _receiptInGroup(_groupOneId, id: 5);
+    final harness = await pumpReceiptForm(
+      tester,
+      groups: _groups(),
+      customFields: _catalog,
+      users: _users,
+      receipt: saved,
+      modifiedReceipt: saved.rebuild((b) => b
+        ..customFields = ListBuilder<api.CustomFieldValue>([
+          buildCustomFieldValue(customFieldId: _fieldAId, receiptId: 5),
+        ])),
+      formState: WranglerFormState.edit,
+    );
+
+    expect(_attachedIds(harness), [_fieldAId]);
+
+    await _selectGroup(tester, 'Group Two');
+
+    expect(_customFieldWidget(_fieldAId), findsNothing);
     expect(_attachedIds(harness), [_fieldBId]);
     _expectNoUiErrors(tester);
   });


### PR DESCRIPTION
## Summary
Group default custom fields are now applied on load in every form state (create, edit, and view), not just on create or group change. This makes defaults read as built-in receipt fields — a receipt saved before a group was configured now shows those fields too, blank and read-only in view mode, and persisted as empty attached values once an edit is saved.

## Key Changes

**Mobile (`lib/receipts/widgets/receipt_form.dart`)**
- `_applyGroupDefaultCustomFields()` now runs on load in every form state via `initState`'s post-frame callback, not just on add
- Added `onLoad` parameter to distinguish load-time application from group-change application
- On load, the form claims every default the **saved** receipt doesn't carry (not just newly added ones), because `ReceiptModel` outlives the screen — a view→edit navigation arrives with the previous mount's defaults already attached to `modifiedReceipt`
- Removed early return for view mode; view mode now displays defaults read-only

**Desktop (`src/receipts/receipt-form/receipt-form.component.ts`)**
- Removed `groupChangeIsInitialEmission` guard that prevented load-time application in edit/view modes
- `applyGroupDefaultCustomFields()` now runs on load in all modes via `listenForGroupChanges()`'s `startWith()` replay
- Removal pass is inert on load because `autoAppliedCustomFieldIds` is cleared at the top of `initForm()`
- View mode displays defaults read-only (template already binds `[readonly]="mode | inputReadonly"`)

**Tests**
- Mobile: Expanded `receipt_form_default_custom_fields_test.dart` with new test cases covering load-time application in view/edit, deduplication, and the swap's ability to reclaim load-applied defaults
- Desktop: Updated `receipt-form.component.spec.ts` with matching test coverage
- E2E: Added test verifying a saved receipt picks up a default its group gained afterwards, including persistence round-trip

**Documentation**
- Updated `CLAUDE.md` files (root, mobile, desktop) to reflect that defaults apply on load in every mode and explain the implications for saved receipts and the swap behavior

## Implementation Details

- **Load-time application is conservative:** On load, the form only claims defaults the saved receipt doesn't already carry. This prevents duplication when a receipt already has a default field.
- **The swap still works correctly:** A default applied on load is still tracked in `_autoAppliedCustomFieldIds` (or `autoAppliedCustomFieldIds`), so a later group change can drop it if it's still empty.
- **View mode is read-only:** Defaults in view mode have no remove button and no add button, displaying them as immutable built-in fields.
- **Saved receipts are retroactively fitted:** A receipt created before a group's defaults were configured will show those fields when opened, making the defaults feel like built-in receipt fields rather than a configuration artifact.

https://claude.ai/code/session_01NVA3iYLoD8YMivxspw24iq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Group default custom fields now load on receipt forms in create, edit, and view modes across desktop and mobile.
  - Existing receipts receive newly configured defaults without duplicating saved fields.
  - Defaults remain available during group changes and persist when edited receipts are saved.
  - In view mode, automatically added fields appear blank and read-only when no value exists.

- **Documentation**
  - Updated guidance to describe default-field behavior across receipt form states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->