### PR TITLE
Make quick date filter target selectable across date fields

### DIFF
--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -1252,10 +1252,11 @@ so they can never disagree.
   later refresh. `getInitialData()` deliberately stays on its own one-shot subscription, because it
   owns the single `setColumns()` call and that reads `viewChild.required` template refs.
 
-### The month stepper is the Date filter
+### The month stepper targets one date field
 
 `app-month-stepper` (`src/shared-ui/month-stepper/`, standalone, deliberately presentational) emits
-months; `receipts-table` translates them with `src/utils/receipt-date-filter.ts`.
+months; `receipts-table` translates them with `src/utils/receipt-date-filter.ts` and writes them to
+**whichever date field the control is pointed at** — `date`, `resolvedDate` or `createdAt`.
 
 **Its panel is a CDK overlay, not a `mat-menu` — do not "simplify" it back.** The panel holds a year
 pager, a month grid and three shortcuts, and **none of them is a `mat-menu-item`**. Inside a menu
@@ -1274,14 +1275,35 @@ The same rule applies to the two house alternatives, which is why neither was us
 is equally wrong for interactive content and cannot be overridden. `e2e/receipt-quick-date-filter.spec.ts`
 pins the keyboard path — it fails against a `mat-menu` implementation. A month is written
 as `BETWEEN [startOfMonth, endOfMonth]` — the one operation that can express *any* month, which is
-why this feature needed no API change. Picking a month **overwrites** whatever the Date filter held.
+why this feature needed no API change. Picking a month **overwrites** whatever that field held.
 
-- **The stepper and the chips never show the same condition twice.** While `monthFromFilterEntry`
-  resolves the Date filter to a month, the label names it and the chip row omits `date`. When it
-  cannot (a partial range, a `GREATER_THAN`, `WITHIN_CURRENT_MONTH`) the label reads **"Custom"** and
-  the Date chip renders, so the filter stays visible and clearable.
+- **The target field is a chip-shaped `mat-menu` trigger** beside the stepper
+  (`receipts-quick-date-field`), offering `RECEIPT_DATE_FILTER_FIELDS` — the `type: "date"` subset of
+  `RECEIPT_FILTER_FIELDS`, so the picker, the dialog row and the chip all name a field identically.
+  **A `mat-menu` is right here and wrong for the stepper's own panel**: every entry really is a
+  `<button mat-menu-item>`, so the `FocusKeyManager` has items. This is not a licence to convert that
+  panel back — see the paragraph above.
+- **The chosen field is persisted state** (`ReceiptTableInterface.quickDateField` +
+  `SetQuickDateField`), because the filter itself is persisted: without it a reload would leave the
+  stepper reading `date` while the user's month sat on `resolvedDate`. The **fallback lives in the
+  `ReceiptTableState.quickDateField` selector, not only in the `@State` defaults** — defaults never
+  run for a state hydrated from localStorage, so every install that filtered before this key existed
+  would otherwise read `undefined` and index the filter with it. `ResetReceiptFilter` clears it back
+  to `date` alongside the filter.
+- **Switching fields is deliberately non-destructive and triggers no refetch.** It changes no
+  condition, only which one the stepper describes, so a Date filter set in the dialog survives a move
+  to Resolved Date — and is still visible and clearable as its own chip. `SetReceiptFilterData` (the
+  sort path) omits the key and `patchState` only touches what it is handed, so sorting cannot reset
+  it either.
+- **Every active condition is chipped, including the stepper's own.** This reverses the original
+  rule ("never show the same condition twice", which omitted `date` while the stepper named that
+  month): now that the target field is selectable, the chip row is the only place that says *which*
+  date column is filtered, and a condition with no chip is one the user can neither see nor clear
+  from there. `buildReceiptFilterChips` therefore no longer takes an `omitKeys` argument. When the
+  stepper cannot describe the entry (a partial range, a `GREATER_THAN`, `WITHIN_CURRENT_MONTH`) the
+  label reads **"Custom"**, and the chip spells out what it actually is.
 - **`monthFromFilterEntry` must accept ISO strings, not just `Date`s.** The filter is persisted and
-  NGXS serializes through JSON, so after a reload `filter.date.value` is two ISO strings. It matches
+  NGXS serializes through JSON, so after a reload the entry's value is two ISO strings. It matches
   on calendar fields (day 1, same year+month, `getDaysInMonth` on the end) rather than on the
   serialized text, which also makes it tolerate the local-midnight pair the dialog's datepickers
   write. Get this wrong and the label silently degrades to "Custom" after every refresh —
@@ -1319,7 +1341,8 @@ Two consequences for tests and styles:
 
 The chips row is inline markup (`mat-chip-set` / `matChipRemove`) with every label built by the pure
 `buildReceiptFilterChips` util, so `ReceiptsModule` must import **`MatChipsModule`** — `SharedUiModule`
-imports it but does not export it. An id the caller cannot resolve (a category outside their grants,
+imports it but does not export it. It makes no exceptions: see "Every active condition is chipped"
+above. An id the caller cannot resolve (a category outside their grants,
 a group they have left) renders as the raw id rather than dropping the chip, so a filter that is
 actively removing rows is never invisible.
 

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -1225,11 +1225,21 @@ The receipts table (`src/receipts/receipts-table/`) offers three ways into **one
 (`app-receipt-filter`), the month stepper and the filter chips all read and write that single slice,
 so they can never disagree.
 
-- **Field metadata is shared.** `RECEIPT_FILTER_FIELDS` (`src/constants/receipt-filter-fields.constant.ts`)
-  is the one definition of each field's key, label and operation type. The dialog's
-  `setupAutoOperationSelection()` and the chip builder both read it, and `OperationsPipe` now reads
-  the extracted `FILTER_OPERATION_DISPLAY_VALUES`, so a chip cannot describe a condition differently
-  from the row that produced it.
+- **Field metadata is shared — but the labels only partly.** `RECEIPT_FILTER_FIELDS`
+  (`src/constants/receipt-filter-fields.constant.ts`) defines each field's key, label and operation
+  type, and `OperationsPipe` reads the extracted `FILTER_OPERATION_DISPLAY_VALUES`, so the operation
+  wording is genuinely single-sourced. **The field labels are not.** The dialog reads only
+  `{ key, type }` from the constant (`setupAutoOperationSelection()`) and **authors its own label in
+  its template** — each row is an `ngTemplateOutlet` with a literal
+  `{ label: 'Receipt Date', fieldName: 'date', type: 'date' }` context. So the constant's `label`
+  reaches the chips and the quick-date picker only, and **renaming a field means editing both
+  `receipt-filter-fields.constant.ts` and `receipt-filter.component.html`** or the dialog row will
+  disagree with the chip it produces. (Collapsing those ten outlets into a loop is not the one-liner
+  it looks like: four rows carry an extra `options:` context key and the Group row sits in its own
+  conditional wrapper.)
+- **A field's label matches its table column.** `date` is **"Receipt Date"**, not "Date" — the
+  column header is `Receipt Date` and the table also shows `Resolved Date` and `Added At`, so a bare
+  "Date" left the user guessing which of the three a filter or chip meant.
 - **`isFilterEntryActive`** (`src/utils/receipt-filter-entry.ts`) is the shared "does this field
   narrow anything" predicate: any non-empty stringified value, **or** the operation
   `WITHIN_CURRENT_MONTH` (the one operation that carries no value). **Zero counts** — no field
@@ -1277,8 +1287,9 @@ pins the keyboard path — it fails against a `mat-menu` implementation. A month
 as `BETWEEN [startOfMonth, endOfMonth]` — the one operation that can express *any* month, which is
 why this feature needed no API change. Picking a month **overwrites** whatever that field held.
 
-- **The target field is a chip-shaped `mat-menu` trigger** beside the stepper
-  (`receipts-quick-date-field`), offering `RECEIPT_DATE_FILTER_FIELDS` — the `type: "date"` subset of
+- **The target field is a chip-shaped `mat-menu` trigger at the right-hand end of the control**
+  (`receipts-quick-date-field`), so it reads left to right as "September 2026 … on Receipt Date".
+  It offers `RECEIPT_DATE_FILTER_FIELDS` — the `type: "date"` subset of
   `RECEIPT_FILTER_FIELDS`, so the picker, the dialog row and the chip all name a field identically.
   **A `mat-menu` is right here and wrong for the stepper's own panel**: every entry really is a
   `<button mat-menu-item>`, so the `FocusKeyManager` has items. This is not a licence to convert that

--- a/desktop/e2e/helpers/provisioning.ts
+++ b/desktop/e2e/helpers/provisioning.ts
@@ -359,6 +359,12 @@ export async function apiCreateReceipt(
     name: string;
     /** Receipt date as an ISO string. Defaults to a fixed date in 2024. */
     date?: string;
+    /**
+     * Receipt status. Defaults to OPEN. Pass RESOLVED to have the server stamp
+     * `resolvedDate` — the only way to seed a receipt the Resolved Date filter
+     * can match.
+     */
+    status?: string;
     customFields?: ReceiptCustomFieldValue[];
   },
 ): Promise<number> {
@@ -369,7 +375,7 @@ export async function apiCreateReceipt(
       date: opts.date ?? '2024-01-01T00:00:00Z',
       groupId: Number(opts.groupId),
       paidByUserId: opts.paidByUserId,
-      status: 'OPEN',
+      status: opts.status ?? 'OPEN',
       ...(opts.customFields ? { customFields: opts.customFields } : {}),
     },
   });

--- a/desktop/e2e/receipt-quick-date-filter.spec.ts
+++ b/desktop/e2e/receipt-quick-date-filter.spec.ts
@@ -235,6 +235,18 @@ test.describe('Receipts quick date filter', () => {
     // Switching the field changes no condition, only which one the stepper
     // describes — so the Date filter is still applied and still chipped.
     await fieldPicker(page).click();
+
+    // The menu is a radio group: aria-checked is only meaningful on a role that
+    // carries a checked state, so a regression to the default menuitem would
+    // silently stop exposing which field is selected.
+    const active = page.getByTestId('receipts-quick-date-field-date');
+    await expect(active).toHaveAttribute('role', 'menuitemradio');
+    await expect(active).toHaveAttribute('aria-checked', 'true');
+    await expect(page.getByTestId('receipts-quick-date-field-resolvedDate')).toHaveAttribute(
+      'aria-checked',
+      'false',
+    );
+
     await page.getByTestId('receipts-quick-date-field-resolvedDate').click();
 
     await expect(fieldPicker(page)).toContainText('Resolved Date');

--- a/desktop/e2e/receipt-quick-date-filter.spec.ts
+++ b/desktop/e2e/receipt-quick-date-filter.spec.ts
@@ -37,6 +37,10 @@ test.describe('Receipts quick date filter', () => {
   const thisMonthReceipt = uniqueName('qdf-this');
   const lastMonthReceipt = uniqueName('qdf-last');
   const olderReceipt = uniqueName('qdf-older');
+  // Created RESOLVED, so the server stamps resolved_date to now: its Resolved
+  // Date is in the current month while its Date is two months back. That split
+  // is what tells the two columns apart on the wire.
+  const resolvedReceipt = uniqueName('qdf-resolved');
 
   let group: { id: number; name: string };
 
@@ -63,6 +67,7 @@ test.describe('Receipts quick date filter', () => {
   }
 
   const stepperLabel = (page: Page) => page.getByTestId('receipts-month-label');
+  const fieldPicker = (page: Page) => page.getByTestId('receipts-quick-date-field');
   const rowLink = (page: Page, name: string) => page.getByRole('link', { name });
 
   test.beforeAll(async () => {
@@ -82,6 +87,14 @@ test.describe('Receipts quick date filter', () => {
           date: isoInMonth(delta),
         });
       }
+
+      await apiCreateReceipt(api, {
+        groupId: group.id,
+        paidByUserId: adminId,
+        name: resolvedReceipt,
+        date: isoInMonth(-2),
+        status: 'RESOLVED',
+      });
     });
   });
 
@@ -122,7 +135,7 @@ test.describe('Receipts quick date filter', () => {
     await expect(rowLink(page, olderReceipt)).toBeVisible();
   });
 
-  test('narrows the table to a month and shows no duplicate date chip', async ({ page }) => {
+  test('narrows the table to a month and chips the date condition', async ({ page }) => {
     await gotoSeededGroup(page);
 
     await stepperLabel(page).click();
@@ -133,9 +146,9 @@ test.describe('Receipts quick date filter', () => {
     await expect(rowLink(page, lastMonthReceipt)).toHaveCount(0);
     await expect(rowLink(page, olderReceipt)).toHaveCount(0);
 
-    // The stepper already names the month, so the Date chip stays suppressed…
-    await expect(page.getByTestId('receipt-filter-chip-date')).toHaveCount(0);
-    // …but it is still a filter, so the badge and the reset control show it.
+    // The chip row names which date column is filtered — the stepper's label
+    // only says the month, and the target field is selectable.
+    await expect(page.getByTestId('receipt-filter-chip-date')).toContainText('Date');
     await expect(page.getByTestId('receipts-filter-reset')).toBeVisible();
   });
 
@@ -193,14 +206,58 @@ test.describe('Receipts quick date filter', () => {
 
     const nameChip = page.getByTestId('receipt-filter-chip-name');
     await expect(nameChip).toContainText(`Name contains ${thisMonthReceipt}`);
-    // Still only the one chip — the month is the stepper's to show.
-    await expect(page.getByTestId('receipt-filter-chip-date')).toHaveCount(0);
+    // Both conditions are chipped; clearing one must not touch the other.
+    await expect(page.getByTestId('receipt-filter-chip-date')).toBeVisible();
 
     await page.getByTestId('receipt-filter-chip-clear-name').click();
 
     await expect(nameChip).toHaveCount(0);
     await expect(stepperLabel(page)).toContainText(monthLabel(0));
     await expect(rowLink(page, thisMonthReceipt)).toBeVisible();
+  });
+
+  // The stepper's target field is selectable, and only an e2e proves a chosen
+  // field reaches the SERVER as a different column — the Jest specs assert
+  // against a mocked store. It also pins the pointer's persistence, the same
+  // reload trap the month itself has.
+  test('filters on the chosen date field and keeps it across a reload', async ({ page }) => {
+    await gotoSeededGroup(page);
+
+    // Start on Date, this month: the resolved receipt is dated two months back,
+    // so it is excluded.
+    await expect(fieldPicker(page)).toContainText('Date');
+    await stepperLabel(page).click();
+    await page.getByTestId('month-stepper-this-month').click();
+    await expect(rowLink(page, thisMonthReceipt)).toBeVisible();
+    await expect(rowLink(page, resolvedReceipt)).toHaveCount(0);
+    await expect(page.getByTestId('receipt-filter-chip-date')).toBeVisible();
+
+    // Switching the field changes no condition, only which one the stepper
+    // describes — so the Date filter is still applied and still chipped.
+    await fieldPicker(page).click();
+    await page.getByTestId('receipts-quick-date-field-resolvedDate').click();
+
+    await expect(fieldPicker(page)).toContainText('Resolved Date');
+    await expect(stepperLabel(page)).toContainText('All time');
+    await expect(page.getByTestId('receipt-filter-chip-date')).toBeVisible();
+
+    await page.getByTestId('receipt-filter-chip-clear-date').click();
+    await expect(page.getByTestId('receipt-filter-chip-date')).toHaveCount(0);
+
+    // Now the month lands on resolved_date, which only the RESOLVED receipt has.
+    await stepperLabel(page).click();
+    await page.getByTestId('month-stepper-this-month').click();
+
+    await expect(rowLink(page, resolvedReceipt)).toBeVisible();
+    await expect(rowLink(page, thisMonthReceipt)).toHaveCount(0);
+    await expect(page.getByTestId('receipt-filter-chip-resolvedDate')).toBeVisible();
+
+    await page.reload();
+
+    await expect(fieldPicker(page)).toContainText('Resolved Date');
+    await expect(stepperLabel(page)).toContainText(monthLabel(0));
+    await expect(rowLink(page, resolvedReceipt)).toBeVisible();
+    await expect(rowLink(page, thisMonthReceipt)).toHaveCount(0);
   });
 
   // A Date filter the stepper cannot express has to stay visible and clearable.

--- a/desktop/e2e/receipt-quick-date-filter.spec.ts
+++ b/desktop/e2e/receipt-quick-date-filter.spec.ts
@@ -148,7 +148,7 @@ test.describe('Receipts quick date filter', () => {
 
     // The chip row names which date column is filtered — the stepper's label
     // only says the month, and the target field is selectable.
-    await expect(page.getByTestId('receipt-filter-chip-date')).toContainText('Date');
+    await expect(page.getByTestId('receipt-filter-chip-date')).toContainText('Receipt Date');
     await expect(page.getByTestId('receipts-filter-reset')).toBeVisible();
   });
 
@@ -225,7 +225,7 @@ test.describe('Receipts quick date filter', () => {
 
     // Start on Date, this month: the resolved receipt is dated two months back,
     // so it is excluded.
-    await expect(fieldPicker(page)).toContainText('Date');
+    await expect(fieldPicker(page)).toContainText('Receipt Date');
     await stepperLabel(page).click();
     await page.getByTestId('month-stepper-this-month').click();
     await expect(rowLink(page, thisMonthReceipt)).toBeVisible();
@@ -276,7 +276,7 @@ test.describe('Receipts quick date filter', () => {
 
     await expect(stepperLabel(page)).toContainText('Custom');
     await expect(page.getByTestId('receipt-filter-chip-date')).toContainText(
-      'Date within current month',
+      'Receipt Date within current month',
     );
 
     await page.getByTestId('receipt-filter-chip-clear-date').click();

--- a/desktop/src/constants/receipt-filter-fields.constant.ts
+++ b/desktop/src/constants/receipt-filter-fields.constant.ts
@@ -33,3 +33,28 @@ export const RECEIPT_FILTER_FIELDS: readonly ReceiptFilterField[] = [
   { key: "resolvedDate", label: "Resolved Date", type: "date" },
   { key: "createdAt", label: "Added At", type: "date" },
 ];
+
+/** The date fields the quick date control can target. */
+export type ReceiptDateFilterFieldKey = "date" | "resolvedDate" | "createdAt";
+
+export interface ReceiptDateFilterField extends ReceiptFilterField {
+  key: ReceiptDateFilterFieldKey;
+}
+
+/**
+ * The subset of the above the quick date control offers, in the same order the
+ * dialog renders them. Derived from the shared table rather than restated, so a
+ * field cannot be named one thing in the picker and another in the chip it
+ * produces.
+ *
+ * The predicate narrows on the key rather than on `type === "date"` so the
+ * runtime check actually justifies the type it claims. Both must agree: a new
+ * `type: "date"` field has to be added to `ReceiptDateFilterFieldKey` to reach
+ * the picker. `receipts-table.component.spec.ts` pins the resulting list.
+ */
+export const RECEIPT_DATE_FILTER_FIELDS: readonly ReceiptDateFilterField[] =
+  RECEIPT_FILTER_FIELDS.filter((field): field is ReceiptDateFilterField =>
+    (["date", "resolvedDate", "createdAt"] as readonly string[]).includes(field.key),
+  );
+
+export const DEFAULT_QUICK_DATE_FIELD: ReceiptDateFilterFieldKey = "date";

--- a/desktop/src/constants/receipt-filter-fields.constant.ts
+++ b/desktop/src/constants/receipt-filter-fields.constant.ts
@@ -22,7 +22,7 @@ export interface ReceiptFilterField {
  * disagree with the row that produced it.
  */
 export const RECEIPT_FILTER_FIELDS: readonly ReceiptFilterField[] = [
-  { key: "date", label: "Date", type: "date" },
+  { key: "date", label: "Receipt Date", type: "date" },
   { key: "name", label: "Name", type: "text" },
   { key: "paidBy", label: "Paid by", type: "users" },
   { key: "group", label: "Group", type: "list" },

--- a/desktop/src/interfaces/receipt-table-interface.ts
+++ b/desktop/src/interfaces/receipt-table-interface.ts
@@ -1,4 +1,5 @@
 import { SortDirection } from "@angular/material/sort";
+import { ReceiptDateFilterFieldKey } from "../constants/receipt-filter-fields.constant";
 import { ReceiptPagedRequestFilter } from "../open-api";
 import { ReceiptTableColumnConfig } from "./receipt-table-column-config.interface";
 
@@ -8,5 +9,11 @@ export interface ReceiptTableInterface {
   orderBy: string;
   sortDirection: SortDirection;
   filter: ReceiptPagedRequestFilter;
+  /**
+   * The date field the quick date control writes to. Optional because state
+   * persisted before it existed deserializes without it — read it through
+   * `ReceiptTableState.quickDateField`, which supplies the fallback.
+   */
+  quickDateField?: ReceiptDateFilterFieldKey;
   columnConfig?: ReceiptTableColumnConfig[];
 }

--- a/desktop/src/receipts/receipts-table/receipts-table.component.html
+++ b/desktop/src/receipts/receipts-table/receipts-table.component.html
@@ -12,13 +12,45 @@
       [buttonRouterLink]="['/receipts/add']"
     ></app-add-button>
 
-    <app-month-stepper
-      class="me-2"
-      [value]="stepperMonth()"
-      [label]="stepperLabel()"
-      (monthSelected)="monthSelected($event)"
-      (allTimeSelected)="allTimeSelected()"
-    ></app-month-stepper>
+    <!--
+      The field picker and the stepper are one control: the picker names the
+      date column the stepper writes to. A mat-menu is right here (unlike the
+      stepper's own panel, which is a CDK overlay) because every entry really is
+      a mat-menu-item, so the FocusKeyManager has items to navigate.
+    -->
+    <div class="receipts-quick-date me-2">
+      <app-button
+        data-testid="receipts-quick-date-field"
+        matButtonType="basic"
+        icon="event"
+        color="accent"
+        tooltip="Choose which date field to filter on"
+        aria-haspopup="menu"
+        [buttonText]="quickDateFieldLabel()"
+        [matMenuTriggerFor]="quickDateFieldMenu"
+      ></app-button>
+
+      <mat-menu #quickDateFieldMenu="matMenu">
+        @for (field of dateFilterFields; track field.key) {
+          <button
+            mat-menu-item
+            [attr.data-testid]="'receipts-quick-date-field-' + field.key"
+            [attr.aria-checked]="field.key === quickDateField()"
+            (click)="quickDateFieldSelected(field.key)"
+          >
+            <mat-icon>{{ field.key === quickDateField() ? "check" : "" }}</mat-icon>
+            <span>{{ field.label }}</span>
+          </button>
+        }
+      </mat-menu>
+
+      <app-month-stepper
+        [value]="stepperMonth()"
+        [label]="stepperLabel()"
+        (monthSelected)="monthSelected($event)"
+        (allTimeSelected)="allTimeSelected()"
+      ></app-month-stepper>
+    </div>
 
     <app-button
       class="me-2 filter-button"

--- a/desktop/src/receipts/receipts-table/receipts-table.component.html
+++ b/desktop/src/receipts/receipts-table/receipts-table.component.html
@@ -41,8 +41,19 @@
 
       <mat-menu #quickDateFieldMenu="matMenu">
         @for (field of dateFilterFields; track field.key) {
+          <!--
+            role="menuitemradio", not the default menuitem: aria-checked is only
+            meaningful on a role that carries a checked state, so on a plain
+            menuitem the selected field was never exposed to a screen reader.
+            MatMenuItem.role is a typed input bound to [attr.role]; Material
+            leaves the state to the app, which is all this needs — the value is
+            single-select off quickDateField(), the panel is role="menu" (a
+            valid owner), and arrow/Enter/typeahead come from MatMenu's own
+            FocusKeyManager because these are real mat-menu-items.
+          -->
           <button
             mat-menu-item
+            role="menuitemradio"
             [attr.data-testid]="'receipts-quick-date-field-' + field.key"
             [attr.aria-checked]="field.key === quickDateField()"
             (click)="quickDateFieldSelected(field.key)"

--- a/desktop/src/receipts/receipts-table/receipts-table.component.html
+++ b/desktop/src/receipts/receipts-table/receipts-table.component.html
@@ -13,12 +13,21 @@
     ></app-add-button>
 
     <!--
-      The field picker and the stepper are one control: the picker names the
-      date column the stepper writes to. A mat-menu is right here (unlike the
-      stepper's own panel, which is a CDK overlay) because every entry really is
-      a mat-menu-item, so the FocusKeyManager has items to navigate.
+      The stepper and the field picker are one control, read left to right as
+      "September 2026 ... on Receipt Date". A mat-menu is right for the picker
+      (unlike the stepper's own panel, which is a CDK overlay) because every
+      entry really is a mat-menu-item, so the FocusKeyManager has items to
+      navigate. The menu stays next to its trigger: [matMenuTriggerFor] resolves
+      the reference within this template.
     -->
     <div class="receipts-quick-date me-2">
+      <app-month-stepper
+        [value]="stepperMonth()"
+        [label]="stepperLabel()"
+        (monthSelected)="monthSelected($event)"
+        (allTimeSelected)="allTimeSelected()"
+      ></app-month-stepper>
+
       <app-button
         data-testid="receipts-quick-date-field"
         matButtonType="basic"
@@ -43,13 +52,6 @@
           </button>
         }
       </mat-menu>
-
-      <app-month-stepper
-        [value]="stepperMonth()"
-        [label]="stepperLabel()"
-        (monthSelected)="monthSelected($event)"
-        (allTimeSelected)="allTimeSelected()"
-      ></app-month-stepper>
     </div>
 
     <app-button

--- a/desktop/src/receipts/receipts-table/receipts-table.component.scss
+++ b/desktop/src/receipts/receipts-table/receipts-table.component.scss
@@ -14,11 +14,14 @@ app-receipts-table {
     row-gap: variables.$spacing-xs;
   }
 
-  // The field picker and the stepper read as one control, so keep them on a
-  // single line and let the pair wrap together.
+  // The stepper and the field picker read as one control, so keep them on a
+  // single line and let the pair wrap together. The gap applies only to those
+  // two direct children, so the stepper's own arrows stay tight against their
+  // label — without it the trailing picker reads as a fourth stepper button.
   .receipts-quick-date {
     display: inline-flex;
     align-items: center;
+    gap: variables.$spacing-xs;
   }
 
   // Chip-shaped, so it reads as the label on the stepper rather than as another

--- a/desktop/src/receipts/receipts-table/receipts-table.component.scss
+++ b/desktop/src/receipts/receipts-table/receipts-table.component.scss
@@ -14,6 +14,38 @@ app-receipts-table {
     row-gap: variables.$spacing-xs;
   }
 
+  // The field picker and the stepper read as one control, so keep them on a
+  // single line and let the pair wrap together.
+  .receipts-quick-date {
+    display: inline-flex;
+    align-items: center;
+  }
+
+  // Chip-shaped, so it reads as the label on the stepper rather than as another
+  // toolbar action.
+  [data-testid="receipts-quick-date-field"] button {
+    min-width: 0;
+    padding: 0 variables.$spacing-xs 0 variables.$spacing-sm;
+    border-radius: 1rem;
+    background: map.get(variables.$accent-palette, 100);
+
+    // A caret, so the label reads as something you can open rather than as a
+    // static description. app-button renders one leading icon only, so this
+    // trailing one is a pseudo-element on the ligature icon font the app
+    // already loads (styles.scss) rather than a second mat-icon.
+    .d-flex::after {
+      content: "arrow_drop_down";
+      font-family: "Material Icons";
+      // Material Icons resolves its names through DISCRETIONARY ligatures,
+      // which browsers leave off by default — without these the glyph renders
+      // blank rather than falling back to the literal text.
+      font-feature-settings: "liga";
+      font-variant-ligatures: discretionary-ligatures;
+      font-size: 1.25rem;
+      line-height: 1;
+    }
+  }
+
   .receipt-filter-chips {
     display: block;
     // app-table-header owns the gap below itself, so only close the gap to the

--- a/desktop/src/receipts/receipts-table/receipts-table.component.spec.ts
+++ b/desktop/src/receipts/receipts-table/receipts-table.component.spec.ts
@@ -17,7 +17,7 @@ import { ApiModule, FilterOperation, Permission, Receipt, ReceiptStatus } from "
 import { ReceiptFilterService } from "../../services/receipt-filter.service";
 import { AuthState, GroupState, UserState } from "../../store";
 import { SetPermissions } from "../../store/auth.state.actions";
-import { SetReceiptFilter } from "../../store/receipt-table.actions";
+import { SetQuickDateField, SetReceiptFilter } from "../../store/receipt-table.actions";
 import { ReceiptsTableComponent } from "./receipts-table.component";
 import { provideHttpClient, withInterceptorsFromDi } from "@angular/common/http";
 
@@ -195,10 +195,76 @@ describe("ReceiptsTableComponent", () => {
       ]);
     });
 
-    it("never shows a date chip for the month the stepper is already showing", () => {
+    // The chip row used to omit the field the stepper was naming. It is the only
+    // place that says WHICH date column is filtered now that the target is
+    // selectable, so it no longer makes exceptions.
+    it("chips the month the stepper is showing", () => {
       component.monthSelected({ year: 2026, month: 8 });
 
-      expect(component.filterChips()).toEqual([]);
+      expect(component.filterChips().map((chip) => chip.key)).toEqual(["date"]);
+    });
+
+    describe("choosing which date field to filter on", () => {
+      it("defaults to the receipt date", () => {
+        expect(component.quickDateField()).toEqual("date");
+        expect(component.quickDateFieldLabel()).toEqual("Date");
+      });
+
+      it("offers exactly the date fields, labelled as the dialog labels them", () => {
+        expect(component.dateFilterFields.map((field) => [field.key, field.label])).toEqual([
+          ["date", "Date"],
+          ["resolvedDate", "Resolved Date"],
+          ["createdAt", "Added At"],
+        ]);
+      });
+
+      it("writes the picked month to the selected field, not to date", () => {
+        component.quickDateFieldSelected("resolvedDate");
+        component.monthSelected({ year: 2026, month: 8 });
+
+        const filter = store.selectSnapshot(ReceiptTableState.filterData).filter as any;
+        expect(filter.resolvedDate.operation).toEqual(FilterOperation.Between);
+        expect(filter.date).toEqual({ operation: null, value: null });
+
+        expect(component.quickDateFieldLabel()).toEqual("Resolved Date");
+        expect(component.stepperLabel()).toEqual("September 2026");
+      });
+
+      it("reads the stepper label and Custom fallback off the selected field", () => {
+        setFilter({
+          date: { operation: FilterOperation.Between, value: [new Date(2026, 8, 1), new Date(2026, 8, 30)] },
+          createdAt: { operation: FilterOperation.WithinCurrentMonth, value: null },
+        });
+
+        expect(component.stepperLabel()).toEqual("September 2026");
+
+        component.quickDateFieldSelected("createdAt");
+
+        expect(component.stepperMonth()).toBeNull();
+        expect(component.stepperLabel()).toEqual("Custom");
+      });
+
+      // Switching the target changes no condition, only which one the stepper
+      // describes — so nothing the user set elsewhere is destroyed, and the
+      // abandoned condition stays visible and clearable as its own chip.
+      it("leaves the previous field's condition applied, with its chip", () => {
+        component.monthSelected({ year: 2026, month: 8 });
+        refetch.mockClear();
+
+        component.quickDateFieldSelected("resolvedDate");
+
+        const filter = store.selectSnapshot(ReceiptTableState.filterData).filter as any;
+        expect(filter.date.operation).toEqual(FilterOperation.Between);
+        expect(component.stepperLabel()).toEqual("All time");
+        expect(component.filterChips().map((chip) => chip.key)).toEqual(["date"]);
+        expect(refetch).not.toHaveBeenCalled();
+      });
+
+      it("follows a field chosen outside the component", () => {
+        store.dispatch(new SetQuickDateField("createdAt"));
+
+        expect(component.quickDateFieldLabel()).toEqual("Added At");
+      });
     });
 
     it("builds a chip per active field, resolving ids to names", () => {

--- a/desktop/src/receipts/receipts-table/receipts-table.component.spec.ts
+++ b/desktop/src/receipts/receipts-table/receipts-table.component.spec.ts
@@ -191,7 +191,7 @@ describe("ReceiptsTableComponent", () => {
       expect(component.stepperMonth()).toBeNull();
       expect(component.stepperLabel()).toEqual("Custom");
       expect(component.filterChips()).toEqual([
-        { key: "date", label: "Date within current month" },
+        { key: "date", label: "Receipt Date within current month" },
       ]);
     });
 
@@ -207,12 +207,12 @@ describe("ReceiptsTableComponent", () => {
     describe("choosing which date field to filter on", () => {
       it("defaults to the receipt date", () => {
         expect(component.quickDateField()).toEqual("date");
-        expect(component.quickDateFieldLabel()).toEqual("Date");
+        expect(component.quickDateFieldLabel()).toEqual("Receipt Date");
       });
 
       it("offers exactly the date fields, labelled as the dialog labels them", () => {
         expect(component.dateFilterFields.map((field) => [field.key, field.label])).toEqual([
-          ["date", "Date"],
+          ["date", "Receipt Date"],
           ["resolvedDate", "Resolved Date"],
           ["createdAt", "Added At"],
         ]);

--- a/desktop/src/receipts/receipts-table/receipts-table.component.ts
+++ b/desktop/src/receipts/receipts-table/receipts-table.component.ts
@@ -11,11 +11,11 @@ import { catchError, EMPTY, map, Subject, switchMap, take, tap } from "rxjs";
 import { fadeInOut } from "src/animations";
 import { ReceiptFilterService } from "src/services/receipt-filter.service";
 import { ConfirmationDialogComponent } from "src/shared-ui/confirmation-dialog/confirmation-dialog.component";
-import { ResetReceiptFilter, SetColumnConfig, SetPage, SetPageSize, SetReceiptFilterData, SetReceiptFilterField, } from "src/store/receipt-table.actions";
+import { ResetReceiptFilter, SetColumnConfig, SetPage, SetPageSize, SetQuickDateField, SetReceiptFilterData, SetReceiptFilterField, } from "src/store/receipt-table.actions";
 import { ReceiptTableState } from "src/store/receipt-table.state";
 import { TableColumn } from "src/table/table-column.interface";
 import { TableComponent } from "src/table/table/table.component";
-import { DEFAULT_DIALOG_CONFIG, DEFAULT_HOST_CLASS } from "../../constants";
+import { DEFAULT_DIALOG_CONFIG, DEFAULT_HOST_CLASS, RECEIPT_DATE_FILTER_FIELDS, ReceiptDateFilterFieldKey } from "../../constants";
 import { ReceiptTableColumnConfig } from "../../interfaces";
 import {
   BulkStatusUpdateCommand,
@@ -118,11 +118,25 @@ export class ReceiptsTableComponent implements OnInit, AfterViewInit {
     () => this.filter()?.filter as ReceiptPagedRequestFilter | undefined
   );
 
+  /** The date field the quick date control writes to. */
+  public quickDateField = this.store.selectSignal(ReceiptTableState.quickDateField);
+
+  public readonly dateFilterFields = RECEIPT_DATE_FILTER_FIELDS;
+
+  public quickDateFieldLabel = computed(
+    () =>
+      RECEIPT_DATE_FILTER_FIELDS.find((field) => field.key === this.quickDateField())?.label ??
+      "Date"
+  );
+
+  /** The entry the quick date control currently owns. */
+  private quickDateEntry = computed(() => this.receiptFilter()?.[this.quickDateField()]);
+
   /**
-   * The month the quick date control is showing, or null when the Date filter
-   * is unset or is something a month cannot express.
+   * The month the quick date control is showing, or null when its field is
+   * unset or holds something a month cannot express.
    */
-  public stepperMonth = computed(() => monthFromFilterEntry(this.receiptFilter()?.date));
+  public stepperMonth = computed(() => monthFromFilterEntry(this.quickDateEntry()));
 
   public stepperLabel = computed(() => {
     const month = this.stepperMonth();
@@ -130,9 +144,9 @@ export class ReceiptsTableComponent implements OnInit, AfterViewInit {
       return this.datePipe.transform(new Date(month.year, month.month, 1), "LLLL y") ?? "";
     }
 
-    // A Date filter the stepper cannot describe still has to be visible as a
-    // filter — the chip beside it spells out what it actually is.
-    return isFilterEntryActive(this.receiptFilter()?.date) ? "Custom" : "All time";
+    // A filter the stepper cannot describe still has to be visible as a
+    // filter — the chip below spells out what it actually is.
+    return isFilterEntryActive(this.quickDateEntry()) ? "Custom" : "All time";
   });
 
   public filterChips = computed<ReceiptFilterChip[]>(() => {
@@ -153,9 +167,7 @@ export class ReceiptsTableComponent implements OnInit, AfterViewInit {
         users,
         formatDate: (value) => this.datePipe.transform(value as string) ?? "",
         formatCurrency: (value) => this.customCurrencyPipe.transform(value as number),
-      },
-      // The stepper already says "September 2026", so don't say it twice.
-      this.stepperMonth() ? ["date"] : []
+      }
     );
   });
 
@@ -437,12 +449,22 @@ export class ReceiptsTableComponent implements OnInit, AfterViewInit {
   }
 
   public monthSelected(month: FilterMonth): void {
-    // The quick control IS the Date filter, so it overwrites whatever was there.
-    this.applyFilterField("date", monthFilterEntry(month) as any);
+    // The quick control IS its field's filter, so it overwrites whatever was there.
+    this.applyFilterField(this.quickDateField(), monthFilterEntry(month) as any);
   }
 
   public allTimeSelected(): void {
-    this.applyFilterField("date", null);
+    this.applyFilterField(this.quickDateField(), null);
+  }
+
+  /**
+   * Re-points the quick date control at another date field. Deliberately
+   * non-destructive: it changes no condition — only which one the stepper
+   * describes — so whatever the previous field held stays applied and keeps its
+   * chip. Nothing to refetch.
+   */
+  public quickDateFieldSelected(field: ReceiptDateFilterFieldKey): void {
+    this.store.dispatch(new SetQuickDateField(field));
   }
 
   public filterChipCleared(field: keyof ReceiptPagedRequestFilter): void {

--- a/desktop/src/receipts/receipts-table/receipts-table.component.ts
+++ b/desktop/src/receipts/receipts-table/receipts-table.component.ts
@@ -126,7 +126,7 @@ export class ReceiptsTableComponent implements OnInit, AfterViewInit {
   public quickDateFieldLabel = computed(
     () =>
       RECEIPT_DATE_FILTER_FIELDS.find((field) => field.key === this.quickDateField())?.label ??
-      "Date"
+      "Receipt Date"
   );
 
   /** The entry the quick date control currently owns. */

--- a/desktop/src/shared-ui/receipt-filter/receipt-filter.component.html
+++ b/desktop/src/shared-ui/receipt-filter/receipt-filter.component.html
@@ -10,7 +10,7 @@
     <ng-template
       [ngTemplateOutlet]="filterField"
       [ngTemplateOutletContext]="{
-        label: 'Date',
+        label: 'Receipt Date',
         fieldName: 'date',
         type: 'date'
       }"

--- a/desktop/src/store/receipt-table.actions.ts
+++ b/desktop/src/store/receipt-table.actions.ts
@@ -1,3 +1,4 @@
+import { ReceiptDateFilterFieldKey } from "../constants/receipt-filter-fields.constant";
 import { FilterOperation, ReceiptPagedRequestFilter } from "../open-api";
 import { ReceiptTableInterface } from "../interfaces";
 import { ReceiptTableColumnConfig } from "../interfaces/receipt-table-column-config.interface";
@@ -34,6 +35,13 @@ export class SetReceiptFilterField {
     /** `null` clears the field back to its default empty shape. */
     public entry: { operation: FilterOperation | null; value: unknown } | null,
   ) {}
+}
+
+export class SetQuickDateField {
+  static readonly type = "[ReceiptTable] Set Quick Date Field";
+
+  /** Which date field the quick date control writes to from now on. */
+  constructor(public field: ReceiptDateFilterFieldKey) {}
 }
 
 export class ResetReceiptFilter {

--- a/desktop/src/store/receipt-table.state.spec.ts
+++ b/desktop/src/store/receipt-table.state.spec.ts
@@ -2,7 +2,7 @@ import { TestBed } from "@angular/core/testing";
 import { NgxsModule, Store } from "@ngxs/store";
 import { DEFAULT_RECEIPT_TABLE_COLUMNS, ReceiptTableInterface } from "src/interfaces";
 import { FilterOperation, ReceiptPagedRequestFilter, ReceiptStatus } from "../open-api";
-import { ResetReceiptFilter, SetPage, SetPageSize, SetReceiptFilter, SetReceiptFilterData, SetReceiptFilterField, } from "./receipt-table.actions";
+import { ResetReceiptFilter, SetPage, SetPageSize, SetQuickDateField, SetReceiptFilter, SetReceiptFilterData, SetReceiptFilterField, } from "./receipt-table.actions";
 import { buildDefaultReceiptFilter, defaultReceiptFilter, ReceiptTableState } from "./receipt-table.state";
 
 describe("ReceiptTableState", () => {
@@ -73,6 +73,7 @@ describe("ReceiptTableState", () => {
       orderBy: "created_at",
       sortDirection: "desc",
       filter: defaultReceiptFilter,
+      quickDateField: "date",
       columnConfig: DEFAULT_RECEIPT_TABLE_COLUMNS,
     });
   });
@@ -132,8 +133,14 @@ describe("ReceiptTableState", () => {
     };
     store.dispatch(new SetReceiptFilterData(filterData));
 
+    // The payload omits columnConfig and quickDateField, and patchState only
+    // touches the keys it is handed — so sorting cannot reset either.
     const result = store.selectSnapshot(ReceiptTableState.filterData);
-    expect(result).toEqual({ ...filterData, columnConfig: DEFAULT_RECEIPT_TABLE_COLUMNS });
+    expect(result).toEqual({
+      ...filterData,
+      quickDateField: "date",
+      columnConfig: DEFAULT_RECEIPT_TABLE_COLUMNS,
+    });
   });
 
   it("should set filter receipt filter", () => {
@@ -197,6 +204,29 @@ describe("ReceiptTableState", () => {
     expect(result.categories).toEqual({ operation: null, value: [] });
     expect(result.date).toEqual({ operation: null, value: null });
     expect(result.name).toEqual(filledFilter.name);
+  });
+
+  it("should set the quick date field", () => {
+    store.dispatch(new SetQuickDateField("resolvedDate"));
+
+    expect(store.selectSnapshot(ReceiptTableState.quickDateField)).toEqual("resolvedDate");
+  });
+
+  // The quick date field arrived after this slice was already being persisted to
+  // localStorage, so every existing install hydrates a state without the key.
+  // @State defaults do not run for a hydrated state, which is why the fallback
+  // has to live in the selector.
+  it("should fall back to date for a state persisted before the key existed", () => {
+    store.reset({ receiptTable: { filter: filledFilter } });
+
+    expect(store.selectSnapshot(ReceiptTableState.quickDateField)).toEqual("date");
+  });
+
+  it("should reset the quick date field along with the filter", () => {
+    store.dispatch(new SetQuickDateField("createdAt"));
+    store.dispatch(new ResetReceiptFilter());
+
+    expect(store.selectSnapshot(ReceiptTableState.quickDateField)).toEqual("date");
   });
 
   // ResetReceiptFilter writes a default filter straight into state, so without a

--- a/desktop/src/store/receipt-table.state.ts
+++ b/desktop/src/store/receipt-table.state.ts
@@ -1,10 +1,11 @@
 import { Injectable } from "@angular/core";
 import { Action, Selector, State, StateContext } from "@ngxs/store";
+import { DEFAULT_QUICK_DATE_FIELD, ReceiptDateFilterFieldKey } from "../constants/receipt-filter-fields.constant";
 import { ReceiptTableInterface } from "../interfaces";
 import { DEFAULT_RECEIPT_TABLE_COLUMNS, ReceiptTableColumnConfig } from "../interfaces/receipt-table-column-config.interface";
 import { ReceiptPagedRequestFilter } from "../open-api";
 import { isFilterEntryActive } from "../utils/receipt-filter-entry";
-import { ResetReceiptFilter, SetColumnConfig, SetPage, SetPageSize, SetReceiptFilter, SetReceiptFilterData, SetReceiptFilterField } from "./receipt-table.actions";
+import { ResetReceiptFilter, SetColumnConfig, SetPage, SetPageSize, SetQuickDateField, SetReceiptFilter, SetReceiptFilterData, SetReceiptFilterField } from "./receipt-table.actions";
 
 /**
  * A pristine filter. This is a factory rather than a shared constant because
@@ -68,6 +69,7 @@ export const defaultReceiptFilter = buildDefaultReceiptFilter();
     orderBy: "created_at",
     sortDirection: "desc",
     filter: buildDefaultReceiptFilter(),
+    quickDateField: DEFAULT_QUICK_DATE_FIELD,
     columnConfig: DEFAULT_RECEIPT_TABLE_COLUMNS,
   },
 })
@@ -95,6 +97,17 @@ export class ReceiptTableState {
     // Shares isFilterEntryActive with the filter chips, so the badge count and
     // the chips can never disagree about what counts as a condition.
     return Object.keys(filter).filter((key) => isFilterEntryActive(filter[key])).length;
+  }
+
+  /**
+   * The date field the quick date control targets. The fallback lives here
+   * rather than only in the state defaults because `defaults` never runs for a
+   * state hydrated from localStorage — every install that filtered before this
+   * key existed would otherwise read `undefined` and index the filter with it.
+   */
+  @Selector()
+  static quickDateField(state: ReceiptTableInterface): ReceiptDateFilterFieldKey {
+    return state.quickDateField ?? DEFAULT_QUICK_DATE_FIELD;
   }
 
   @Selector()
@@ -159,10 +172,23 @@ export class ReceiptTableState {
     });
   }
 
+  @Action(SetQuickDateField)
+  setQuickDateField(
+    { patchState }: StateContext<ReceiptTableInterface>,
+    payload: SetQuickDateField
+  ) {
+    patchState({
+      quickDateField: payload.field,
+    });
+  }
+
   @Action(ResetReceiptFilter)
   resetFilter({ patchState }: StateContext<ReceiptTableInterface>) {
+    // The targeted field is part of what the user configured, so a reset puts
+    // the control back where a fresh install starts it.
     patchState({
       filter: buildDefaultReceiptFilter(),
+      quickDateField: DEFAULT_QUICK_DATE_FIELD,
     });
   }
 

--- a/desktop/src/utils/receipt-filter-chips.spec.ts
+++ b/desktop/src/utils/receipt-filter-chips.spec.ts
@@ -96,12 +96,16 @@ describe("buildReceiptFilterChips", () => {
     expect(chip.label).toBe("Date within current month");
   });
 
-  it("omits the keys the caller already renders elsewhere", () => {
+  // The quick date control used to suppress its own field's chip while the
+  // month stepper named that month. Its target field is now selectable, so the
+  // chip row is the only place that says WHICH date column is filtered — and a
+  // condition with no chip is one the user cannot clear from here.
+  it("chips a whole-month date condition like any other, alongside the rest", () => {
     const filter = filterWith({
       date: { operation: FilterOperation.Between, value: [new Date(2026, 8, 1), new Date(2026, 8, 30)] },
       name: { operation: FilterOperation.Contains, value: "whole" },
     });
 
-    expect(buildReceiptFilterChips(filter, lookups, ["date"]).map((chip) => chip.key)).toEqual(["name"]);
+    expect(buildReceiptFilterChips(filter, lookups).map((chip) => chip.key)).toEqual(["date", "name"]);
   });
 });

--- a/desktop/src/utils/receipt-filter-chips.spec.ts
+++ b/desktop/src/utils/receipt-filter-chips.spec.ts
@@ -44,7 +44,7 @@ describe("buildReceiptFilterChips", () => {
       lookups
     );
 
-    expect(chip.label).toBe("Date between Tue Sep 01 2026 – Wed Sep 30 2026");
+    expect(chip.label).toBe("Receipt Date between Tue Sep 01 2026 – Wed Sep 30 2026");
   });
 
   it("labels a currency comparison", () => {
@@ -93,7 +93,7 @@ describe("buildReceiptFilterChips", () => {
       lookups
     );
 
-    expect(chip.label).toBe("Date within current month");
+    expect(chip.label).toBe("Receipt Date within current month");
   });
 
   // The quick date control used to suppress its own field's chip while the

--- a/desktop/src/utils/receipt-filter-chips.ts
+++ b/desktop/src/utils/receipt-filter-chips.ts
@@ -33,23 +33,22 @@ const BETWEEN_SEPARATOR = " – ";
  * One chip per filter field that actually narrows the result set, labelled
  * `"<Field> <operation> <value>"`.
  *
- * `omitKeys` lets a caller suppress a field it already renders another way —
- * the receipts table passes `["date"]` while the month stepper is displaying
- * that exact month, so the same condition never appears twice.
+ * Exceptionless on purpose: the quick date control's own condition is chipped
+ * too. It used to be suppressed while the month stepper named that month, but
+ * the stepper's target field is now selectable, so this row is the only place
+ * that says *which* date column is being filtered — and a condition with no
+ * chip is one the user can neither see nor clear from here.
  */
 export function buildReceiptFilterChips(
   filter: ReceiptPagedRequestFilter | undefined | null,
   lookups: ReceiptFilterChipLookups,
-  omitKeys: readonly string[] = [],
 ): ReceiptFilterChip[] {
   if (!filter) {
     return [];
   }
 
-  return RECEIPT_FILTER_FIELDS.filter(
-    (field) =>
-      !omitKeys.includes(field.key) &&
-      isFilterEntryActive((filter as Record<string, unknown>)[field.key]),
+  return RECEIPT_FILTER_FIELDS.filter((field) =>
+    isFilterEntryActive((filter as Record<string, unknown>)[field.key]),
   ).map((field) => ({
     key: field.key,
     label: buildLabel(field, (filter as Record<string, unknown>)[field.key] as ReceiptFilterEntry, lookups),


### PR DESCRIPTION
## Summary
The month stepper now targets a selectable date field (`date`, `resolvedDate`, or `createdAt`) instead of always filtering on the `date` field. This allows users to filter receipts by Receipt Date, Resolved Date, or Added At, with the choice persisted across page reloads.

## Key Changes

- **Added field picker UI**: A chip-shaped `mat-menu` trigger next to the month stepper lets users choose which date field to filter on. The menu reads left-to-right as "September 2026 ... on Receipt Date".

- **Persisted field selection**: The chosen field is stored in state (`ReceiptTableInterface.quickDateField` + `SetQuickDateField` action) so it survives reloads. A fallback in the selector handles pre-existing persisted state that lacks this key.

- **Non-destructive field switching**: Changing the target field does not clear or modify any filter conditions—it only changes which field the stepper describes. A Date filter set in the dialog survives a switch to Resolved Date and remains visible and clearable as its own chip.

- **Unified field metadata**: Extracted `RECEIPT_DATE_FILTER_FIELDS` (the `type: "date"` subset of `RECEIPT_FILTER_FIELDS`) so the picker, dialog, and chips all name fields identically. Renamed the `date` field label from "Date" to "Receipt Date" to disambiguate it from the other date columns.

- **Chips now include the stepper's field**: Removed the `omitKeys` parameter from `buildReceiptFilterChips()`. The stepper's own condition is now always chipped, since the chip row is the only place that says *which* date column is being filtered—critical now that the target is selectable.

- **E2E test coverage**: Added a test that verifies the field picker works end-to-end, persists across reloads, and correctly filters on the chosen field. Also seeded a RESOLVED receipt to test the Resolved Date column independently.

## Implementation Details

- The field picker is a `mat-menu` (not a CDK overlay like the stepper's panel) because every entry is a true `mat-menu-item`, giving the `FocusKeyManager` items to navigate.
- The stepper's label reads "Custom" when the selected field holds a condition it cannot express (e.g., a partial range or `WITHIN_CURRENT_MONTH`), and the chip spells out what it actually is.
- `ResetReceiptFilter` clears the field back to `date` alongside the filter, so a fresh install always starts on Receipt Date.
- The `SetReceiptFilterData` action (used by sorting) omits the field key, so `patchState` only touches what it is handed—sorting cannot reset the field either.

https://claude.ai/code/session_01S39TY22vkdyyLsrbB6qdyi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a date-field selector to the receipts month filter for receipt date, resolved date, and created date.
  - The selected field is remembered across reloads and preserved when switching fields.
  - Month, custom-date, and all-time filters apply to the selected date field.
  - Active date conditions appear as filter chips, including whole-month selections and unresolved receipt references.
- **Improvements**
  - Renamed the “Date” filter label to “Receipt Date” for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->